### PR TITLE
Fix page scaling on scroll

### DIFF
--- a/src/components/SideBar/SideBar.css
+++ b/src/components/SideBar/SideBar.css
@@ -1,5 +1,4 @@
 .SideBar {
-  /* width: 100%; */
   height: inherit;
   background: #06222f;
   mix-blend-mode: normal;

--- a/src/components/SideBar/SideBar.css
+++ b/src/components/SideBar/SideBar.css
@@ -1,12 +1,13 @@
 .SideBar {
-  width: 100%;
-  height: 100%;
+  /* width: 100%; */
+  height: inherit;
   background: #06222f;
   mix-blend-mode: normal;
   margin-left: 0px;
   overflow-x: hidden;
   display: flex;
   flex-direction: column;
+  position: fixed;
 }
 
 .SideBarTopSection {

--- a/src/index.css
+++ b/src/index.css
@@ -28,9 +28,12 @@ body {
 }
 
 div#root {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-flow: column;
+}
+div#root::-webkit-scrollbar {
+  display: none;
 }
 
 textarea,
@@ -254,6 +257,7 @@ tr.TableLoading td {
 .SideBarSection {
   overflow: hidden;
   overflow-y: scroll;
+  height: calc(100vh - 5rem);
 }
 
 .SideBarSection::-webkit-scrollbar {


### PR DESCRIPTION
#### What does this PR do?
This fixes an issue from pages that have a sidebar with the scrollbar scaling as long as the page, so this fixes the issue by having only the content section scrollable

#### Ticket
https://trello.com/c/5mIfiKGg

#### Screenshots

**Before**
![Screenshot from 2021-06-30 12-30-52](https://user-images.githubusercontent.com/32802973/123938495-d7e3f380-d99f-11eb-9c08-d8b1c6a85995.png)

![Screenshot from 2021-06-30 12-31-00](https://user-images.githubusercontent.com/32802973/123938563-e4684c00-d99f-11eb-8c85-7b1ec2c85da7.png)

**After**

![Screenshot from 2021-06-30 12-17-30](https://user-images.githubusercontent.com/32802973/123938743-0cf04600-d9a0-11eb-94bc-e75d61422570.png)
![Screenshot from 2021-06-30 12-17-41](https://user-images.githubusercontent.com/32802973/123938760-111c6380-d9a0-11eb-95fe-7eece2e194e5.png)

