### PR TITLE
Clear existing user at Verification

### DIFF
--- a/src/components/VerificationSentPage/index.js
+++ b/src/components/VerificationSentPage/index.js
@@ -32,6 +32,11 @@ class VerificationSentPage extends React.Component {
     const { match, saveUser } = this.props;
     const { token } = match.params;
 
+      // remove the current state from local storage
+      // so that when a person doesnt access the panel of another
+      // the previous state which wasnt cleared
+      localStorage.removeItem('state');
+
     axios
       .get(`${API_BASE_URL}/users/verify/${token}`)
       .then((response) => {

--- a/src/components/VerificationSentPage/index.js
+++ b/src/components/VerificationSentPage/index.js
@@ -32,10 +32,10 @@ class VerificationSentPage extends React.Component {
     const { match, saveUser } = this.props;
     const { token } = match.params;
 
-      // remove the current state from local storage
-      // so that when a person doesnt access the panel of another
-      // the previous state which wasnt cleared
-      localStorage.removeItem('state');
+    // remove the current state from local storage
+    // so that when a person doesnt access the panel of another
+    // from the previous state which wasnt cleared
+    localStorage.removeItem('state');
 
     axios
       .get(`${API_BASE_URL}/users/verify/${token}`)


### PR DESCRIPTION
#### What does this PR do?
This clears the existing user from the system, hence the user menu does not (should not) appear when someone tries to verify their account, because it is a loophole for someone hijacking another account.

#### Screenshots:
Look at the top right-hand side of the images
Before:
![image](https://user-images.githubusercontent.com/32802973/83545177-856ba580-a507-11ea-90ed-67e2b98bac8f.png)

After
![image](https://user-images.githubusercontent.com/32802973/83545125-72f16c00-a507-11ea-9c0c-133b3d100b2f.png)
