### PR TITLE
Redesign project delete confirmation modal

### DIFF
--- a/src/components/DeleteWarning/DeleteWarning.css
+++ b/src/components/DeleteWarning/DeleteWarning.css
@@ -2,3 +2,9 @@
   color: #f00;
   text-align: center;
 }
+.DeleteWarning.Left{
+  text-align: left;
+}
+.DeleteWarning.Right{
+  text-align: right;
+}

--- a/src/components/DeleteWarning/index.js
+++ b/src/components/DeleteWarning/index.js
@@ -1,10 +1,14 @@
 import React from "react";
+
 import "./DeleteWarning.css";
 
-const DeleteWarning = () => (
-  <div className="DeleteWarning">
-    <small>Note that this action is irreversible.</small>
-  </div>
-);
+const DeleteWarning = (props) => {
+  const { textAlignment } = props;
+  return (
+    <div className={textAlignment ? `DeleteWarning ${textAlignment}` : "DeleteWarning"}>
+      <small>Note that this action is irreversible.</small>
+    </div>
+  );
+};
 
 export default DeleteWarning;

--- a/src/components/PrimaryButton/index.js
+++ b/src/components/PrimaryButton/index.js
@@ -2,9 +2,10 @@ import React from "react";
 import "./PrimaryButton.css";
 
 const PrimaryButton = (props) => {
-  const { label, className } = props;
+  const { label, className,disable } = props;
   return (
     <button
+      disabled={disable}
       className={`Primary-Btn uppercase ${className}`}
       onClick={props.onClick}
     >

--- a/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
+++ b/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
@@ -28,11 +28,13 @@
 
 .DeleteDescription {
   cursor: default;
+  font-weight: 700;
 }
 
 .DeleteDescription span {
   padding: 0.2rem 0.4rem;
   margin: 0;
+  font-weight: bold;
   font-size: 90%;
   background-color: rgba(27, 31, 35, 0.1);
   border-radius: 3px;
@@ -146,4 +148,28 @@
   flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
+}
+.InnerModalDescription {
+  display: grid;
+  gap: 0.5rem;
+}
+.DeleteWarning {
+  color: #f00;
+}
+.InactiveDelete {
+  background-color: #fff;
+  outline: #ff9595;
+  color: #ff9595;
+}
+.InactiveDelete:hover {
+  background-color: #fff;
+  outline: #ff9595;
+  color: #ff9595;
+}
+.WarningContainer {
+  display: grid;
+  gap: 1rem;
+}
+.DeleteSubDescription {
+  font-weight: 500;
 }

--- a/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
+++ b/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
@@ -168,7 +168,8 @@
 }
 .WarningContainer {
   display: grid;
-  gap: 1rem;
+  gap: 0.6rem;
+  width: 25rem;
 }
 .DeleteSubDescription {
   font-weight: 500;

--- a/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
+++ b/src/components/ProjectSettingsPage/ProjectSettingsPage.module.css
@@ -168,7 +168,7 @@
 }
 .WarningContainer {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.8rem;
   width: 25rem;
 }
 .DeleteSubDescription {

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -16,7 +16,7 @@ import Modal from "../Modal";
 import SideBar from "../SideBar";
 import TextArea from "../TextArea";
 import Feedback from "../Feedback";
-//import DeleteWarning from "../DeleteWarning";
+import DeleteWarning from "../DeleteWarning";
 import BlackInputText from "../BlackInputText";
 import styles from "./ProjectSettingsPage.module.css";
 
@@ -33,7 +33,7 @@ class ProjectSettingsPage extends React.Component {
       projectName: name ? name : "",
       projectDescription: description ? description : "",
       error: "",
-      Confirmprojectname:"",
+      Confirmprojectname: "",
       disableDelete: true,
     };
 
@@ -65,7 +65,7 @@ class ProjectSettingsPage extends React.Component {
   }
 
   handleChange(e) {
-    const { error,projectName,openDeleteAlert } = this.state;
+    const { error, projectName, openDeleteAlert } = this.state;
     const { errorMessage, clearUpdateProjectState } = this.props;
     this.setState({
       [e.target.name]: e.target.value,
@@ -78,11 +78,11 @@ class ProjectSettingsPage extends React.Component {
         error: "",
       });
     }
-    if( e.target.value===projectName && openDeleteAlert){
+    if (e.target.value === projectName && openDeleteAlert) {
       this.setState({
         disableDelete: false,
       });
-    } else if(e.target.value !== projectName && openDeleteAlert){
+    } else if (e.target.value !== projectName && openDeleteAlert) {
       this.setState({
         disableDelete: true,
       });
@@ -109,7 +109,10 @@ class ProjectSettingsPage extends React.Component {
           error: "please provide either a new name or description",
         });
       } else {
-        if (trimprojectName !== name && trimprojectDescription === description) {
+        if (
+          trimprojectName !== name &&
+          trimprojectDescription === description
+        ) {
           if (!this.validateProjectName(trimprojectName)) {
             this.setState({
               error: "name should start with a letter",
@@ -130,12 +133,18 @@ class ProjectSettingsPage extends React.Component {
           }
         }
 
-        if (trimprojectName === name && trimprojectDescription !== description) {
+        if (
+          trimprojectName === name &&
+          trimprojectDescription !== description
+        ) {
           const newProject = { description: trimprojectDescription };
           updateProject(projectID, newProject);
         }
 
-        if (trimprojectName !== name && trimprojectDescription !== description) {
+        if (
+          trimprojectName !== name &&
+          trimprojectDescription !== description
+        ) {
           if (!this.validateProjectName(trimprojectName)) {
             this.setState({
               error: "name should start with a letter",
@@ -195,12 +204,19 @@ class ProjectSettingsPage extends React.Component {
     const projectInfo = JSON.parse(localStorage.getItem("project"));
     const name = projectInfo.name;
     const description = projectInfo.description;
-    const { openDeleteAlert, projectName, projectDescription, error,Confirmprojectname,disableDelete } = this.state;
+    const {
+      openDeleteAlert,
+      projectName,
+      projectDescription,
+      error,
+      Confirmprojectname,
+      disableDelete,
+    } = this.state;
 
     const { projectID, userID } = params;
 
     return (
-      <div className={styles.Page} >
+      <div className={styles.Page}>
         {isUpdated || isDeleted ? this.renderRedirect() : null}
         <div className={styles.TopBarSection}>
           <Header />
@@ -251,7 +267,11 @@ class ProjectSettingsPage extends React.Component {
                     {(errorMessage || error) && (
                       <Feedback
                         type="error"
-                        message={errorMessage ? "you cant update only the description" : error}
+                        message={
+                          errorMessage
+                            ? "you cant update only the description"
+                            : error
+                        }
                       />
                     )}
 
@@ -277,25 +297,21 @@ class ProjectSettingsPage extends React.Component {
                   >
                     <div className={styles.DeleteProjectModel}>
                       <div className={styles.DeleteProjectModalUpperSection}>
-                      <div className={styles.WarningContainer}>
-                        <div className={styles.DeleteDescription}>
-                          Are you sure you want to delete&nbsp;
-                          <span>{projectName}</span>
-                          &nbsp; ?   
-                        </div>
-                        <div className={styles.DeleteSubDescription}>
-                          This will permanantly delete the project and all resourses it contains
-                          </div> 
-                          <div>
-                           <div className={styles.DeleteWarning}>
-                             Please type the name of your project to confirm deletion
-                            </div>
-                            <div className={styles.DeleteWarning}>
-                            <small>Note that this action is irreversible.</small>      
-                            </div>
+                        <div className={styles.WarningContainer}>
+                          <div className={styles.DeleteDescription}>
+                            Are you sure you want to delete&nbsp;
+                            <span>{projectName}</span>
+                            &nbsp;?
                           </div>
-                      </div>
-                        <div className={styles.InnerModalDescription}>
+                          <div className={styles.DeleteSubDescription}>
+                            This will permanantly delete the project and all
+                            resourses it contains.
+                          </div>
+                          <div>
+                            Please confirm by typing <b className={styles.DeleteWarning}>{projectName}</b> below.
+                          </div>
+                          <DeleteWarning textAlignment="Left"/>
+                          <div className={styles.InnerModalDescription}>
                             <BlackInputText
                               required
                               placeholder={projectName}
@@ -304,8 +320,9 @@ class ProjectSettingsPage extends React.Component {
                               onChange={(e) => {
                                 this.handleChange(e);
                               }}
-                            />                     
-                        </div>                       
+                            />
+                          </div>
+                        </div>
                       </div>
                       <div className={styles.DeleteProjectModalLowerSection}>
                         <div className={styles.DeleteProjectModelButtons}>
@@ -316,8 +333,12 @@ class ProjectSettingsPage extends React.Component {
                           />
                           <PrimaryButton
                             label={isDeleting ? <Spinner /> : "Delete"}
-                            className={disableDelete ? styles.InactiveDelete:styles.DeleteBtn  }
-                            disable ={disableDelete}
+                            className={
+                              disableDelete
+                                ? styles.InactiveDelete
+                                : styles.DeleteBtn
+                            }
+                            disable={disableDelete}
                             onClick={(e) =>
                               this.handleDeleteProject(e, params.projectID)
                             }

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -16,7 +16,7 @@ import Modal from "../Modal";
 import SideBar from "../SideBar";
 import TextArea from "../TextArea";
 import Feedback from "../Feedback";
-import DeleteWarning from "../DeleteWarning";
+//import DeleteWarning from "../DeleteWarning";
 import BlackInputText from "../BlackInputText";
 import styles from "./ProjectSettingsPage.module.css";
 
@@ -33,6 +33,8 @@ class ProjectSettingsPage extends React.Component {
       projectName: name ? name : "",
       projectDescription: description ? description : "",
       error: "",
+      Confirmprojectname:"",
+      disableDelete: true,
     };
 
     this.handleDeleteProject = this.handleDeleteProject.bind(this);
@@ -63,7 +65,7 @@ class ProjectSettingsPage extends React.Component {
   }
 
   handleChange(e) {
-    const { error } = this.state;
+    const { error,projectName,openDeleteAlert } = this.state;
     const { errorMessage, clearUpdateProjectState } = this.props;
     this.setState({
       [e.target.name]: e.target.value,
@@ -74,6 +76,15 @@ class ProjectSettingsPage extends React.Component {
     if (error) {
       this.setState({
         error: "",
+      });
+    }
+    if( e.target.value===projectName && openDeleteAlert){
+      this.setState({
+        disableDelete: false,
+      });
+    } else if(e.target.value !== projectName && openDeleteAlert){
+      this.setState({
+        disableDelete: true,
       });
     }
   }
@@ -184,7 +195,7 @@ class ProjectSettingsPage extends React.Component {
     const projectInfo = JSON.parse(localStorage.getItem("project"));
     const name = projectInfo.name;
     const description = projectInfo.description;
-    const { openDeleteAlert, projectName, projectDescription, error } = this.state;
+    const { openDeleteAlert, projectName, projectDescription, error,Confirmprojectname,disableDelete } = this.state;
 
     const { projectID, userID } = params;
 
@@ -266,14 +277,36 @@ class ProjectSettingsPage extends React.Component {
                   >
                     <div className={styles.DeleteProjectModel}>
                       <div className={styles.DeleteProjectModalUpperSection}>
+                      <div className={styles.WarningContainer}>
                         <div className={styles.DeleteDescription}>
                           Are you sure you want to delete&nbsp;
                           <span>{projectName}</span>
-                          &nbsp; ?
-                          <DeleteWarning />
+                          &nbsp; ?   
                         </div>
+                        <div className={styles.DeleteSubDescription}>
+                          This will permanantly delete the project and all resourses it contains
+                          </div> 
+                          <div>
+                           <div className={styles.DeleteWarning}>
+                             Please type the name of your project to confirm deletion
+                            </div>
+                            <div className={styles.DeleteWarning}>
+                            <small>Note that this action is irreversible.</small>      
+                            </div>
+                          </div>
                       </div>
-
+                        <div className={styles.InnerModalDescription}>
+                            <BlackInputText
+                              required
+                              placeholder={projectName}
+                              name="Confirmprojectname"
+                              value={Confirmprojectname}
+                              onChange={(e) => {
+                                this.handleChange(e);
+                              }}
+                            />                     
+                        </div>                       
+                      </div>
                       <div className={styles.DeleteProjectModalLowerSection}>
                         <div className={styles.DeleteProjectModelButtons}>
                           <PrimaryButton
@@ -283,7 +316,8 @@ class ProjectSettingsPage extends React.Component {
                           />
                           <PrimaryButton
                             label={isDeleting ? <Spinner /> : "Delete"}
-                            className={styles.DeleteBtn}
+                            className={disableDelete ? styles.InactiveDelete:styles.DeleteBtn  }
+                            disable ={disableDelete}
                             onClick={(e) =>
                               this.handleDeleteProject(e, params.projectID)
                             }

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -314,7 +314,6 @@ class ProjectSettingsPage extends React.Component {
                           <div>
                             Please confirm by typing <b className={styles.DeleteWarning}>{projectName}</b> below.
                           </div>
-                          <DeleteWarning textAlignment="Left"/>
                           <div className={styles.InnerModalDescription}>
                             <BlackInputText
                               required
@@ -325,6 +324,7 @@ class ProjectSettingsPage extends React.Component {
                                 this.handleChange(e);
                               }}
                             />
+                            <DeleteWarning textAlignment="Left"/>
                           </div>
                         </div>
                       </div>
@@ -332,7 +332,7 @@ class ProjectSettingsPage extends React.Component {
                         <div className={styles.DeleteProjectModelButtons}>
                           <PrimaryButton
                             label="cancel"
-                            className={styles.CancelBtn}
+                            className="CancelBtn"
                             onClick={this.hideDeleteAlert}
                           />
                           <PrimaryButton

--- a/src/components/ProjectSettingsPage/index.jsx
+++ b/src/components/ProjectSettingsPage/index.jsx
@@ -66,7 +66,7 @@ class ProjectSettingsPage extends React.Component {
 
   handleChange(e) {
     const { error, projectName, openDeleteAlert } = this.state;
-    const { errorMessage, clearUpdateProjectState } = this.props;
+    const { errorMessage, clearUpdateProjectState,clearDeleteProjectState,isFailed,message  } = this.props;
     this.setState({
       [e.target.name]: e.target.value,
     });
@@ -77,6 +77,10 @@ class ProjectSettingsPage extends React.Component {
       this.setState({
         error: "",
       });
+    }
+    if(isFailed && message){
+      clearDeleteProjectState();
+     
     }
     if (e.target.value === projectName && openDeleteAlert) {
       this.setState({


### PR DESCRIPTION
# Description

This adds a provision for users to retype the project name before deleting it. It also removes the persistent error when new text is added

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Trello Ticket ID

https://trello.com/c/osF4aFnV

## How Can This Been Tested?

Pull this branch and run it locally, open and try to delete a project. In the modal fill in the correct project name so as to activate the delete option

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Screenshots
How  it was Before
![deleting before](https://user-images.githubusercontent.com/69305400/126689452-fc43997e-1bf9-4849-8abf-920ea9157d4c.png)

Now
Before inputting the  write name, "inactive delete button"
![new delete comfirmation modal](https://user-images.githubusercontent.com/69305400/126689019-6665865b-1721-489f-8bc9-19e72c1d539e.png)
After inputting the  write name, "active delete button"
![delete confirmation2](https://user-images.githubusercontent.com/69305400/126689026-9bcf244c-2f9c-4d39-9c46-9641de59fca5.png)

