### PR TITLE
Add scroll to app logs

### DIFF
--- a/src/components/LogsFrame/LogsFrame.css
+++ b/src/components/LogsFrame/LogsFrame.css
@@ -27,6 +27,8 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  height: 6rem;
+  overflow-y: auto;
 }
 
 .LogsSpinner {


### PR DESCRIPTION
# Description

App logs do not have scrolling or height limits, making the pages long for multiple logs. This is to fix that issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/EyDehWpm

## How Can This Be Tested?

Pull this branch and run it locally, open a project and view its logs. The logs should have a fixed height with scrolling enabled.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Screenshots

## Before:
![Before scroll](https://user-images.githubusercontent.com/41950223/129796342-4c0f9716-65f9-4dab-882e-2d35011ec774.gif)

## After:
![After scroll](https://user-images.githubusercontent.com/41950223/129796789-b605a7dd-e72a-4cf6-be8c-529aadf11434.gif)

