### PR TITLE
Remove app modal redudant space

### DIFF
--- a/src/components/AppsPage/AppsPage.css
+++ b/src/components/AppsPage/AppsPage.css
@@ -50,7 +50,6 @@
   grid-template-columns: 1fr 1fr;
 }
 
-
 .EnvVarsInputGroup .EnvVarsAddBtn {
   position: relative;
   display: flex;

--- a/src/components/AppsPage/AppsPage.css
+++ b/src/components/AppsPage/AppsPage.css
@@ -50,9 +50,6 @@
   grid-template-columns: 1fr 1fr;
 }
 
-.ModalFormInputs .ModalFormInputsEnvVars {
-height: 200px; /* I've had to limit this height for now */
-}
 
 .EnvVarsInputGroup .EnvVarsAddBtn {
   position: relative;


### PR DESCRIPTION
#### What does the PR do?
This Pr removes redundant space on the app modal, just below the environment values

#### Screenshots
Before 
![image](https://user-images.githubusercontent.com/32802973/85411908-a3aa4b80-b571-11ea-8747-9355c39353d0.png)

After

![image](https://user-images.githubusercontent.com/32802973/85411794-78276100-b571-11ea-91a6-e4cd788aab15.png)
