### PR TITLE
Make Database Modals Consistent

### DIFF
--- a/src/components/DBSettingsPage/DBSettingsPage.css
+++ b/src/components/DBSettingsPage/DBSettingsPage.css
@@ -17,23 +17,37 @@
   gap: 1rem;
   align-items: center;
 }
-.ResetBtn {
-  background-color: #f7b21f;
-  float: left;
+
+.DatabaseName{
+  font-weight: bold;
 }
 
-.DBDeleteBtn {
-  background-color: #ff9595;
-  outline: 2px solid #ff9595;
+.ResetBtn {
+  background-color: #ff0000;
+  outline: none;
   color: #fff;
   float: left;
 }
 
-.DBDeleteBtn:hover {
-  background-color: transparent;
-  outline: 2px solid #ff9595;
-  color: #ff9595;
+.DBDeleteBtn {
+  background-color: #ff0000;
+  outline: none;
+  color: #fff;
+  float: left;
 }
+
+.ResetBtn:hover {
+  background-color: #fff;
+  outline: 2px solid #e02626;
+  color: #e02626;
+}
+
+.DBDeleteBtn:hover {
+  background-color: #fff;
+  outline: 2px solid #e02626;
+  color: #e02626;
+}
+
 .rowDiv {
   display: grid;
 }

--- a/src/components/DBSettingsPage/index.jsx
+++ b/src/components/DBSettingsPage/index.jsx
@@ -592,8 +592,8 @@ class DBSettingsPage extends React.Component {
                       <div className="DeleteDatabaseModel">
                         <div className="DeleteProjectModalUpperSection">
                           <div className="InnerModalDescription">
-                            Are you sure you want to delete this Database &nbsp;
-                            <span>{dbInfo.name} ?</span>
+                            Are you sure you want to delete this database &nbsp;
+                            <span className="DatabaseName">{dbInfo.name} ?</span>
                             <DeleteWarning />
                           </div>
                         </div>
@@ -637,7 +637,7 @@ class DBSettingsPage extends React.Component {
                         <div className="DeleteProjectModalUpperSection">
                           <div className="InnerModalDescription">
                             Are you sure you want to reset this Database &nbsp;
-                            <span>{dbInfo.name} ?</span>
+                            <span className="DatabaseName">{dbInfo.name} ?</span>
                             <DeleteWarning />
                           </div>
                         </div>

--- a/src/components/DBSettingsPage/index.jsx
+++ b/src/components/DBSettingsPage/index.jsx
@@ -636,7 +636,7 @@ class DBSettingsPage extends React.Component {
                       <div className="DeleteDatabaseModel">
                         <div className="DeleteProjectModalUpperSection">
                           <div className="InnerModalDescription">
-                            Are you sure you want to reset this Database &nbsp;
+                            Are you sure you want to reset this database &nbsp;
                             <span className="DatabaseName">{dbInfo.name} ?</span>
                             <DeleteWarning />
                           </div>


### PR DESCRIPTION
# Description

Modifies the Reset and Delete Database Modal Alerts for the Database Settings page making them somewhat uniform.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

https://trello.com/c/ahZ6tqBe

## How Can This Been Tested?

Run this branch locally and visit a database settings page to test and review both the Reset and Delete Modals.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

Before
![image](https://user-images.githubusercontent.com/63339234/127684709-4d0f1599-c3bd-4dad-8ddd-7936ae2ac5ae.png)

![image](https://user-images.githubusercontent.com/63339234/127684777-58ca4b17-57e6-4292-9551-31ea1a818d95.png)

After
![image](https://user-images.githubusercontent.com/63339234/127686878-4b4f9d56-144d-4165-8128-6c5ab34f4865.png)

![image](https://user-images.githubusercontent.com/63339234/127686791-6fa53396-5ac0-474a-bd34-6aaf10005ec1.png)
