### PR TITLE
Show error for existing email on register.

### DIFF
--- a/src/components/RegisterPage/index.js
+++ b/src/components/RegisterPage/index.js
@@ -120,7 +120,8 @@ export default class RegisterPage extends Component {
         })
         .catch((error) => {
           this.setState({
-            loading: false
+            loading: false,
+            error: "Email already in use by another account."
           });
         });
     }

--- a/src/components/RegisterPage/index.js
+++ b/src/components/RegisterPage/index.js
@@ -121,7 +121,7 @@ export default class RegisterPage extends Component {
         .catch((error) => {
           this.setState({
             loading: false,
-            error: "Email already in use by another account."
+            error: 'Email already in use by another account.'
           });
         });
     }


### PR DESCRIPTION
#### What does this PR do?

This feature adds an error message to a user when they try to register with an email address that is already associated with a particular account already on the platform.

#### Screenshots:

![image](https://user-images.githubusercontent.com/32802973/82556791-1e4b0a00-9b73-11ea-93dd-9cb633c6341f.png)
