### PR TITLE
Remove the pricing page

### DIFF
--- a/src/components/LandingFooter/index.js
+++ b/src/components/LandingFooter/index.js
@@ -69,9 +69,9 @@ const LandingFooter = () => (
                 <li className="TextDivSpacing">
                   <Link to="/privacy-policy" target="_blank">Privacy policy</Link>
                 </li>
-                <li className="TextDivSpacing">
+                {/* <li className="TextDivSpacing">
                   <Link to="/pricing">Pricing</Link>
-                </li>
+                </li> */}
                 <li className="TextDivSpacing">
                   <Link to="/contact">Contact</Link>
                 </li>

--- a/src/components/NewHeader/index.js
+++ b/src/components/NewHeader/index.js
@@ -76,9 +76,9 @@ const NewHeader = (props) => {
               >
                 Blog
               </a>
-              <Link to="/pricing" className="HeaderLinkDocs">
+              {/* <Link to="/pricing" className="HeaderLinkDocs">
                 Pricing
-              </Link>
+              </Link> */}
               <Link to="/login" className="HeaderLinkDocs">
                 Login
               </Link>
@@ -111,9 +111,9 @@ const NewHeader = (props) => {
               >
                 Blog
               </a>
-              <Link to="/pricing" className="HeaderLinkDocs">
+              {/* <Link to="/pricing" className="HeaderLinkDocs">
                 Pricing
-              </Link>
+              </Link> */}
               <Link
                 to={`/projects`}
                 className="HeaderLinkDocs"
@@ -162,9 +162,9 @@ const NewHeader = (props) => {
               >
                 Blog
               </a>
-              <Link to="/pricing" className="HeaderDropLinkDocs">
+              {/* <Link to="/pricing" className="HeaderDropLinkDocs">
                 Pricing
-              </Link>
+              </Link> */}
               <Link to="/login" className="HeaderDropLinkDocs">
                 Login
               </Link>
@@ -197,9 +197,9 @@ const NewHeader = (props) => {
               >
                 Blog
               </a>
-              <Link to="/pricing" className="HeaderDropLinkDocs">
+              {/* <Link to="/pricing" className="HeaderDropLinkDocs">
                 Pricing
-              </Link>
+              </Link> */}
               <Link
                 to={`/projects`}
                 className="HeaderDropLinkDocs"

--- a/src/router.js
+++ b/src/router.js
@@ -8,7 +8,7 @@ import {
 import store from "./redux/store";
 import App from "./components/App";
 import LoginPage from "./components/LoginPage";
-import PricingPage from "./components/PricingPage";
+// import PricingPage from "./components/PricingPage";
 import ContactPage from "./components/ContactPage";
 import PasswordReset from "./components/PasswordReset";
 import RegisterPage from "./components/RegisterPage";
@@ -64,7 +64,7 @@ const Routes = () => (
     <Switch>
       <Route exact path="/" component={App} />
       <Route path="/login" component={LoginPage} />
-      <Route path="/pricing" component={PricingPage} />
+      {/* <Route path="/pricing" component={PricingPage} /> */}
       <Route path="/contact" component={ContactPage} />
       <Route path="/admin-login" component={AdminLoginPage} />
       <Route path="/forgot-password" component={PasswordReset} />


### PR DESCRIPTION
# Description
Remove the pricing page, this is because of the confusion it is currently breeding yet the figures on there are no conclusive hence are portraying a totally different image of what we aim to achieve. I request we can have it back up when we have finally confirmed and approved the figures and details to be on there. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID
https://trello.com/c/ro64AsUZ

## How Can This Been Tested?
Check the homepage

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
