### PR TITLE
fix project card hover

### DIFF
--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -1,6 +1,7 @@
 .ProjectsCard {
   background-color: #ffffff;
   width: 15rem;
+  height: min-content;
 }
 
 .ProjectsCard:hover {


### PR DESCRIPTION
# Description
Single line fix of overlapping white on project card when other project cards are hovered
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## Trello Ticket ID
https://trello.com/c/QESIUGrD
## How Can This Been Tested?
run the branch and hover around you projects

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Screenshots
problem
![hover white](https://user-images.githubusercontent.com/69305400/128410728-b389861e-c1da-4e56-87a2-d92b5ee2a037.png)
required
![white hover fix](https://user-images.githubusercontent.com/69305400/128410788-a0fe222f-7404-4b79-b182-32a6976e04c8.png)
