### PR TITLE
Add required prop to input components

### DIFF
--- a/src/components/BlackInputText/index.jsx
+++ b/src/components/BlackInputText/index.jsx
@@ -6,12 +6,13 @@ const BlackInputText = ({
   onChange,
   placeholder,
   name,
-  value
+  value,
+  required
 }) => (
   <input
     className="BlackInputText"
     type="text"
-    placeholder={`${placeholder} *`}
+    placeholder={`${placeholder}${required ? ' *' : ''}`}
     name={name}
     value={value}
     onChange={(e) => {
@@ -24,11 +25,13 @@ BlackInputText.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string,
   placeholder: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool
 };
 
 BlackInputText.defaultProps = {
-  value: ''
+  value: '',
+  required: false
 };
 
 export default BlackInputText;

--- a/src/components/InputPassword/index.js
+++ b/src/components/InputPassword/index.js
@@ -5,7 +5,7 @@ import './InputPassword.css';
 const InputPassword = (props) => {
   const [inputBackground, setBackground] = useState('InitialBackground');
   const {
-    name, value, placeholder, onChange
+    name, value, placeholder, onChange, required
   } = props;
 
   const changeBackground = () => {
@@ -22,7 +22,7 @@ const InputPassword = (props) => {
     <input
       className={`InputPassword ${inputBackground}`}
       type="password"
-      placeholder={`${placeholder} *`}
+      placeholder={`${placeholder}${required ? ' *' : ''}`}
       name={name}
       value={value}
       onChange={(e) => {
@@ -36,11 +36,13 @@ InputPassword.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string,
   placeholder: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool
 };
 
 InputPassword.defaultProps = {
-  value: ''
+  value: '',
+  required: false
 };
 
 export default InputPassword;

--- a/src/components/InputText/index.js
+++ b/src/components/InputText/index.js
@@ -5,7 +5,7 @@ import './InputText.css';
 const InputText = (props) => {
   const [inputBackground, setBackground] = useState('InitialBackground');
   const {
-    name, value, placeholder, onChange
+    name, value, placeholder, onChange, required
   } = props;
 
   const changeBackground = () => {
@@ -22,7 +22,7 @@ const InputText = (props) => {
     <input
       className={`InputText ${inputBackground}`}
       type="text"
-      placeholder={`${placeholder} *`}
+      placeholder={`${placeholder}${required ? ' *' : ''}`}
       name={name}
       value={value}
       onChange={(e) => {
@@ -36,11 +36,13 @@ InputText.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string,
   placeholder: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool
 };
 
 InputText.defaultProps = {
-  value: ''
+  value: '',
+  required: false
 };
 
 export default InputText;


### PR DESCRIPTION
### What does this PR do?
Adds `required` prop to all input components.
The reason for this is to conditionally show the * symbol for required inputs.
Currently, the * symbol is on all inputs by default and this can be misleading to users.

After this is merged, we can go ahead to use this prop in all inputs that are required 