### PR TITLE
Remove rounded corners from app card

### DIFF
--- a/src/components/AppsCard/AppsCard.css
+++ b/src/components/AppsCard/AppsCard.css
@@ -9,7 +9,6 @@
   word-wrap: break-word;
   background-clip: border-box;
   border: 1px solid rgba(0, 0, 0, 0.125);
-  border-radius: 0.25rem;
   height: 200px;
 }
 
@@ -19,7 +18,6 @@
   text-transform: lowercase;
   cursor: pointer;
   font-size: 18px;
-  border-radius: calc(0.25rem - 1px) calc(0.25rem - 1px) 0 0;
   padding: 0.75rem 0.2rem 0.75rem 1.25rem;
   margin-bottom: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);


### PR DESCRIPTION
### what does this do? 
Remove the border-radius from the `Apps` card for consistency with design.

### Screenhots

BEFORE             |  AFTER
:-------------------------:|:-------------------------:
![Screenshot from 2020-06-17 16-17-39](https://user-images.githubusercontent.com/29985169/84902945-1f118600-b0b6-11ea-9b6d-c5f9b11a54cf.png) | ![Screenshot from 2020-06-17 16-13-56](https://user-images.githubusercontent.com/29985169/84902773-ec678d80-b0b5-11ea-850a-33e5a1cf020d.png)

### corresponding Trello ticket
https://trello.com/c/YLIW3fkq