### PR TITLE
Give dropdown defined width

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -72,7 +72,7 @@ div.HeaderLinksWrap.LoggedIn .BelowHeader {
   background-color: #f9f9f9;
   position: absolute;
   top: 100%;
-  left: 0;
+  width: 10rem;
   right: 0;
 }
 


### PR DESCRIPTION
### What does this PR do?
Currently, the dropdown's width is responsive depending on the width of the parent. 
This gives the dropdown a defined width...

### Screenshots
**BEFORE - flexible width**
![Screenshot from 2020-07-01 14-37-59](https://user-images.githubusercontent.com/29985169/86244187-3f5e3c00-bbb0-11ea-8065-7b1cd9582098.png)
![Screenshot from 2020-07-01 14-34-21](https://user-images.githubusercontent.com/29985169/86244194-4127ff80-bbb0-11ea-8f8b-f9982533ca9c.png)

**AFTER - fixed width**
![Screenshot from 2020-07-01 15-02-46](https://user-images.githubusercontent.com/29985169/86244396-95cb7a80-bbb0-11ea-9975-46b7472f6596.png)

### Trello
https://trello.com/c/oeDJURlo
