### PR TITLE
Fix page layouts

### DIFF
--- a/src/components/CreateNewPassword/CreateNewPassword.css
+++ b/src/components/CreateNewPassword/CreateNewPassword.css
@@ -1,20 +1,20 @@
 .NewPasswordPageContainer {
-    background: #008ac1;
-    height: 100%;
-    color: #ffffff;
-    display: flex;
-    flex-direction: column;
+  flex-grow: 1;
+  background: #008ac1;
+  height: 100%;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
 }
 
 .NewPasswordContent {
- justify-self: center;
- flex: 1;
- display: flex;
- align-self: center;
- flex-direction: column;
- padding: 5rem 4rem;
+  flex-grow: 1;
+  justify-self: center;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-
 
 .NewPasswordContentInputs {
   display: grid;
@@ -44,31 +44,17 @@
 
 .NewPasswordErrorDiv {
   background-color: rgba(255, 255, 255, 0.5);
-  color: rgb(214, 59, 59);
+  color: #d63b3b;
   text-align: center;
   padding: 1rem 0;
-}
-
-.NewPasswordPageFooter {
-  position: relative;
-  margin-top: 5rem;
 }
 
 @media only screen and (max-width: 640px) {
   .NewPasswordContent {
     width: 90%;
   }
- 
+
   .InputText {
     width: 90%;
-  }
-}
-/* weird media query to fix fullscreen misbehavior */
-@media only screen and (min-height: 768px) {
-  .NewPasswordPageContainer {
-    height: 100vh;
-  }
-  .NewPasswordContent {
-    padding: 8rem 4rem 0;
   }
 }

--- a/src/components/LandingFooter/LandingFooter.css
+++ b/src/components/LandingFooter/LandingFooter.css
@@ -1,6 +1,5 @@
 footer.LandingFooter {
   color: white;
   text-align: center;
-  padding-bottom: 1rem;
   cursor: pointer;
 }

--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -47,10 +47,3 @@
     display: none;
   }
 }
-
-/* weird media query to fix fullscreen misbehavior */
-@media only screen and (min-height: 700px) {
-  .LandingPage {
-    height: 100vh;
-  }
-}

