### PR TITLE
Add common style layout

### DIFF
--- a/src/components/DeploymentsPage/DeploymentsPage.css
+++ b/src/components/DeploymentsPage/DeploymentsPage.css
@@ -1,19 +1,20 @@
-.DeploymentsPageContainer {
+.DashboardContainer {
   height: auto;
   display: flex;
   flex-direction: column;
 }
 
-.DeploymentsPageMain {
+.DashboardMainContainer {
+  margin-top: 80px; /* Height of the hedaer */
   display: flex;
   flex-direction: row;
 }
 
-.DeploymentsPageSideNav {
+.DashboardSideNav {
   min-width: 250px;
 }
 
-.DeploymentsPageMainContent {
+.DashboardContentWrap {
   flex: 1;
   background: #f1f1f1;
 }
@@ -31,15 +32,12 @@
   padding: 5rem;
 }
 
-.PageHeaderContainer {
+.DashboardHeaderContainer {
   position: fixed;
   width: 100%;
   z-index: 5;
 }
 
-.DeploymentsPageMain {
-  margin-top: 80px; /* Height of the hedaer */
-}
 
 
 /*- ///// TABLE STYLING HERE ///////// */

--- a/src/components/DeploymentsPage/DeploymentsPage.css
+++ b/src/components/DeploymentsPage/DeploymentsPage.css
@@ -1,5 +1,7 @@
 .DeploymentsPageContainer {
   height: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .DeploymentsPageMain {
@@ -16,6 +18,30 @@
   background: #f1f1f1;
 }
 
+.FailedToRetrieveMsg {
+  text-align: center;
+  color: #555;
+  display: flex;
+  justify-content: center;
+}
+
+.FailedToRetrieveMsg p {
+  box-shadow: .5rem .5rem rgba(0, 138, 193, 0.2);
+  border-radius: 25px;
+  padding: 5rem;
+}
+
+.PageHeaderContainer {
+  position: fixed;
+  width: 100%;
+  z-index: 5;
+}
+
+.DeploymentsPageMain {
+  margin-top: 80px; /* Height of the hedaer */
+}
+
+
 /*- ///// TABLE STYLING HERE ///////// */
 .ResourcesTable {
   padding: 2rem;
@@ -28,16 +54,31 @@
 }
 
 .ResourcesTable::-webkit-scrollbar {
-  width: 4px;
+  width: 10px;
   height: 0px;
 }
 .ResourcesTable::-webkit-scrollbar-track {
   background: #f1f1f1;
 }
 .ResourcesTable::-webkit-scrollbar-thumb {
-  background: #888;
+  border-radius: 25px;
+  background: #008AC1;
 }
 .ResourcesTable::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
+body::-webkit-scrollbar {
+  width: 4px;
+  height: 0px;
+}
+body::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+body::-webkit-scrollbar-thumb {
+  background: #888;
+}
+body::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
 

--- a/src/components/DeploymentsPage/index.js
+++ b/src/components/DeploymentsPage/index.js
@@ -98,6 +98,11 @@ class DeploymentsPage extends Component {
                     </tbody>
                   )}
                 </table>
+                {(isFetched && deployments.length === 0) && (
+                  <div className="FailedToRetrieveMsg">
+                    <p>No deployments available</p>
+                  </div>
+                )}
                 {(!isFetchingDeployments && !isFetched) && (
                   <div className="FailedToRetrieveMsg">
                     <p>

--- a/src/components/DeploymentsPage/index.js
+++ b/src/components/DeploymentsPage/index.js
@@ -43,7 +43,9 @@ class DeploymentsPage extends Component {
 
     return (
       <div className="DeploymentsPageContainer">
-        <Header />
+        <div className="PageHeaderContainer">
+          <Header />
+        </div>
         <div className="DeploymentsPageMain">
           <div className="DeploymentsPageSideNav">
             <SideNav
@@ -71,7 +73,7 @@ class DeploymentsPage extends Component {
                     </tr>
                   ) : (
                     <tbody>
-                      {isFetched && deployments !== undefined ? (
+                      {(isFetched && deployments !== undefined) && (
                         deployments.map((deployment) => (
                           <tr>
                             <td>{deployment.metadata.name}</td>
@@ -90,10 +92,19 @@ class DeploymentsPage extends Component {
                             </td>
                             <td>{tellAge(deployment.metadata.creationTimestamp)}</td>
                           </tr>
-                        ))) : <div>No deployments</div>}
+                        )))}
                     </tbody>
                   )}
                 </table>
+                {(!isFetchingDeployments && !isFetched) && (
+                  <div className="FailedToRetrieveMsg">
+                    <p>
+                      Oops! Something went wrong!
+                      <br />
+                      Failed to retrieve deployments.
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/DeploymentsPage/index.js
+++ b/src/components/DeploymentsPage/index.js
@@ -42,20 +42,22 @@ class DeploymentsPage extends Component {
     } = this.props;
 
     return (
-      <div className="DeploymentsPageContainer">
-        <div className="PageHeaderContainer">
+      <div className="DashboardContainer">
+        <div className="DashboardHeaderContainer">
           <Header />
         </div>
-        <div className="DeploymentsPageMain">
-          <div className="DeploymentsPageSideNav">
+        <div className="DashboardMainContainer">
+          <div className="DashboardSideNav">
             <SideNav
               clusterName={clusterName}
               clusterId={match.params.clusterID}
             />
           </div>
-          <div className="DeploymentsPageMainContent">
-            <InformationBar header="Deployments" />
-            <div className="DeploymentsPageTableSection">
+          <div className="DashboardContentWrap">
+            <div className="DashboardContentInfobar">
+              <InformationBar header="Deployments" />
+            </div>
+            <div className="DashboardContentMain">
               <div className="ResourcesTable">
                 <table>
                   <thead className="uppercase">

--- a/src/components/NamespacesList/index.js
+++ b/src/components/NamespacesList/index.js
@@ -20,21 +20,23 @@ class NamespacesListPage extends React.Component {
   }
 
   render() {
-    const { namespacesList, isRetrieving } = this.props;
+    const { namespacesList, isRetrieving, isRetrieved } = this.props;
     const clusterName = localStorage.getItem('clusterName');
 
     return (
-      <div>
-        <Header />
-        <div className="MainSection">
-          <div className="SiteSideNav">
+      <div className="DashboardContainer">
+        <div className="DashboardHeaderContainer">
+          <Header />
+        </div>
+        <div className="DashboardMainContainer">
+          <div className="DashboardSideNav">
             <SideNav clusterName={clusterName} clusterId={this.props.match.params.clusterID} />
           </div>
-          <div className="Content">
-            <div className="UpperBar">
+          <div className="DashboardContentWrap">
+            <div className="DashboardContentInfobar">
               <InformationBar header="Namespaces" showBtn={false} />
             </div>
-            <div className="LowerBar">
+            <div className="DashboardContentMain">
               <div className="ResourcesTable">
                 <table className="NamespacesTable">
                   <thead>
@@ -71,7 +73,15 @@ class NamespacesListPage extends React.Component {
                     )
                   }
                 </table>
-
+                {(!isRetrieving && !isRetrieved) && (
+                  <div className="FailedToRetrieveMsg">
+                    <p>
+                      Oops! Something went wrong!
+                      <br />
+                      Failed to retrieve deployments.
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/NamespacesList/index.js
+++ b/src/components/NamespacesList/index.js
@@ -55,7 +55,7 @@ class NamespacesListPage extends React.Component {
                       </tr>
                     ) : (
                       <tbody>
-                        {namespacesList.length !== 0 ? (
+                        {isRetrieved && namespacesList.length !== 0 && (
                           namespacesList.map((namespace) => (
                             <tr>
                               <td>{namespace.metadata.name}</td>
@@ -63,22 +63,22 @@ class NamespacesListPage extends React.Component {
                               <td>{tellAge(namespace.metadata.creationTimestamp)}</td>
                             </tr>
 
-                          )))
-                          : (
-                            <div className="EmptyList">
-                              <h3>No Namespaces Available</h3>
-                            </div>
-                          )}
+                          )))}
                       </tbody>
                     )
                   }
                 </table>
+                {(isRetrieved && namespacesList.length === 0) && (
+                  <div className="FailedToRetrieveMsg">
+                    <p>No namespaces available</p>
+                  </div>
+                )}
                 {(!isRetrieving && !isRetrieved) && (
                   <div className="FailedToRetrieveMsg">
                     <p>
                       Oops! Something went wrong!
                       <br />
-                      Failed to retrieve deployments.
+                      Failed to retrieve namespaces.
                     </p>
                   </div>
                 )}

--- a/src/components/NamespacesList/index.js
+++ b/src/components/NamespacesList/index.js
@@ -94,18 +94,20 @@ class NamespacesListPage extends React.Component {
 NamespacesListPage.propTypes = {
   namespacesList: PropTypes.object,
   isRetrieving: PropTypes.bool,
+  isRetrieved: PropTypes.bool,
   clusterName: PropTypes.string,
 };
 
 NamespacesListPage.defaultProps = {
   namespacesList: [],
   isRetrieving: false,
+  isRetrieved: false,
   clusterName: '',
 };
 
 export const mapStateToProps = (state) => {
-  const { isRetrieving, namespacesList, clusterName } = state.NamespacesListReducer;
-  return { isRetrieving, namespacesList, clusterName };
+  const { isRetrieved, isRetrieving, namespacesList, clusterName } = state.NamespacesListReducer;
+  return { isRetrieved, isRetrieving, namespacesList, clusterName };
 };
 
 export const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/redux/reducers/NamespacesListReducer.js
+++ b/src/redux/reducers/NamespacesListReducer.js
@@ -7,6 +7,7 @@ import {
 const initialState = {
   namespacesList: [],
   isRetrieving: false,
+  isRetrieved: false,
   message: 'No Namespaces Available'
 };
 
@@ -17,20 +18,23 @@ const NamespacesListReducer = (state = initialState, action) => {
       ...state,
       namespacesList: action.payload,
       isRetrieving: false,
+      isRetrieved: true,
       message: 'All Namespaces in this Cluster fetched'
     };
 
   case IS_FETCHING:
     return {
       ...state,
-      isRetrieving: true
+      isRetrieving: true,
+      isRetrieved: false,
     };
 
   case FETCH_NAMESPACES_FAILED:
     return {
       ...state,
       message: action.payload,
-      isRetrieving: false
+      isRetrieving: false,
+      isRetrieved: false,
     };
   default:
     return state;


### PR DESCRIPTION
### What does this PR do?
1. Adds global styling for the Common Dashboard. We can reuse these classes to save time
2. Fix the header (Header remains on top on scroll)
3. Add some styling to the feedback

### Screenshots
1. Added styling for this dashboard layout. 
![Screenshot from 2020-03-18 14-00-41](https://user-images.githubusercontent.com/29985169/76964248-770fe380-6933-11ea-9418-7c548c5ae915.png)

2. Header is fixed at the top when you scroll
![Screenshot from 2020-03-18 14-01-19](https://user-images.githubusercontent.com/29985169/76964305-93138500-6933-11ea-8b70-4b57d2a1ac94.png)

3. Style the feedback we give
CASE 1: Namespaces not available
![Screenshot from 2020-03-18 14-06-16](https://user-images.githubusercontent.com/29985169/76964390-b50d0780-6933-11ea-9fa5-ab93c9f900bc.png)

CASE 2: Namespaces could be available but failed to retrieve (maybe because of network)
![Screenshot from 2020-03-18 14-03-59](https://user-images.githubusercontent.com/29985169/76964447-d1a93f80-6933-11ea-842c-c9f8e5ce3c52.png)

### Some additional context
This styling has been tested on the Deployments and Namespaces pages only.
Once approved and merged, we can go ahead and add this to all other dashboard pages
(Didn't want to do too much in one PR)