### PR TITLE
Add trimming on update project form and use css modules

### DIFF
--- a/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
+++ b/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
@@ -99,3 +99,51 @@
 .ErrorOnWhite {
   width: 25rem;
 }
+.SideBarSection {
+  overflow: hidden;
+  overflow-y: scroll;
+  height: calc(100vh - 5rem);
+}
+
+.SideBarSection::-webkit-scrollbar {
+  display: none;
+  min-width: fit-content;
+}
+
+.Page {
+  margin: 0;
+  background: #f1f1f1;
+  max-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
+}
+
+.MainSection {
+  /* divided into two columns */
+  background-color: #f1f1f1;
+  display: grid;
+  grid-template-columns: 1.3fr 6fr;
+  overflow: hidden;
+}
+
+.MainContentSection {
+  /* divided into two rows */
+  display: grid;
+  grid-template-rows: 80px 4fr;
+  overflow: hidden;
+}
+.TopBarSection {
+  background-color: black;
+}
+
+.SideBarSection {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.ContentSection {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+}

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -79,7 +79,7 @@ class ProjectSettingsPage extends React.Component {
   }
 
   handleSubmit() {
-    var { projectName, projectDescription } = this.state;
+    const { projectName, projectDescription } = this.state;
     const {
       updateProject,
       name,
@@ -88,56 +88,54 @@ class ProjectSettingsPage extends React.Component {
         params: { projectID },
       },
     } = this.props;
-    projectName = projectName.trim();
-    projectDescription = projectDescription.trim();
 
-    if (projectName !== name || projectDescription !== description) {
-      if (!projectName || !projectDescription) {
+    if (projectName.trim() !== name || projectDescription.trim() !== description) {
+      if (!projectName.trim() || !projectDescription.trim()) {
         this.setState({
           error: "please provide either a new name or description",
         });
       } else {
-        if (projectName !== name && projectDescription === description) {
-          if (!this.validateProjectName(projectName)) {
+        if (projectName.trim() !== name && projectDescription.trim() === description) {
+          if (!this.validateProjectName(projectName.trim())) {
             this.setState({
               error: "name should start with a letter",
             });
           } else if (
-            this.validateProjectName(projectName) === "false_convention"
+            this.validateProjectName(projectName.trim()) === "false_convention"
           ) {
             this.setState({
               error: "name may only contain letters and a hypen -",
             });
-          } else if (projectName.length > 22) {
+          } else if (projectName.trim().length > 22) {
             this.setState({
               error: "project name cannot exceed 22 characters",
             });
           } else {
-            const newProject = { name: projectName };
+            const newProject = { name: projectName.trim() };
             updateProject(projectID, newProject);
           }
         }
 
-        if (projectName === name && projectDescription !== description) {
-          const newProject = { description: projectDescription };
+        if (projectName.trim() === name && projectDescription.trim() !== description) {
+          const newProject = { description: projectDescription.trim() };
           updateProject(projectID, newProject);
         }
 
-        if (projectName !== name && projectDescription !== description) {
-          if (!this.validateProjectName(projectName)) {
+        if (projectName.trim() !== name && projectDescription.trim() !== description) {
+          if (!this.validateProjectName(projectName.trim())) {
             this.setState({
               error: "name should start with a letter",
             });
           } else if (
-            this.validateProjectName(projectName) === "false_convention"
+            this.validateProjectName(projectName.trim()) === "false_convention"
           ) {
             this.setState({
               error: "name may only contain letters and a hypen -",
             });
           } else {
             const newProject = {
-              name: projectName,
-              description: projectDescription,
+              name: projectName.trim(),
+              description: projectDescription.trim(),
             };
             updateProject(projectID, newProject);
           }

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -88,8 +88,9 @@ class ProjectSettingsPage extends React.Component {
         params: { projectID },
       },
     } = this.props;
-    const trimprojectName = projectName.trim();
-    const trimprojectDescription = projectDescription.trim()
+    const trimmed = (input) => input.trim();
+    const trimprojectName = trimmed(projectName);
+    const trimprojectDescription = trimmed(projectDescription);
 
     if (trimprojectName !== name || trimprojectDescription !== description) {
       if (!trimprojectName || !trimprojectDescription) {

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -88,54 +88,56 @@ class ProjectSettingsPage extends React.Component {
         params: { projectID },
       },
     } = this.props;
+    const trimprojectName = projectName.trim();
+    const trimprojectDescription = projectDescription.trim()
 
-    if (projectName.trim() !== name || projectDescription.trim() !== description) {
-      if (!projectName.trim() || !projectDescription.trim()) {
+    if (trimprojectName !== name || trimprojectDescription !== description) {
+      if (!trimprojectName || !trimprojectDescription) {
         this.setState({
           error: "please provide either a new name or description",
         });
       } else {
-        if (projectName.trim() !== name && projectDescription.trim() === description) {
-          if (!this.validateProjectName(projectName.trim())) {
+        if (trimprojectName !== name && trimprojectDescription === description) {
+          if (!this.validateProjectName(trimprojectName)) {
             this.setState({
               error: "name should start with a letter",
             });
           } else if (
-            this.validateProjectName(projectName.trim()) === "false_convention"
+            this.validateProjectName(trimprojectName) === "false_convention"
           ) {
             this.setState({
               error: "name may only contain letters and a hypen -",
             });
-          } else if (projectName.trim().length > 22) {
+          } else if (trimprojectName.length > 22) {
             this.setState({
               error: "project name cannot exceed 22 characters",
             });
           } else {
-            const newProject = { name: projectName.trim() };
+            const newProject = { name: trimprojectName };
             updateProject(projectID, newProject);
           }
         }
 
-        if (projectName.trim() === name && projectDescription.trim() !== description) {
-          const newProject = { description: projectDescription.trim() };
+        if (trimprojectName === name && trimprojectDescription !== description) {
+          const newProject = { description: trimprojectDescription };
           updateProject(projectID, newProject);
         }
 
-        if (projectName.trim() !== name && projectDescription.trim() !== description) {
-          if (!this.validateProjectName(projectName.trim())) {
+        if (trimprojectName !== name && trimprojectDescription !== description) {
+          if (!this.validateProjectName(trimprojectName)) {
             this.setState({
               error: "name should start with a letter",
             });
           } else if (
-            this.validateProjectName(projectName.trim()) === "false_convention"
+            this.validateProjectName(trimprojectName) === "false_convention"
           ) {
             this.setState({
               error: "name may only contain letters and a hypen -",
             });
           } else {
             const newProject = {
-              name: projectName.trim(),
-              description: projectDescription.trim(),
+              name: trimprojectName,
+              description: trimprojectDescription,
             };
             updateProject(projectID, newProject);
           }

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -18,7 +18,7 @@ import TextArea from "../TextArea";
 import Feedback from "../Feedback";
 import DeleteWarning from "../DeleteWarning";
 import BlackInputText from "../BlackInputText";
-import "./ProjectSettingsPage.css";
+import styles from "./ProjectSettingsPage.module.css";
 
 class ProjectSettingsPage extends React.Component {
   constructor(props) {
@@ -79,7 +79,7 @@ class ProjectSettingsPage extends React.Component {
   }
 
   handleSubmit() {
-    const { projectName, projectDescription } = this.state;
+    var { projectName, projectDescription } = this.state;
     const {
       updateProject,
       name,
@@ -88,6 +88,8 @@ class ProjectSettingsPage extends React.Component {
         params: { projectID },
       },
     } = this.props;
+    projectName = projectName.trim();
+    projectDescription = projectDescription.trim();
 
     if (projectName !== name || projectDescription !== description) {
       if (!projectName || !projectDescription) {
@@ -186,13 +188,13 @@ class ProjectSettingsPage extends React.Component {
     const { projectID, userID } = params;
 
     return (
-      <div className="Page">
+      <div className={styles.Page} >
         {isUpdated || isDeleted ? this.renderRedirect() : null}
-        <div className="TopBarSection">
+        <div className={styles.TopBarSection}>
           <Header />
         </div>
-        <div className="MainSection">
-          <div className="SideBarSection">
+        <div className={styles.MainSection}>
+          <div className={styles.SideBarSection}>
             <SideBar
               name={name}
               params={params}
@@ -205,11 +207,11 @@ class ProjectSettingsPage extends React.Component {
               networkLink={`/users/${userID}/projects/${projectID}/network/`}
             />
           </div>
-          <div className="MainContentSection">
-            <div className="InformationBarSection">
+          <div className={styles.MainContentSection}>
+            <div className={styles.InformationBarSection}>
               <InformationBar header="Settings" />
             </div>
-            <div className="ContentSection">
+            <div className={styles.ContentSection}>
               <div>
                 <div
                   onSubmit={(e) => {
@@ -217,7 +219,7 @@ class ProjectSettingsPage extends React.Component {
                     e.preventDefault();
                   }}
                 >
-                  <div className="UpdateForm">
+                  <div className={styles.UpdateForm}>
                     <BlackInputText
                       placeholder="Project Name"
                       name="projectName"
@@ -248,22 +250,22 @@ class ProjectSettingsPage extends React.Component {
                   </div>
                 </div>
               </div>
-              <div className="DeleteButtonDiv">
+              <div className={styles.DeleteButtonDiv}>
                 <PrimaryButton
                   label="Delete Project"
-                  className="DeleteBtn"
+                  className={styles.DeleteBtn}
                   onClick={this.showDeleteAlert}
                 />
               </div>
               {openDeleteAlert && (
-                <div className="ProjectDeleteModel">
+                <div className={styles.ProjectDeleteModel}>
                   <Modal
                     showModal={openDeleteAlert}
                     onClickAway={this.hideDeleteAlert}
                   >
-                    <div className="DeleteProjectModel">
-                      <div className="DeleteProjectModalUpperSection">
-                        <div className="DeleteDescription">
+                    <div className={styles.DeleteProjectModel}>
+                      <div className={styles.DeleteProjectModalUpperSection}>
+                        <div className={styles.DeleteDescription}>
                           Are you sure you want to delete&nbsp;
                           <span>{projectName}</span>
                           &nbsp; ?
@@ -271,16 +273,16 @@ class ProjectSettingsPage extends React.Component {
                         </div>
                       </div>
 
-                      <div className="DeleteProjectModalLowerSection">
-                        <div className="DeleteProjectModelButtons">
+                      <div className={styles.DeleteProjectModalLowerSection}>
+                        <div className={styles.DeleteProjectModelButtons}>
                           <PrimaryButton
                             label="cancel"
-                            className="CancelBtn"
+                            className={styles.CancelBtn}
                             onClick={this.hideDeleteAlert}
                           />
                           <PrimaryButton
                             label={isDeleting ? <Spinner /> : "Delete"}
-                            className="DeleteBtn"
+                            className={styles.DeleteBtn}
                             onClick={(e) =>
                               this.handleDeleteProject(e, params.projectID)
                             }


### PR DESCRIPTION
# Description

Adds trimming at the end of text entered  when its being submitted to prevent prompting an error when there is text at the end and at the same time prevent submitting text with white space at the end. Also integration of css modules

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID
https://trello.com/c/cGVuNiDD

## How Can This Been Tested?

Switch to the branch and add input with white spaces at the end to try and up date, after update you can go bade on the update page and verify if it wasn't added added with white space at the end. Also check the design to be sure it matches the original css since a switch to css modules has been made

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Screenshots
Before
![no  trimming](https://user-images.githubusercontent.com/69305400/125775226-5e9201da-d22a-4f4f-9d78-81387d2201aa.png)
After
![Hnet-image](https://user-images.githubusercontent.com/69305400/125775355-24a9b0b2-bf6b-4322-a9a4-d8458c144c37.gif)
