### PR TITLE
Center the database message 

### DIFF
--- a/src/components/DatabaseList/DatabaseList.module.css
+++ b/src/components/DatabaseList/DatabaseList.module.css
@@ -92,7 +92,7 @@
   flex-grow: 1;
   display: flex;
   font-size: 16px;
-  padding-top: 15%;
+  height: 50vh;
   text-align: center;
   justify-content: center;
   align-items: center;

--- a/src/components/DatabaseList/DatabaseList.module.css
+++ b/src/components/DatabaseList/DatabaseList.module.css
@@ -92,6 +92,7 @@
   flex-grow: 1;
   display: flex;
   font-size: 16px;
+  padding-top: 15%;
   text-align: center;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
# Description

Putting the the message provided when a user has not created any database yet in the center of the page 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Trello Ticket ID

https://trello.com/c/DSPo0JLC

## How Can This Been Tested?

On the develop branch, login and click on the database in the sidebar, if you have no databases it displays a message to indicate that but the message is at the top on the page, when you switch to this branch you should test if the text is at the center of the screen.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings



# Screenshots

![alignment before](https://user-images.githubusercontent.com/69305400/124819212-d32fba00-df20-11eb-8185-4399d73b3914.png)
![center align](https://user-images.githubusercontent.com/69305400/124819259-e17dd600-df20-11eb-897c-f587e0fef84f.png)



