### PR TITLE
Rewrite database route in app navigation sidebar

### DIFF
--- a/src/components/AppCpuPage/index.jsx
+++ b/src/components/AppCpuPage/index.jsx
@@ -124,7 +124,7 @@ class AppCpuPage extends React.Component {
               allMetricsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/metrics/`}
               cpuLink={`/users/${userID}/projects/${projectID}/apps/${appID}/cpu`}
               memoryLink={`/users/${userID}/projects/${projectID}/apps/${appID}/memory/`}
-              databaseLink={`/users/${userID}/projects/${projectID}/apps/${appID}/databases`}
+              databaseLink={`/users/${userID}/projects/${projectID}/databases`}
               networkLink={`/users/${userID}/projects/${projectID}/apps/${appID}/network/`}
               appLogsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/logs/`}
             />

--- a/src/components/AppLogsPage/index.jsx
+++ b/src/components/AppLogsPage/index.jsx
@@ -47,7 +47,7 @@ class AppLogsPage extends React.Component {
               allMetricsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/metrics/`}
               cpuLink={`/users/${userID}/projects/${projectID}/apps/${appID}/cpu/`}
               memoryLink={`/users/${userID}/projects/${projectID}/apps/${appID}/memory/`}
-              databaseLink={`/users/${userID}/projects/${projectID}/apps/${appID}/databases`}
+              databaseLink={`/users/${userID}/projects/${projectID}/databases`}
               networkLink={`/users/${userID}/projects/${projectID}/apps/${appID}/network/`}
               appLogsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/logs/`}
             />

--- a/src/components/AppMemoryPage/index.jsx
+++ b/src/components/AppMemoryPage/index.jsx
@@ -128,7 +128,7 @@ class AppMemoryPage extends React.Component {
               allMetricsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/metrics/`}
               cpuLink={`/users/${userID}/projects/${projectID}/apps/${appID}/cpu/`}
               memoryLink={`/users/${userID}/projects/${projectID}/apps/${appID}/memory/`}
-              databaseLink={`/users/${userID}/projects/${projectID}/apps/${appID}/databases`}
+              databaseLink={`/users/${userID}/projects/${projectID}/databases`}
               networkLink={`/users/${userID}/projects/${projectID}/apps/${appID}/network/`}
               appLogsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/logs/`}
             />

--- a/src/components/AppMetricsPage/index.jsx
+++ b/src/components/AppMetricsPage/index.jsx
@@ -97,7 +97,7 @@ class AppMetricsPage extends React.Component {
               allMetricsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/metrics/`}
               cpuLink={`/users/${userID}/projects/${projectID}/apps/${appID}/cpu/`}
               memoryLink={`/users/${userID}/projects/${projectID}/apps/${appID}/memory/`}
-              databaseLink={`/users/${userID}/projects/${projectID}/apps/${appID}/databases`}
+              databaseLink={`/users/${userID}/projects/${projectID}/databases`}
               networkLink={`/users/${userID}/projects/${projectID}/apps/${appID}/network/`}
               appLogsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/logs/`}
             />

--- a/src/components/AppNetworkPage/index.jsx
+++ b/src/components/AppNetworkPage/index.jsx
@@ -140,7 +140,7 @@ class AppNetworkPage extends React.Component {
               allMetricsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/metrics/`}
               cpuLink={`/users/${userID}/projects/${projectID}/apps/${appID}/cpu/`}
               memoryLink={`/users/${userID}/projects/${projectID}/apps/${appID}/memory/`}
-              databaseLink={`/users/${userID}/projects/${projectID}/apps/${appID}/databases`}
+              databaseLink={`/users/${userID}/projects/${projectID}/databases`}
               networkLink={`/users/${userID}/projects/${projectID}/apps/${appID}/network/`}
               appLogsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/logs/`}
             />

--- a/src/components/AppSettingsPage/index.jsx
+++ b/src/components/AppSettingsPage/index.jsx
@@ -92,7 +92,7 @@ class AppSettingsPage extends React.Component {
               allMetricsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/metrics/`}
               cpuLink={`/users/${userID}/projects/${projectID}/apps/${appID}/cpu/`}
               memoryLink={`/users/${userID}/projects/${projectID}/apps/${appID}/memory/`}
-              databaseLink={`/users/${userID}/projects/${projectID}/apps/${appID}/databases`}
+              databaseLink={`/users/${userID}/projects/${projectID}/databases`}
               networkLink={`/users/${userID}/projects/${projectID}/apps/${appID}/network/`}
               appLogsLink={`/users/${userID}/projects/${projectID}/apps/${appID}/logs/`}
             />


### PR DESCRIPTION
#### What does this PR do?

It rewrites the databases route in all the app-related pages navigation bar as it was rerouting to a 404.

#### Ticket

 https://trello.com/c/ARZ6emt2

#### How to test this?

1. On staging in a particular app navigation re-routing to databases causes a 404.
2. Pull this branch and retry step 1.