### PR TITLE
Align button height with input elements

### DIFF
--- a/src/components/AppsPage/AppsPage.css
+++ b/src/components/AppsPage/AppsPage.css
@@ -55,14 +55,15 @@ height: 200px; /* I've had to limit this height for now */
 }
 
 .EnvVarsInputGroup .EnvVarsAddBtn {
-position: relative;
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .EnvVarsInputGroup .EnvVarsAddBtn button.EnvVarAddBtn {
   position: absolute;
   max-width: 100%;
   color: #fff;
-  height: 100%;
   background-color: #008ac1;
   outline: 2px solid #008ac1;
 }
@@ -144,7 +145,7 @@ table-layout: fixed;
 }
 
 .ModalForm.AddAppModal input {
-  max-height: 50px;
+  height: 3.1rem;
 }
 
 .ModalForm.AddAppModal .ModalFormHeading {

--- a/src/components/PrimaryButton/PrimaryButton.css
+++ b/src/components/PrimaryButton/PrimaryButton.css
@@ -1,7 +1,7 @@
 .Primary-Btn {
   background-color: #F7B21F;
   width: 155px;
-  height: 50px;
+  height: 2.9rem;
   color: white;
   font-size: 16px;
   font-style: normal;

--- a/src/components/PrimaryButton/PrimaryButton.css
+++ b/src/components/PrimaryButton/PrimaryButton.css
@@ -1,9 +1,9 @@
 .Primary-Btn {
   background-color: #F7B21F;
-  width: 155px;
+  width: 9.7rem;
   height: 2.9rem;
   color: white;
-  font-size: 16px;
+  font-size: 1rem;
   font-style: normal;
   font-weight: bold;
   font-family: 'Roboto', sans-serif;

--- a/src/components/SecondaryButton/SecondaryButton.css
+++ b/src/components/SecondaryButton/SecondaryButton.css
@@ -1,24 +1,24 @@
 .Secondary-Btn {
-    background-color: transparent;
-    width: 155px;
-    height: 50px;
-    font-size: 16px;
-    font-weight: bold;
-    font-family: 'Roboto', sans-serif;
-    border: none;
-    /* box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19); */
-  }
-  
-  .Secondary-Btn:hover{
-  background-color: #DDDDDD;
-  }
-  
-  .SecondaryBlack{
+  background-color: transparent;
+  width: 9.7rem;
+  height: 2.9rem;
+  font-size: 1rem;
+  font-weight: bold;
+  font-family: "Roboto", sans-serif;
+  border: none;
+  /* box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19); */
+}
+
+.Secondary-Btn:hover {
+  background-color: #dddddd;
+}
+
+.SecondaryBlack {
   outline: 2px solid black;
   color: black;
-  }
-  
-  .SecondaryWhite{
+}
+
+.SecondaryWhite {
   outline: 2px solid white;
   color: white;
-  }
+}


### PR DESCRIPTION
### What this does?
- Align button height with input element. i.e. On the **Deploy App** modal >> Env Vars section
- Also, use `rem` units instead of `px` for Buttons width and height

![Screenshot from 2020-06-02 12-29-39](https://user-images.githubusercontent.com/29985169/83506268-9c8ea100-a4cf-11ea-8f92-d0cf3f8d5b03.png)

Corresponding Trello ticket [here](https://trello.com/c/jybh3zJ1)

