### PR TITLE
Add spacing above the more-options DBSection

### DIFF
--- a/src/components/DBSettingsPage/DBSettingsPage.css
+++ b/src/components/DBSettingsPage/DBSettingsPage.css
@@ -147,10 +147,15 @@
   padding-right: 1rem;
 }
 
+.DBSections{
+  padding-top: 1rem;
+}
+
 .DBSectionTitle{
   font-size: 18px;
   font-weight: bold;
 }
+
 @media only screen and (min-device-width: 641px) and (max-width: 900px) {
   .DBDetailRow {
     grid-template-columns: 18% 40% 10% auto;


### PR DESCRIPTION
# Description

This PR performs a quick fix to the database setting's page by adding spacing above the more-options section.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/9wA3pOb1

## How Can This Been Tested?

Checkout this branch locally and visit the database settings page to notice the fix.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

Before 
![1628531820902_image](https://user-images.githubusercontent.com/63339234/128755981-e5f912df-9d75-4fb9-b2ef-87ac7ea72691.png)

After
![image](https://user-images.githubusercontent.com/63339234/128756018-a86f8137-4a06-4b9b-8882-dd90c12dfce7.png)
