### PR TITLE
Fix app name bug on app settings

### DIFF
--- a/src/components/AppSettingsPage/index.jsx
+++ b/src/components/AppSettingsPage/index.jsx
@@ -34,16 +34,21 @@ class AppSettingsPage extends React.Component {
   }
 
   handleChange(e) {
-    const { name } = this.props.location;
     const {  openDeleteAlert} = this.state;
+    const {
+      match: { params },
+    } = this.props;
+    const {appID } = params;
+
     this.setState({
       [e.target.name]: e.target.value,
     });
-    if (e.target.value === name && openDeleteAlert) {
+
+    if (  openDeleteAlert && e.target.value === this.getAppName(appID)) {
       this.setState({
         disableDelete: false,
       });
-    } else if (e.target.value !== name && openDeleteAlert) {
+    } else if ( openDeleteAlert && e.target.value !== this.getAppName(appID) ) {
       this.setState({
         disableDelete: true,
       });
@@ -55,6 +60,10 @@ class AppSettingsPage extends React.Component {
     if (isDeleted !== prevProps.isDeleted) {
       this.hideDeleteAlert();
     }
+  }
+  getAppName(id) {
+    const { apps } = this.props;
+    return apps.apps.find((app) => app.id === id).name;
   }
 
   handleDeleteApp(e, appId) {
@@ -92,8 +101,10 @@ class AppSettingsPage extends React.Component {
       isFailed,
     } = this.props;
     const { openDeleteAlert,ConfirmAppname,disableDelete} = this.state;
-    const { name } = this.props.location;
+    // project name from line 105 disappears on refreash, another source of the name was needed
+    //const { name } = this.props.location;
     const { projectID, userID, appID } = params;
+    const name = this.getAppName(appID);  
 
     return (
       <div className={styles.Page}>
@@ -210,11 +221,14 @@ AppSettingsPage.propTypes = {
 AppSettingsPage.defaultProps = {
   isDeleted: false,
   isFailed: false,
+  apps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 
 const mapStateToProps = (state) => {
   const { isDeleting, isDeleted, isFailed, message } = state.deleteAppReducer;
+  const { apps } = state.appsListReducer;
   return {
+    apps,
     isDeleting,
     isDeleted,
     isFailed,


### PR DESCRIPTION
# Description

On app settings, the name of the app is attained in a way that wen the screen is refreshed it dis appears, this bug was also affecting app delete since the name is required on deleting the app

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID

https://trello.com/c/HT4CNy7f

## How Can This Been Tested?
checkout develop and go to app setting and refresh, notice what it does to the name in the sidebar, then
check out the branch, and go to app setting and refresh.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots
problem**
on loading the page before
![be4refresh](https://user-images.githubusercontent.com/69305400/130110916-ebf0ee50-3ba0-4e84-91c1-fce1986ab1d2.png)
 then when you refresh notice the name disappears in the side bar
![onrefresh](https://user-images.githubusercontent.com/69305400/130110999-ed00f288-a640-4b72-9dff-e2fe24685ef9.png)
 for the fix**
check the branch
![fixname](https://user-images.githubusercontent.com/69305400/130111117-59bfe7f4-2331-4c67-9d7e-7fa3ecd879ee.png)


