### PR TITLE
Remove redundant links

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -82,9 +82,6 @@ const Header = (props) => {
           {hidden && (
             <div ref={dropdownRef} className="BelowHeader">
               <div className="DropDownContent">
-                <div className="DropDownLink">Profile</div>
-                <div className="DropDownLink">Account</div>
-                <div className="DropDownLink">Settings</div>
                 <div className="DropDownLink" role="presentation" onClick={logout}>Logout</div>
               </div>
             </div>


### PR DESCRIPTION
### What does this do?
Remove the following unused links on the user-profile section dropdown: Profile, Settings & Account... leaving only Logout. 

### SCREENSHOTS
### BEFORE
![Screenshot from 2020-06-19 09-22-53](https://user-images.githubusercontent.com/29985169/85103151-cd304380-b20e-11ea-8d32-56b4ce92051f.png)

### AFTER
![Screenshot from 2020-06-19 09-22-33](https://user-images.githubusercontent.com/29985169/85103161-d28d8e00-b20e-11ea-8570-06002c8d70a2.png)

### Trello ticket
https://trello.com/c/fKrc2zom