### PR TITLE
Change and position the create-database-error

### DIFF
--- a/src/components/CreateDatabase/CreateDatabase.css
+++ b/src/components/CreateDatabase/CreateDatabase.css
@@ -3,6 +3,11 @@
   padding-top: 2rem;
   height: 100%;
 }
+
+.CreateDBError{
+  padding-bottom: 1rem;
+}
+
 .SelectWrapper {
   width: 100%;
 }

--- a/src/components/CreateDatabase/index.jsx
+++ b/src/components/CreateDatabase/index.jsx
@@ -113,7 +113,7 @@ class CreateDatabase extends React.Component {
                     onChange={this.handleSelectChange}
                   />
                   <div />
-                  <div>
+                  <div className="CreateDBError">
                     {error && <Feedback type="error" message={error} />}
 
                     {message && (
@@ -122,7 +122,6 @@ class CreateDatabase extends React.Component {
                       type={isCreated ? "success" : "error"}
                       />
                     )}
-              
                   </div>
                   <div className="DBButtons">
                     <div className="DBDetailRow">

--- a/src/components/CreateDatabase/index.jsx
+++ b/src/components/CreateDatabase/index.jsx
@@ -115,6 +115,14 @@ class CreateDatabase extends React.Component {
                   <div />
                   <div>
                     {error && <Feedback type="error" message={error} />}
+
+                    {message && (
+                      <Feedback
+                      message={message !== "" ? message : null}
+                      type={isCreated ? "success" : "error"}
+                      />
+                    )}
+              
                   </div>
                   <div className="DBButtons">
                     <div className="DBDetailRow">
@@ -127,12 +135,6 @@ class CreateDatabase extends React.Component {
                   </div>
                 </div>
               </div>
-              {message && (
-                <Feedback
-                  message={message !== "" ? message : null}
-                  type={isCreated ? "success" : "error"}
-                />
-              )}
             </div>
           </div>
         </div>

--- a/src/redux/reducers/createDatabase.js
+++ b/src/redux/reducers/createDatabase.js
@@ -41,7 +41,7 @@ const createDatabaseReducer = (state = initialState, action) => {
         database: null,
         isCreating: false,
         isCreated: false,
-        message: "Deployment failed. Please try again",
+        message: "Failed to create database. Please try again",
         errorCode: action.payload.errorCode,
       };
 


### PR DESCRIPTION
# Description

This PR changes the context of the error showed when a database has failed to be created by making it more meaningful and also adjust its position for it to be above the create button.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

https://trello.com/c/gMVQwYW4

## How Can This Been Tested?

Run this branch locally on your machine and watch out for an error when trying to create a database.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

Before
![image-4](https://user-images.githubusercontent.com/63339234/128360537-8aa21483-fb2d-4125-9e49-8dab5fddeaeb.png)

After
![image](https://user-images.githubusercontent.com/63339234/128360602-057cdcc3-4fd0-475c-a840-764585faf538.png)

