### PR TITLE
Reposition wrongly placed spinners

### DIFF
--- a/src/components/AdminProjectsPage/index.js
+++ b/src/components/AdminProjectsPage/index.js
@@ -47,7 +47,7 @@ class AdminProjectsPage extends React.Component {
               <InformationBar header="Projects" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table>
                   <thead className="uppercase">
                     <tr>

--- a/src/components/AppsList/index.jsx
+++ b/src/components/AppsList/index.jsx
@@ -45,7 +45,7 @@ class AppsList extends Component {
   render() {
     const { apps, isRetrieved, isRetrieving } = this.props;
     return (
-      <div className="AppsList">
+      <>
         {
           isRetrieving ? (
             <div className="TableLoading">
@@ -83,8 +83,7 @@ class AppsList extends Component {
             Failed to retrieve Apps.
           </div>
         )}
-
-      </div>
+      </>
     );
   }
 }

--- a/src/components/DeploymentsPage/index.js
+++ b/src/components/DeploymentsPage/index.js
@@ -68,7 +68,7 @@ class DeploymentsPage extends Component {
               <InformationBar header="Deployments" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isFetchingDeployments ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table>
                   <thead className="uppercase">
                     <tr>

--- a/src/components/JobsListPage/index.js
+++ b/src/components/JobsListPage/index.js
@@ -36,7 +36,7 @@ class JobsListPage extends React.Component {
               <InformationBar header="Jobs" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table>
                   <thead>
                     <tr>

--- a/src/components/NamespacesList/index.js
+++ b/src/components/NamespacesList/index.js
@@ -35,7 +35,7 @@ class NamespacesListPage extends React.Component {
               <InformationBar header="Namespaces" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table className="NamespacesTable">
                   <thead>
                     <tr>

--- a/src/components/NodesList/index.jsx
+++ b/src/components/NodesList/index.jsx
@@ -60,7 +60,7 @@ class NodesList extends Component {
               <InformationBar header="Nodes" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table className="Nodes table">
                   <thead>
                     <tr>

--- a/src/components/PodsList/index.jsx
+++ b/src/components/PodsList/index.jsx
@@ -92,7 +92,7 @@ class PodsList extends Component {
               <InformationBar header="Pods" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table className="PodsTable">
                   <thead>
                     <tr>

--- a/src/components/PvcsList/index.js
+++ b/src/components/PvcsList/index.js
@@ -34,7 +34,7 @@ class PvcsListPage extends React.Component {
               <InformationBar header="Volume Claims" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table>
                   <thead>
                     <tr>

--- a/src/components/PvsListPage/index.js
+++ b/src/components/PvsListPage/index.js
@@ -33,7 +33,7 @@ class PvsListPage extends React.Component {
               <InformationBar header="Volumes" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table>
                   <thead>
                     <tr>

--- a/src/components/ServicesList/index.js
+++ b/src/components/ServicesList/index.js
@@ -48,7 +48,7 @@ class ServicesListPage extends React.Component {
               <InformationBar header="Services" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table>
                   <thead>
                     <tr>

--- a/src/components/StorageClassList/index.js
+++ b/src/components/StorageClassList/index.js
@@ -34,7 +34,7 @@ class StorageClassList extends Component {
               <InformationBar header="Storage Classes" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isRetrieving ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table className="StorageClassesTable">
                   <thead>
                     <tr>

--- a/src/components/UserAccounts/index.js
+++ b/src/components/UserAccounts/index.js
@@ -33,7 +33,7 @@ class UserAccounts extends Component {
               <InformationBar header="User Accounts" showBtn={false} />
             </div>
             <div className="ContentSection">
-              <div className="ResourcesTable">
+              <div className={isFetching ? 'ResourcesTable LoadingResourcesTable' : 'ResourcesTable'}>
                 <table className="UsersTable">
                   <thead>
                     <tr>

--- a/src/components/UserProjectsPage/index.jsx
+++ b/src/components/UserProjectsPage/index.jsx
@@ -156,45 +156,42 @@ class UserProjectsPage extends React.Component {
           <InformationBar header="Projects" showBtn btnAction={this.showForm} />
         </div>
         <div className="MainRow">
-          <div className="ProjectList">
-            {
-              isRetrieving ? (
-                <div className="TableLoading">
-                  <div className="SpinnerWrapper">
-                    <Spinner size="big" />
+          {
+            isRetrieving ? (
+              <div className="TableLoading">
+                <div className="SpinnerWrapper">
+                  <Spinner size="big" />
+                </div>
+              </div>
+            ) : (
+              <div className="ProjectList">
+                {(isFetched && projects !== undefined && (
+                  (projects.map((project) => (
+                    <div key={project.id} className="ProjectCardItem">
+                      <ProjectCard
+                        name={project.name}
+                        description={project.description}
+                        cardID={project.id}
+                        icon={crane}
+                      />
+                    </div>
+                  ))))
+                )}
+                {(isFetched && projects.length === 0) && (
+                  <div className="NoContentDiv">
+                    You haven’t created any projects yet.
+                    Click the create button to get started.
                   </div>
-                </div>
-              ) : (
-                <div className="ProjectList">
-                  {(isFetched && projects !== undefined && (
-                    (projects.map((project) => (
-                      <div key={project.id} className="ProjectCardItem">
-                        <ProjectCard
-                          name={project.name}
-                          description={project.description}
-                          cardID={project.id}
-                          icon={crane}
-                        />
-                      </div>
-                    ))))
-                  )}
-                  {(isFetched && projects.length === 0) && (
-                    <div className="NoContentDiv">
-                      You haven’t created any projects yet.
-                      Click the create button to get started.
-                    </div>
-                  )}
-                  {(!isRetrieving && !isFetched) && (
-                    <div className="NoContentDiv">
-                      Oops! Something went wrong!
-                      Failed to retrieve Projects.
-                    </div>
-                  )}
-
-                </div>
-              )
-            }
-          </div>
+                )}
+                {(!isRetrieving && !isFetched) && (
+                  <div className="NoContentDiv">
+                    Oops! Something went wrong!
+                    Failed to retrieve Projects.
+                  </div>
+                )}
+              </div>
+            )
+          }
         </div>
         <div className="FooterRow">
           <p>

--- a/src/index.css
+++ b/src/index.css
@@ -137,8 +137,12 @@ input[type="password"] {
 /*- ////////////////////////////////// */
 
 /*- ///// TABLE STYLING ///////// */
-.ResourcesTable {
-  padding-top: 2rem;
+div.ResourcesTable {
+  padding-top: 1rem;
+}
+
+div.ResourcesTable.LoadingResourcesTable {
+  flex-grow: 1;
 }
 
 .ResourcesTable table thead {
@@ -165,6 +169,7 @@ body::-webkit-scrollbar-thumb:hover {
   text-align: center;
   border-collapse: collapse;
   width: 100%;
+  height: 100%;
 }
 
 .ResourcesTable table th {
@@ -190,12 +195,23 @@ body::-webkit-scrollbar-thumb:hover {
   font-weight: normal;
 }
 
-.TableLoading {
+div.TableLoading {
   display: flex;
   height: 100%;
   justify-self: center;
   justify-content: center;
   align-items: center;
+}
+
+tr.TableLoading {
+  position: relative;
+}
+
+tr.TableLoading td {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .ResourcesTable table tr:hover {
@@ -263,6 +279,8 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .ContentSection {
+  display: flex;
+  flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -214,8 +214,8 @@ tr.TableLoading td {
   transform: translate(-50%, -50%);
 }
 
-.ResourcesTable table tr.TableLoading:hover {
-  cursor: inherit;
+.ResourcesTable table tr.TableLoading:hover, .ResourcesTable table thead tr:hover {
+  cursor: default;
   background-color: inherit;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -214,6 +214,11 @@ tr.TableLoading td {
   transform: translate(-50%, -50%);
 }
 
+.ResourcesTable table tr.TableLoading:hover {
+  cursor: inherit;
+  background-color: inherit;
+}
+
 .ResourcesTable table tr:hover {
   background-color: #e0e0e0;
   cursor: pointer;

--- a/src/index.css
+++ b/src/index.css
@@ -191,13 +191,11 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .TableLoading {
-  position: relative;
-}
-
-.SpinnerWrapper {
-  position: absolute;
-  width: 100%;
-  margin-top: 4rem;
+  display: flex;
+  height: 100%;
+  justify-self: center;
+  justify-content: center;
+  align-items: center;
 }
 
 .ResourcesTable table tr:hover {
@@ -316,7 +314,8 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .MainRow {
-  width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .FooterRow {


### PR DESCRIPTION
### What does this do?
Reposition spinners in the middle of pages when loading content...
These pages include: 
1. User Projects Page
2. User Apps Page
3. All admin resources pages (when loading the tables)

### Screenshots
- **User Projects Page - fixed**
![Screenshot from 2020-06-19 12-36-01](https://user-images.githubusercontent.com/29985169/85119698-d5967780-b22a-11ea-835e-71e35863852e.png)

- **BEFORE (Admin resources pages)**... 
![Screenshot from 2020-06-19 12-34-19](https://user-images.githubusercontent.com/29985169/85119947-3625b480-b22b-11ea-8c5a-031a0727e4e9.png)

- **AFTER (Admin resources pages)**... 
![Screenshot from 2020-06-19 12-33-34](https://user-images.githubusercontent.com/29985169/85119977-3faf1c80-b22b-11ea-801a-2da225dcd658.png)

### Trello ticket
https://trello.com/c/YBNiYJSY

### Some more context
We might need to revise our Spinner colours on white/near-white background. As you can see from the screenshots above, it is almost invisible.