### PR TITLE
Add click away for Modals

### DIFF
--- a/src/components/AppsCard/index.jsx
+++ b/src/components/AppsCard/index.jsx
@@ -105,7 +105,7 @@ const AppsCard = (props) => {
       {
         (openDeleteAlert && (
           <div className="AppDeleteModel">
-            <Modal showModal={openDeleteAlert}>
+            <Modal showModal={openDeleteAlert} onClickAway={hideDeleteAlert}>
               <div className="DeleteAppModel">
                 <div className="DeleteModalUpperSection">
                   <div className="DeleteDescription">

--- a/src/components/AppsPage/index.jsx
+++ b/src/components/AppsPage/index.jsx
@@ -360,7 +360,7 @@ class AppsPage extends React.Component {
 
         {/* Modal for creating a new app
         Its triggered by the value of state.openModal */}
-        <Modal showModal={openModal}>
+        <Modal showModal={openModal} onClickAway={this.hideForm}>
           <div className="ModalForm AddAppModal">
             <div className="ModalFormHeading">
               <h2>Deploy an app</h2>

--- a/src/components/ClusterPage/index.jsx
+++ b/src/components/ClusterPage/index.jsx
@@ -122,7 +122,7 @@ class ClusterPage extends React.Component {
 
         {/* Modal for creating a new project
         Its triggered by the value of state.openModal */}
-        <Modal showModal={openModal}>
+        <Modal showModal={openModal} onClickAway={this.hideForm}>
           <div className="ModalForm">
             <div className="ModalFormHeading">
               <h2>Add a cluster</h2>

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -23,10 +23,6 @@
   flex-direction: column;
 }
 
-.ModalContentSection {
-  height: 100%;
-}
-
 .ModalForm {
   display: grid;
   gap: 2rem;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,18 +1,30 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import './Modal.css';
 
-const Modal = ({ showModal, children }) => (
-  (showModal && (
-    <div className="ModalParentWrap">
-      <div className="ModalChildWrap">
-        <div className="ModalContent">
-          {children}
+const Modal = ({ showModal, children }) => {
+  const [show, setShow] = useState(showModal);
+
+  const toggleModal = () => {
+    setShow(showModal);
+  };
+
+  useEffect(() => (
+    toggleModal()
+  ), [showModal]); // eslint-disable-line
+
+  return (
+    (show && (
+      <div className="ModalParentWrap">
+        <div className="ModalChildWrap">
+          <div className="ModalContent">
+            {children}
+          </div>
         </div>
       </div>
-    </div>
-  ))
-);
+    ))
+  );
+};
 
 Modal.propTypes = {
   showModal: PropTypes.bool.isRequired,

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,22 +1,39 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import './Modal.css';
 
-const Modal = ({ showModal, children }) => {
+const Modal = ({ showModal, children, onClickAway }) => {
   const [show, setShow] = useState(showModal);
+  const modalRef = useRef(null);
 
-  const toggleModal = () => {
+  const toggleShowModal = () => {
     setShow(showModal);
   };
 
+  const handleClickOutsideModal = (event) => {
+    if (modalRef.current && !modalRef.current.contains(event.target)) {
+      onClickAway();
+    }
+  };
+
+  // componentWillMount & componentWillUnmount
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutsideModal);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutsideModal);
+    };
+  }, []);
+
+  // componentDidUpdate
   useEffect(() => (
-    toggleModal()
-  ), [showModal]); // eslint-disable-line
+    toggleShowModal()
+  ), [showModal]);
 
   return (
     (show && (
       <div className="ModalParentWrap">
-        <div className="ModalChildWrap">
+        <div ref={modalRef} className="ModalChildWrap">
           <div className="ModalContent">
             {children}
           </div>
@@ -28,7 +45,8 @@ const Modal = ({ showModal, children }) => {
 
 Modal.propTypes = {
   showModal: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  onClickAway: PropTypes.func.isRequired
 };
 
 export default Modal;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -6,7 +6,7 @@ const Modal = ({ showModal, children }) => (
   (showModal && (
     <div className="ModalParentWrap">
       <div className="ModalChildWrap">
-        <div className="ModalContentSection">
+        <div className="ModalContent">
           {children}
         </div>
       </div>

--- a/src/components/ProjectCard/index.js
+++ b/src/components/ProjectCard/index.js
@@ -254,7 +254,7 @@ class ProjectCard extends React.Component {
 
         {(openDeleteAlert && (
           <div className="ProjectDeleteModel">
-            <Modal showModal={openDeleteAlert}>
+            <Modal showModal={openDeleteAlert} onClickAway={this.hideDeleteAlert}>
               <div className="DeleteProjectModel">
                 <div className="DeleteProjectModalUpperSection">
                   <div className="DeleteDescription">
@@ -287,7 +287,7 @@ class ProjectCard extends React.Component {
 
         {(openUpdateModal && (
           <div className="ProjectDeleteModel">
-            <Modal showModal={openUpdateModal}>
+            <Modal showModal={openUpdateModal} onClickAway={this.hideUpdateForm}>
               <div className="ModalUpdateForm">
                 <div className="ModalFormHeading">
                   <div className="HeadingWithTooltip">

--- a/src/components/UserProjectsPage/index.jsx
+++ b/src/components/UserProjectsPage/index.jsx
@@ -206,7 +206,7 @@ class UserProjectsPage extends React.Component {
 
         {/* Modal for creating a new project
         Its triggered by the value of state.openModal */}
-        <Modal showModal={openModal}>
+        <Modal showModal={openModal} onClickAway={this.hideForm}>
           <div className="ModalForm">
             <div className="ModalFormHeading">
               <h2>Add a project</h2>


### PR DESCRIPTION
### What does this PR do?
1. Adds a listener to close Modal when a user clicks outside it.
2. Adds an `onClickAway` prop to all components that use the Modal. 

![Peek 2020-07-08 13-28](https://user-images.githubusercontent.com/29985169/86908381-1a714800-c11f-11ea-84fa-f9f4d866d292.gif)

### Trello ticket 
https://trello.com/c/dDtyfUJn