### PR TITLE
 Github login funtionality to register page

### DIFF
--- a/src/components/RegisterPage/RegisterPage.css
+++ b/src/components/RegisterPage/RegisterPage.css
@@ -2,7 +2,7 @@
   background: #008ac1;
   color: #ffffff;
   display: flex;
-  overflow-y: hidden;
+  overflow-y: scroll;
   flex-direction: column;
   flex-grow: 1;
 }
@@ -12,7 +12,7 @@
   display: flex;
   flex-direction: column;
   align-self: center;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .RegisterSuccessContent {
@@ -55,6 +55,50 @@ a.RegisterContentLink {
   color: #d63b3b;
   text-align: center;
   padding: 1rem 0;
+}
+.GitLoginBtn {
+  display: grid;
+  grid-gap: 0.2rem;
+  grid-auto-flow: column;
+  align-items: center;
+}
+.LogoIcon {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+.GithubLoginBtn {
+  width: 100%;
+  color: #fff;
+  background-color: #000;
+  outline: 2px solid #000000;
+}
+
+.GithubLoginBtn:hover {
+  outline: 2px solid #06222f;
+  background-color: #06222f;
+}
+.GitText {
+  color: #fff;
+  text-transform: capitalize;
+}
+.SignupBtn{
+  width: 100%;
+}
+.SignupWith {
+  width: 100%;
+  text-align: center;
+  border-bottom: 1px solid #fff;
+  line-height: 0.1em;
+}
+.SignupWith span {
+  background-color: #008ac1;
+  padding: 0 1rem;
+}
+.LowerSignupSection {
+  display: grid;
+  grid-template-columns: 1fr;
+  padding-top: 0.5rem;
+  gap: 0.5rem;
 }
 
 @media only screen and (max-width: 640px) {

--- a/src/components/RegisterPage/index.js
+++ b/src/components/RegisterPage/index.js
@@ -6,8 +6,10 @@ import InputText from "../InputText";
 import InputPassword from "../InputPassword";
 import PrimaryButton from "../PrimaryButton";
 import Spinner from "../Spinner";
+import { ReactComponent as LogoIcon } from "../../assets/images/githublogo.svg";
+import { API_BASE_URL, GIT_REDIRECT_URL } from "../../config";
 import Checkbox from "../Checkbox";
-import { API_BASE_URL } from "../../config";
+
 
 import "./RegisterPage.css";
 
@@ -23,6 +25,7 @@ export default class RegisterPage extends Component {
       hasAgreed: false,
       loading: false,
       registered: false,
+      gitLoading:false,
       error: "",
     };
 
@@ -30,6 +33,7 @@ export default class RegisterPage extends Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.toggleAgreed = this.toggleAgreed.bind(this);
     this.validateEmail = this.validateEmail.bind(this);
+    this.toGithubauth = this.toGithubauth.bind(this);
   }
 
   toggleAgreed() {
@@ -44,6 +48,24 @@ export default class RegisterPage extends Component {
       });
     }
   }
+  toGithubauth = () => {
+    // on return, github will be redricted to the login page where the
+    // functions that handle the rest of the authrntications are
+    const { hasAgreed } = this.state;
+    if(hasAgreed){
+    this.setState({
+      loading:true,
+      gitLoading:true,
+    });
+    window.location.href = `${GIT_REDIRECT_URL}`;
+    }else{
+      this.setState({
+        loading: false,
+        gitLoading:false,
+        error: "Please agree to our Terms of Service",
+      });
+    }
+  };
 
   handleOnChange(e) {
     const { error } = this.state;
@@ -131,6 +153,7 @@ export default class RegisterPage extends Component {
       registered,
       error,
       hasAgreed,
+      gitLoading,
     } = this.state;
 
     return (
@@ -138,7 +161,7 @@ export default class RegisterPage extends Component {
         <Header />
         <div className="RegisterContent">
           {!registered ? (
-            <>
+          <>
               <div className="RegisterContentHeading">
                 <h1>Create an account</h1>
               </div>
@@ -186,12 +209,14 @@ export default class RegisterPage extends Component {
                   </div>
 
                   <PrimaryButton
+                    className="SignupBtn"
                     label={loading ? <Spinner /> : "Register"}
                     onClick={this.handleSubmit}
                   />
                 </div>
               </form>
-            </>
+
+           </>
           ) : (
             <div className="RegisterSuccessContent">
               <div className="RegisteredMessage">
@@ -208,6 +233,29 @@ export default class RegisterPage extends Component {
               </div>
             </div>
           )}
+          <div className="LowerSignupSection">
+            <div>
+              <p className="SignupWith">
+                <span>Or Join with</span>
+              </p>
+            </div>
+            <PrimaryButton
+              label={
+                gitLoading ? (
+                  <Spinner />
+                ) : (
+                  <div className="GitLoginBtn">
+                    <LogoIcon className="LogoIcon" />
+                    <div className="GitText">Github</div>
+                  </div>
+                )
+              }
+              className="GithubLoginBtn"
+              disable={gitLoading}
+              onClick={this.toGithubauth}
+            />
+           </div>
+           
         </div>
       </div>
     );


### PR DESCRIPTION
# Description

Add Github login funtionality to register page

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Trello Ticket ID
https://trello.com/c/ty973U1l

## How Can This Been Tested?

You local branch should have the staging client id, go to the register page and join with github.
Note: with a staging client id , the app will direct you to the staging environment login page, since it's what is configured in the github app, with means the branch is operating fine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


# Screenshots
![image](https://user-images.githubusercontent.com/69305400/151373142-0f60a631-c06c-4744-ab1e-34efba12786a.png)
