### PR TITLE
Change backend Api url to from cluster to staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,5 @@
-export const API_BASE_URL = 'http://crane-mak-w1.cranecloud.io:30895';
+// cluster Url
+// export const API_BASE_URL = 'http://crane-mak-w1.cranecloud.io:30895';http://staging-api.cranecloud.io/
+
+// Staging Url
+export const API_BASE_URL = 'http://staging-api.cranecloud.io/';

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,2 @@
-// cluster Url
-// export const API_BASE_URL = 'http://crane-mak-w1.cranecloud.io:30895';http://staging-api.cranecloud.io/
-
 // Staging Url
-export const API_BASE_URL = 'http://staging-api.cranecloud.io/';
+export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;


### PR DESCRIPTION
#### What this Pr Does
Changes back-end url to the `gcp` staging api

#### How to use it
- Add a `.env` file to your project directory and add `REACT_APP_API_BASE_URL` variable to it,
eg
`REACT_APP_API_BASE_URL=http://backendurl/` no quotes. staging url is in slack
