### PR TITLE
Fix app menu routing

### DIFF
--- a/src/components/AppMetricsPage/index.jsx
+++ b/src/components/AppMetricsPage/index.jsx
@@ -90,7 +90,7 @@ class AppMetricsPage extends React.Component {
   }
 
   render() {
-    const { appName, appUrl, liveAppStatus } = this.state.appRelatedInfo;
+    // const { appName, appUrl, liveAppStatus } = this.state.appRelatedInfo;
     const { params } = this.props.match;
     const { projectID, userID, appID } = params;
     const { logs, retrieveingLogs } = this.props;
@@ -137,7 +137,7 @@ class AppMetricsPage extends React.Component {
                 </MetricsCard>
               </div>
               <div className="LogsSection">
-                <LogsFrame loading={retrieveingLogs} data={logs} title={`${appName} logs`} />
+                <LogsFrame loading={retrieveingLogs} data={logs} title={`${appInfo.name} logs`} />
               </div>
             </div>
           </div>

--- a/src/components/AppMetricsPage/index.jsx
+++ b/src/components/AppMetricsPage/index.jsx
@@ -20,10 +20,6 @@ class AppMetricsPage extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      appRelatedInfo: this.props.location.state
-    };
-
     this.getAppMemoryMetrics = this.getAppMemoryMetrics.bind(this);
     this.getAppCPUMetrics = this.getAppCPUMetrics.bind(this);
     this.getAppNetworkMetrics = this.getAppNetworkMetrics.bind(this);
@@ -59,15 +55,6 @@ class AppMetricsPage extends React.Component {
     
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (props.location.state !== state.appRelatedInfo) {
-      return {
-        appRelatedInfo: props.location.state
-      };
-    }
-    return null;
-  }
-
   getAppMemoryMetrics(){
     const { appID } = this.props.match.params;
     const { appMemoryMetrics } = this.props;
@@ -90,7 +77,6 @@ class AppMetricsPage extends React.Component {
   }
 
   render() {
-    // const { appName, appUrl, liveAppStatus } = this.state.appRelatedInfo;
     const { params } = this.props.match;
     const { projectID, userID, appID } = params;
     const { logs, retrieveingLogs } = this.props;

--- a/src/components/AppMetricsPage/index.jsx
+++ b/src/components/AppMetricsPage/index.jsx
@@ -30,6 +30,18 @@ class AppMetricsPage extends React.Component {
 
   }
 
+  getAppInfo(id) {
+    const { apps } = this.props;
+    const found = apps.apps.find((app) => app.id === id);
+    const info = {
+      name: found.name,
+      status: found.app_running_status,
+      url: found.url
+    };
+
+    return info;
+  }
+
   componentDidMount() {
     const {
       getAppLogs,
@@ -86,6 +98,7 @@ class AppMetricsPage extends React.Component {
     const formattedMemoryMetrics = this.getAppMemoryMetrics();
     const formattedCPUMetrics = this.getAppCPUMetrics();
     const formattedNetworkMetrics = this.getAppNetworkMetrics();
+    const appInfo = this.getAppInfo(appID);
     
     return (
       <div className="Page">
@@ -93,7 +106,7 @@ class AppMetricsPage extends React.Component {
         <div className="MainSection">
           <div className="SideBarSection">
             <SideBar
-              name={appName}
+              name={appInfo.name}
               params={params}
               pageRoute={this.props.location.pathname}
               allMetricsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/metrics/`}
@@ -107,8 +120,8 @@ class AppMetricsPage extends React.Component {
           <div className="MainContentSection">
             <div className="InformationBarSection">
               <InformationBar
-                header={appUrl}
-                status={liveAppStatus}
+                header={appInfo.url}
+                status={appInfo.status}
               />
             </div>
             <div className="ContentSection">
@@ -152,6 +165,8 @@ const mapStateToProps = (state) => {
     appNetworkMetrics, isFetchingAppNetwork, appNetworkMessage
   } = state.appNetworkReducer;
 
+  const { apps } = state.appsListReducer;
+
   return {
     isFetchingAppMemory,
     appMemoryMetrics,
@@ -164,7 +179,8 @@ const mapStateToProps = (state) => {
     cpuMessage,
     appNetworkMetrics,
     isFetchingAppNetwork,
-    appNetworkMessage
+    appNetworkMessage,
+    apps
   };
 
 };

--- a/src/components/AppsCard/index.jsx
+++ b/src/components/AppsCard/index.jsx
@@ -33,7 +33,7 @@ class AppsCard extends React.Component {
 
   render(){
     const {
-      name, appStatus, url, appId, otherData
+      name, appStatus, appId, otherData
     } = this.props;
     
     const formattedMemoryMetrics = this.getAppMemoryMetrics();
@@ -42,8 +42,8 @@ class AppsCard extends React.Component {
       <>
         <Link
           to={{
-            pathname: `/users/${otherData.userID}/projects/${otherData.projectID}/apps/${appId}/metrics`, state: { appName: name, liveAppStatus: appStatus, appUrl: url
-          }}}
+            pathname: `/users/${otherData.userID}/projects/${otherData.projectID}/apps/${appId}/metrics`
+          }}
           key={otherData.projectID}
           className="AppName"
         >


### PR DESCRIPTION
#### What does this PR do?

This PR fixes a bug that can be replicated when you navigate to the apps network/cpu/memory page and then try to navigate back to the app's metrics page, currently on staging and Production, it throws an error and shows an empty page. This PR fixes that problem.