### PR TITLE
Change location to Data center location

### DIFF
--- a/src/components/UserProjectsPage/index.jsx
+++ b/src/components/UserProjectsPage/index.jsx
@@ -214,7 +214,7 @@ class UserProjectsPage extends React.Component {
             <div className="ModalFormInputs">
               <Select
                 required
-                placeholder="Choose a location"
+                placeholder="Choose Datacenter location"
                 options={clusters}
                 onChange={this.handleSelectChange}
               />


### PR DESCRIPTION
#### What does this PR do?
It replaces project form location to data center location, this arose as UX feedback from users as they could understand what location meant at Project Creation with the first instinct being that they were being asked for their location.

#### Ticket
https://trello.com/c/mWNF8E4E

#### Screenshots
                                                                 **from**
![Screenshot from 2021-07-02 04-36-02](https://user-images.githubusercontent.com/32802973/124210935-fc9daf80-daf4-11eb-8673-ab6834cd8d60.png)

                                                                 **To**
![Screenshot from 2021-07-02 04-38-01](https://user-images.githubusercontent.com/32802973/124210941-fe677300-daf4-11eb-9739-ba61550c83fd.png)
