### PR TITLE
customize error for conflicting app names

### DIFF
--- a/src/components/AppsPage/index.jsx
+++ b/src/components/AppsPage/index.jsx
@@ -96,7 +96,8 @@ class AppsPage extends React.Component {
       createApp,
       match,
       isCreated,
-      attempted
+      attempted,
+      errorCode
     } = this.props;
 
 
@@ -131,9 +132,15 @@ class AppsPage extends React.Component {
       }
 
       if (attempted === true && isCreated === false) {
-        this.setState({
-          createFeedback: 'Something went wrong. Failed to deploy'
-        });
+        if (errorCode === 409) {
+          this.setState({
+            createFeedback: 'App name already in use, select another and try again'
+          });
+        } else {
+          this.setState({
+            createFeedback: 'Something went wrong. Failed to deploy'
+          });
+        }
       }
     }
   }
@@ -297,14 +304,15 @@ class AppsPage extends React.Component {
 
 const mapStateToProps = ({ user, createNewApp }) => {
   const {
-    isCreated, isCreating, app, attempted
+    isCreated, isCreating, app, attempted, errorCode
   } = createNewApp;
   return {
     user,
     isCreated,
     isCreating,
     app,
-    attempted
+    attempted,
+    errorCode
   };
 };
 

--- a/src/redux/actions/createApp.js
+++ b/src/redux/actions/createApp.js
@@ -16,6 +16,8 @@ const createAppFail = (error) => ({
   payload: {
     status: false,
     error: error.status,
+    errorCode: error.response.status
+
   },
 });
 

--- a/src/redux/reducers/createApp.js
+++ b/src/redux/reducers/createApp.js
@@ -34,6 +34,7 @@ const createAppReducer = (state = initialState, action) => {
       isCreating: false,
       isCreated: false,
       attempted: true,
+      errorCode: action.payload.errorCode
     };
 
   default:


### PR DESCRIPTION
### What does this PR do?
It creates a customized error for the edge case where the user tries to create a new app with an existing app's name

### How to test?
Pull branch and run locally.
Create a project, and then create an app with a name of your choice, then try to create another app using the same name.

### Screenshots 
This shows a list of apps in my project, focus attention on app called "helloz"
![Screenshot from 2020-04-06 12-27-29](https://user-images.githubusercontent.com/36065782/78544788-5c7aad00-7803-11ea-928e-4ff7edace063.png)

Here i try to create another app with the name "helloz" which is for an existing app
![Screenshot from 2020-04-06 12-28-39](https://user-images.githubusercontent.com/36065782/78544818-669cab80-7803-11ea-8787-0781e30f4a51.png)
