### PR TITLE
Modify project update modal title

### DIFF
--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -86,12 +86,6 @@
     display: inline;
 }
 
-.UpdateToolTip{
-    width: 2rem;
-    padding-top: 1.75rem;
-}
-
-
 /*///////////// Delete Model //////////////////*/
 
 .ProjectDeleteModel{

--- a/src/components/ProjectCard/index.js
+++ b/src/components/ProjectCard/index.js
@@ -302,12 +302,6 @@ class ProjectCard extends React.Component {
                     <h2>
                       Update your project
                     </h2>
-                    <div className="UpdateToolTip">
-                      <Tooltip
-                        showIcon
-                        message="You can update either project name or description or both."
-                      />
-                    </div>
                   </div>
                 </div>
                 <div className="ModalFormInputs">

--- a/src/components/ProjectCard/index.js
+++ b/src/components/ProjectCard/index.js
@@ -301,10 +301,6 @@ class ProjectCard extends React.Component {
                   <div className="HeadingWithTooltip">
                     <h2>
                       Update your project
-                      <b>
-                        {' '}
-                        {name}
-                      </b>
                     </h2>
                     <div className="UpdateToolTip">
                       <Tooltip


### PR DESCRIPTION
### What does this PR do?
Makes changes on the title of the update project modal...

**The changes**
1. Remove tooltip
![Screenshot from 2020-06-24 10-12-26](https://user-images.githubusercontent.com/29985169/85521018-54652900-b60c-11ea-8fee-e70519964797.png)

The tooltip says that _"You can update either project name or description or both."_.
I feel like this should be obvious info.

2. Remove the project name
This feels redundant given that the user knows what project they are updating
**BEFORE**
![Screenshot from 2020-06-24 10-09-39](https://user-images.githubusercontent.com/29985169/85521057-65159f00-b60c-11ea-81c0-243073a9bb35.png)

**AFTER**
![Screenshot from 2020-06-24 10-09-06](https://user-images.githubusercontent.com/29985169/85521077-6b0b8000-b60c-11ea-8160-9321021cbc97.png)

