### PR TITLE
disable storage link

### DIFF
--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -13,7 +13,7 @@ const SideBar = (props) => {
     pageRoute,
     cpuLink,
     memoryLink,
-    storageLink,
+    // storageLink,
     networkLink,
     allMetricsLink,
     appLogsLink
@@ -75,7 +75,7 @@ const SideBar = (props) => {
           <div>
             <Link to={cpuLink} className="SubBarListItem">CPU</Link>
             <Link to={memoryLink} className="SubBarListItem">Memory</Link>
-            <Link to={storageLink} className="SubBarListItem">Storage</Link>
+            {/* <Link to={storageLink} className="SubBarListItem">Storage</Link> */}
             <Link to={networkLink} className="SubBarListItem">Network</Link>
             {(isAppLogsPage || isAppPage) && (
               <Link to={appLogsLink} className="SubBarListItem">Logs</Link>


### PR DESCRIPTION
### what does this do?
disable the link for storage on the sidenav


![Screenshot from 2020-10-23 07-57-50](https://user-images.githubusercontent.com/29985169/96958461-364dfd80-1506-11eb-9e74-27d28d54fb53.png)
