### PR TITLE
Hide overflowing descriptions on card

### DIFF
--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -20,6 +20,8 @@
 .BottomContainer {
     padding: 0.625rem;
     height: 5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .ProjectsCardName{


### PR DESCRIPTION
### BEFORE
![Screenshot from 2020-05-14 22-11-31](https://user-images.githubusercontent.com/29985169/81976002-90ca6000-9630-11ea-8a16-0e3acc373a3d.png)

### AFTER
![Screenshot from 2020-05-14 22-11-43](https://user-images.githubusercontent.com/29985169/81976028-9a53c800-9630-11ea-9bb3-8751665de3eb.png)

The description is there but hidden.