### PR TITLE
Fix space for delete modal

### DIFF
--- a/src/components/AppsCard/AppsCard.css
+++ b/src/components/AppsCard/AppsCard.css
@@ -191,3 +191,8 @@
   outline: 2px solid #ff0000;
   color: #ff0000;
 }
+
+.AppDeleteModel .ModalChildWrap {
+  min-width: 21rem;
+  max-width: 25rem;
+}


### PR DESCRIPTION
#### What does this PR do?

It adds space for the app delete modal for the buttons.

#### Screenshots
Before
![image](https://user-images.githubusercontent.com/32802973/86150314-eb971880-bb05-11ea-86dd-799bc7a00a59.png)

After
![image](https://user-images.githubusercontent.com/32802973/86150371-fe115200-bb05-11ea-8061-5a28ecb6ebd6.png)