--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -1,21 +1,23 @@
 .LandingPage {
   height: 100%;
   background: #008ac1;
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column;
 }
 
 .LandingPageMain {
-  height: 100%;
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
 }
 
 .LandingPageMainContent {
-  margin-top: 2rem;
-  flex: 1;
+  flex-grow: 1;
   display: flex;
   flex-direction: row;
   align-self: center;
-  padding: 5rem 4rem 0;
+  padding: 0 4rem;
 }
 
 .LandingPageMainContentInfo {
@@ -38,11 +40,6 @@
   line-height: 37px;
   font-size: 32px;
   width: 80%;
-}
-
-.LandingPageFooter {
-  position: relative;
-  margin-top: 5rem;
 }
 
 @media only screen and (max-width: 640px) {

--- a/src/components/LoginPage/LoginPage.css
+++ b/src/components/LoginPage/LoginPage.css
@@ -1,15 +1,14 @@
 .LoginPageContainer {
-  height: 100%;
   background: #008ac1;
   color: #ffffff;
   display: flex;
   flex-direction: column;
   overflow-y: hidden;
+  flex-grow: 1;
 }
 
 .LoginContent {
-  margin-top: 4rem;
-  flex: 1;
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   align-self: center;
@@ -38,32 +37,13 @@ a.LoginContentLink {
 }
 
 .LoginContentBottomLink {
-  margin-top: 1rem;
+  padding-top: 1rem;
 }
 
-.LoginPageFooter {
-  position: relative;
-  margin-top: 5rem;
-}
 
 @media only screen and (max-width: 640px) {
   .LoginContent {
     width: 90%;
   }
-
-  .InputPassword,
-  .InputText {
-    width: 90%;
-  }
 }
 
-/* weird media query to fix fullscreen misbehavior */
-@media only screen and (min-height: 700px) {
-  .LoginPageContainer {
-    height: 100vh;
-  }
-
-  .LoginContent {
-    padding: 8rem 4rem 0;
-  }
-}

--- a/src/components/LoginPage/LoginPage.css
+++ b/src/components/LoginPage/LoginPage.css
@@ -31,7 +31,7 @@ a.LoginContentLink {
 }
 .LoginErrorDiv {
   background-color: rgba(255, 255, 255, 0.5);
-  color: rgb(214, 59, 59);
+  color: #d63b3b;
   text-align: center;
   padding: 1rem 0;
 }

--- a/src/components/PasswordReset/PasswordReset.css
+++ b/src/components/PasswordReset/PasswordReset.css
@@ -1,20 +1,19 @@
 .ResetPasswordPageContainer {
-    background: #008ac1;
-    height: 100%;
-    color: #ffffff;
-    display: flex;
-    flex-direction: column;
+  flex-grow: 1;
+  background: #008ac1;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
 }
 
 .ResetPasswordContent {
- justify-self: center;
- flex: 1;
- display: flex;
- align-self: center;
- flex-direction: column;
- padding: 5rem 4rem;
+  flex-grow: 1;
+  justify-self: center;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-
 
 .ResetPasswordContentInputs {
   display: grid;
@@ -22,17 +21,9 @@
   gap: 1rem;
 }
 
-.ResetPasswordLinkContainer {
-  display: inline-block;
-}
-
 a.ResetPasswordContentLink {
-  color: #F7B21F;
-  border-bottom: 1px solid #F7B21F;
-}
-
-.ResetPasswordContentBottomLink {
-  margin-top: 1rem;
+  color: #f7b21f;
+  border-bottom: 1px solid #f7b21f;
 }
 
 .ResetPasswordMessage {
@@ -58,31 +49,17 @@ a.ResetPasswordContentLink {
 .ResetPasswordErrorDiv {
   background-color: rgba(255, 255, 255, 0.5);
   width: 25rem;
-  color: rgb(214, 59, 59);
+  color: #d63b3b;
   text-align: center;
   padding: 1rem 0;
-}
-
-.PasswordResetPageFooter {
-  position: relative;
-  margin-top: 5rem;
 }
 
 @media only screen and (max-width: 640px) {
   .ResetPasswordContent {
     width: 90%;
   }
- 
+
   .InputText {
     width: 90%;
-  }
-}
-/* weird media query to fix fullscreen misbehavior */
-@media only screen and (min-height: 768px) {
-  .ResetPasswordPageContainer {
-    height: 100vh;
-  }
-  .ResetPasswordContent {
-    padding: 8rem 4rem 0;
   }
 }

--- a/src/components/RegisterPage/RegisterPage.css
+++ b/src/components/RegisterPage/RegisterPage.css
@@ -1,14 +1,14 @@
 .RegisterPageContainer {
   background: #008ac1;
-  height: 100%;
   color: #ffffff;
   display: flex;
   overflow-y: hidden;
   flex-direction: column;
+  flex-grow: 1;
 }
 
 .RegisterContent {
-  flex: 1;
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   align-self: center;
@@ -52,18 +52,9 @@ a.RegisterContentLink {
 
 .RegisterErrorDiv {
   background-color: rgba(255, 255, 255, 0.5);
-  color: rgb(214, 59, 59);
+  color: #d63b3b;
   text-align: center;
   padding: 1rem 0;
-}
-
-.RegisterContentBottomLink {
-  margin-top: 1rem;
-}
-
-.RegisterPageFooter {
-  /* position: relative; */
-  margin-top: 5rem;
 }
 
 @media only screen and (max-width: 640px) {
@@ -82,15 +73,4 @@ a.RegisterContentLink {
   .VerificationCodeInput .InputText {
     width: 100%;
   }
-}
-
-/* weird media query to fix fullscreen misbehavior */
-@media only screen and (min-height: 700px) {
-  .RegisterPageContainer {
-    height: 100vh;
-  }
-
-  /* .RegisterContent {
-    padding: 8rem 4rem 0;
-  } */
 }

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,12 @@ body {
   font-family: proxima-nova, sans-serif;
 }
 
+div#root {
+  min-height: 100vh;
+  display: flex;
+  flex-flow: column;
+}
+
 textarea, input, select, button {
   font-family: inherit;
   font-size: inherit;


### PR DESCRIPTION
### What does this PR do?
At the start, we did not implement the layouts well. Thus, some pages ended up having an extra white space below the content. 
So, after a discussion with @mrwagaba, this PR re-implements some of these pages using `flexbox`.

The pages being modified include:
- Landing
- Login
- Register
- Forgot Password
- Create New Password

### How this is being done...
Consider this below as an example of our layout on every featured component:

**|body
|---root
|-----component**

1. **root** is set to `min-height:100vh` and `display: flex` 
2. the **component's containers** then have `flex-grow: 1` 

### Also...
- Removes media query that was being used for height on all the above pages
- Removes `margin` css property on the above pages
