### PR TITLE
Give cta buttons appropriate labels

### DIFF
--- a/src/components/AppsPage/index.jsx
+++ b/src/components/AppsPage/index.jsx
@@ -630,7 +630,7 @@ class AppsPage extends React.Component {
 
             <div className="ModalFormButtons AddAddButtons">
               <PrimaryButton label="cancel" className="CancelBtn" onClick={this.hideForm} />
-              <PrimaryButton label={isCreating ? <Spinner /> : 'proceed'} onClick={this.handleSubmit} />
+              <PrimaryButton label={isCreating ? <Spinner /> : 'deploy'} onClick={this.handleSubmit} />
             </div>
 
             {message && (

--- a/src/components/ProjectCard/index.js
+++ b/src/components/ProjectCard/index.js
@@ -343,7 +343,7 @@ class ProjectCard extends React.Component {
 
                 <div className="ModalFormButtons">
                   <PrimaryButton label="Cancel" className="CancelBtn" onClick={this.hideUpdateForm} />
-                  <PrimaryButton label={isUpdating ? <Spinner /> : 'Proceed'} onClick={this.handleSubmit} />
+                  <PrimaryButton label={isUpdating ? <Spinner /> : 'update'} onClick={this.handleSubmit} />
                 </div>
 
               </div>

--- a/src/components/UserProjectsPage/index.jsx
+++ b/src/components/UserProjectsPage/index.jsx
@@ -247,7 +247,7 @@ class UserProjectsPage extends React.Component {
             )}
             <div className="ModalFormButtons">
               <PrimaryButton label="Cancel" className="CancelBtn" onClick={this.hideForm} />
-              <PrimaryButton label={isAdding ? <Spinner /> : 'Proceed'} onClick={this.handleSubmit} />
+              <PrimaryButton label={isAdding ? <Spinner /> : 'add'} onClick={this.handleSubmit} />
             </div>
 
             {message && (


### PR DESCRIPTION
### What this PR does?
Rename `CTA` button labels... Instead of **'PROCEED'**, the labels have been changed as follows:

**For Deploy App:**
![Screenshot from 2020-06-18 14-46-15](https://user-images.githubusercontent.com/29985169/85016840-32cef200-b173-11ea-839b-50b0f8bef872.png)

**For Add a project:**
![Screenshot from 2020-06-18 14-46-29](https://user-images.githubusercontent.com/29985169/85016862-40847780-b173-11ea-8b59-c18d70558040.png)

**For update a project**
![Screenshot from 2020-06-18 14-46-44](https://user-images.githubusercontent.com/29985169/85016903-48dcb280-b173-11ea-8e7f-44190b3ee9a9.png)

**Corresponding Trello Ticket**
https://trello.com/c/cAzau74g