### PR TITLE
Center Page Not Found

### DIFF
--- a/src/components/PageNotFound/PageNotFound.css
+++ b/src/components/PageNotFound/PageNotFound.css
@@ -4,6 +4,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
+  height: calc(100vh - 5rem);
 }
 
 .ErrorPageDigit {


### PR DESCRIPTION
# Description

This PR provides a quick fix for the page not found content that was not centered to the height of the browser.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?

Run this branch locally and visit a random route say localhost:3000/paqkq inorder to see the page not found.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots
Before
![page-not-found-before](https://user-images.githubusercontent.com/63339234/151534863-367fbce8-7e45-41d9-808b-943166b763b9.jpg)

After
![center-not-found-message](https://user-images.githubusercontent.com/63339234/151534896-97162b0a-86b0-4eb8-9db7-c3ac18e81f31.jpg)
