### PR TITLE
Fix add status to deployments

### DIFF
--- a/src/components/DeploymentsPage/index.js
+++ b/src/components/DeploymentsPage/index.js
@@ -6,6 +6,7 @@ import getDeployments from '../../redux/actions/getDeployments';
 import Header from '../Header';
 import SideNav from '../SideNav';
 import InformationBar from '../InformationBar';
+import Status from '../Status';
 import ProgressBar from '../ProgressBar';
 import { BigSpinner } from '../SpinnerComponent';
 import tellAge from '../../helpers/ageUtility';
@@ -30,6 +31,20 @@ class DeploymentsPage extends Component {
 
   displayFraction(numerator, denominator) {
     return `${numerator}/${denominator}`;
+  }
+
+  deploymentStatus(conditions) {
+    let status = '';
+    conditions.map((condition) => {
+      if (condition.type === 'Available') {
+        status = condition.status;
+      }
+      return null;
+    });
+    if (status === 'True') {
+      return true;
+    }
+    return false;
   }
 
   render() {
@@ -64,6 +79,7 @@ class DeploymentsPage extends Component {
                     <tr>
                       <th>name</th>
                       <th>ready</th>
+                      <th>status</th>
                       <th>age</th>
                     </tr>
                   </thead>
@@ -92,6 +108,7 @@ class DeploymentsPage extends Component {
                                 />
                               )}
                             </td>
+                            <td><Status status={this.deploymentStatus(deployment.status.conditions)} /></td>
                             <td>{tellAge(deployment.metadata.creationTimestamp)}</td>
                           </tr>
                         )))}


### PR DESCRIPTION
#### What this Pr does
- Adds status to deployments 
- This is to create uniformity between `admin app deployments` and `user app status` 

### ScreenShots

![Screenshot from 2020-03-27 12-30-40](https://user-images.githubusercontent.com/18049550/77742040-e4540080-7026-11ea-9ebd-1bb9d796b272.png)



