### PR TITLE
github button hover effect

### DIFF
--- a/src/components/LoginPage/LoginPage.css
+++ b/src/components/LoginPage/LoginPage.css
@@ -72,9 +72,8 @@ a.LoginContentLink {
 }
 
 .GithubLoginBtn:hover {
-  outline: 2px solid #000;
-  background-color: #000;
-  opacity: 60%;
+  outline: 2px solid #06222f;
+  background-color: #06222f;
 }
 .GitText {
   color: #fff;


### PR DESCRIPTION
# Description

The hover effect on the login with GitHub button was affected by opacity

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/n3hYpc4o

## How Can This Been Tested?

check this branch out, hover over the login with GitHub button and suggest any changes that can be added to it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots
 please check it out
