### PR TITLE
Fix routing and refreshing error 

### DIFF
--- a/src/components/AppMetricsPage/index.jsx
+++ b/src/components/AppMetricsPage/index.jsx
@@ -37,10 +37,7 @@ function shuffle(array) {
 }
 
 class AppMetricsPage extends React.Component {
-  // constructor(props) {
-  //   super(props);
-  //   this.state = {};
-  // }
+
   state = {
     appRelatedInfo: this.props.location.state
   };
@@ -55,11 +52,9 @@ class AppMetricsPage extends React.Component {
   }
 
   render() {
-    // const { appName, appUrl, liveAppStatus } = this.props.location;
     const { appName, appUrl, liveAppStatus } = this.state.appRelatedInfo;
     const { projectID, userID } = this.props.match.params;
-    // console.log(this.props.location.state);
-    console.log(this.state.appRelatedInfo);
+    
     return (
       <div className="Page">
         <div className="TopBarSection"><Header /></div>

--- a/src/components/AppMetricsPage/index.jsx
+++ b/src/components/AppMetricsPage/index.jsx
@@ -37,15 +37,29 @@ function shuffle(array) {
 }
 
 class AppMetricsPage extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
+  // constructor(props) {
+  //   super(props);
+  //   this.state = {};
+  // }
+  state = {
+    appRelatedInfo: this.props.location.state
+  };
+
+  static getDerivedStateFromProps(props, state) {
+    if (props.location.state !== state.appRelatedInfo) {
+      return {
+        appRelatedInfo: props.location.state
+      };
+    }
+    return null;
   }
 
   render() {
-    const { appName, appUrl, liveAppStatus } = this.props.location;
+    // const { appName, appUrl, liveAppStatus } = this.props.location;
+    const { appName, appUrl, liveAppStatus } = this.state.appRelatedInfo;
     const { projectID, userID } = this.props.match.params;
-
+    // console.log(this.props.location.state);
+    console.log(this.state.appRelatedInfo);
     return (
       <div className="Page">
         <div className="TopBarSection"><Header /></div>

--- a/src/components/AppsCard/index.jsx
+++ b/src/components/AppsCard/index.jsx
@@ -41,8 +41,8 @@ const AppsCard = (props) => {
   return (
     <Link
       to={{
-        pathname: `/users/${otherData.userID}/projects/${otherData.projectID}/apps/${appId}/metrics`, appName: name, liveAppStatus: appStatus, appUrl: url
-      }}
+        pathname: `/users/${otherData.userID}/projects/${otherData.projectID}/apps/${appId}/metrics`, state: { appName: name, liveAppStatus: appStatus, appUrl: url
+      }}}
       key={otherData.projectID}
       className="AppName"
     >

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -11,9 +11,9 @@ const SideBar = (props) => {
 
   return (
     <div className="SideBar">
-      <div className="SideBarTopSection">
+      <div className="">
         { projectID ? (
-          <div>
+          <div className="SideBarTopSection">
             <Link to={{ pathname: `/users/${userId}/projects/${projectID}/apps` }}>
               <img src={BackButton} alt="Back Button" />
               <span>&nbsp; &nbsp; &nbsp;</span>
@@ -21,7 +21,7 @@ const SideBar = (props) => {
             <Link to={{ pathname: `/users/${userId}/projects/${projectID}/apps` }} className="ProjectName">{ projectName }</Link>
           </div>
         ): (
-          <div>
+          <div className="SideBarTopSection">
             <Link to={{ pathname: `/users/${userId}/projects/` }}>
               <img src={BackButton} alt="Back Button" />
               <span>&nbsp; &nbsp; &nbsp;</span>

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -7,16 +7,28 @@ import { ReactComponent as Settings } from '../../assets/images/settings.svg';
 
 
 const SideBar = (props) => {
-  const { projectName, userId } = props;
+  const { projectName, userId, projectID } = props;
 
   return (
     <div className="SideBar">
       <div className="SideBarTopSection">
-        <Link to={{ pathname: `/users/${userId}/projects/` }}>
-          <img src={BackButton} alt="Back Button" />
-          <span>&nbsp; &nbsp; &nbsp;</span>
-        </Link>
-        <Link to={{ pathname: `/users/${userId}/projects/` }} className="ProjectName">{ projectName }</Link>
+        { projectID ? (
+          <div>
+            <Link to={{ pathname: `/users/${userId}/projects/${projectID}` }}>
+              <img src={BackButton} alt="Back Button" />
+              <span>&nbsp; &nbsp; &nbsp;</span>
+            </Link>
+            <Link to={{ pathname: `/users/${userId}/projects/` }} className="ProjectName">{ projectName }</Link>
+          </div>
+        ): (
+          <div>
+            <Link to={{ pathname: `/users/${userId}/projects/` }}>
+              <img src={BackButton} alt="Back Button" />
+              <span>&nbsp; &nbsp; &nbsp;</span>
+            </Link>
+            <Link to={{ pathname: `/users/${userId}/projects/` }} className="ProjectName">{ projectName }</Link>
+          </div>
+        )}
       </div>
 
       <div className="SideBarBottomSection">

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -11,7 +11,7 @@ const SideBar = (props) => {
 
   return (
     <div className="SideBar">
-      <div className="">
+      <div>
         { projectID ? (
           <div className="SideBarTopSection">
             <Link to={{ pathname: `/users/${userId}/projects/${projectID}/apps` }}>

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -14,11 +14,11 @@ const SideBar = (props) => {
       <div className="SideBarTopSection">
         { projectID ? (
           <div>
-            <Link to={{ pathname: `/users/${userId}/projects/${projectID}` }}>
+            <Link to={{ pathname: `/users/${userId}/projects/${projectID}/apps` }}>
               <img src={BackButton} alt="Back Button" />
               <span>&nbsp; &nbsp; &nbsp;</span>
             </Link>
-            <Link to={{ pathname: `/users/${userId}/projects/` }} className="ProjectName">{ projectName }</Link>
+            <Link to={{ pathname: `/users/${userId}/projects/${projectID}/apps` }} className="ProjectName">{ projectName }</Link>
           </div>
         ): (
           <div>


### PR DESCRIPTION
#### What does this PR do?

This PR fixes an error of routing on the app metrics page that previously redirected to the projects page instead of the apps page, plus the error of losing App metrics data like url, status and app name on refresh.

#### Screenshots
![Screenshot from 2020-08-09 23-42-44](https://user-images.githubusercontent.com/32802973/89741448-1f1c7980-da9a-11ea-88c6-256cadc7a6b0.png)
