### PR TITLE
Fix context menu arrangement order

### DIFF
--- a/src/components/AppsCard/index.jsx
+++ b/src/components/AppsCard/index.jsx
@@ -70,13 +70,13 @@ const AppsCard = (props) => {
                     <img src={DotsImg} alt="three dots" className="DropDownImg" />
                     {openDropDown && (
                       <div className="AppDropDownContent">
+                        <div>Update</div>
                         <div
                           onClick={showDeleteAlert}
                           role="presentation"
                         >
                           Delete
                         </div>
-                        <div>Update</div>
                       </div>
                     )}
                   </div>

--- a/src/components/ProjectCard/index.js
+++ b/src/components/ProjectCard/index.js
@@ -217,16 +217,16 @@ class ProjectCard extends React.Component {
                           {openDropDown && (
                             <div className="ProjectDropDownContent">
                               <div
-                                onClick={this.showDeleteAlert}
-                                role="presentation"
-                              >
-                                Delete
-                              </div>
-                              <div
                                 onClick={this.showUpdateForm}
                                 role="presentation"
                               >
                                 Update
+                              </div>
+                              <div
+                                onClick={this.showDeleteAlert}
+                                role="presentation"
+                              >
+                                Delete
                               </div>
                             </div>
                           )}


### PR DESCRIPTION
#### PR do?
Re-arrange the order for context menu items for the app card and project card.

#### Screenshots:
Before:
![image](https://user-images.githubusercontent.com/32802973/83243167-34298200-a1a6-11ea-81c1-1ca7bb1e4c22.png)

After:
![image](https://user-images.githubusercontent.com/32802973/83243086-178d4a00-a1a6-11ea-8597-4378c3e14d2e.png)
