### PR TITLE
Made Teams Page Responsive

### DIFF
--- a/src/components/TeamPage/TeamPage.css
+++ b/src/components/TeamPage/TeamPage.css
@@ -7,7 +7,7 @@
     display: flex;
     flex-wrap: wrap;
     padding: 2.5rem 0;
-    row-gap: 1rem;
+    gap: 1rem;
     width: 100%;
 }
 

--- a/src/components/TeamPage/TeamPage.css
+++ b/src/components/TeamPage/TeamPage.css
@@ -2,13 +2,13 @@
   background-color: #f1f1f1;
 }
 .TeamImagesRow {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  width: 100%;
-  justify-items: center;
-  align-items: center;
-  padding: 2.5rem 0rem;
-  row-gap: 1rem;
+    align-items: center;
+    justify-content: center;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 2.5rem 0;
+    row-gap: 1rem;
+    width: 100%;
 }
 
 img .TeamMemberImage {


### PR DESCRIPTION
The row will display as many rows as it can to fill up the space without having images overflowing out.

# Description

Fixes issue where images overflow on mobile devices.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Can This Been Tested?

Ran the new changes in via the Chrome Dev tools using the device toggle mode part.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

# Screenshots

Add relevant screenshots incase they are relevant

![image](https://user-images.githubusercontent.com/51344005/162182893-babed43a-7466-43ca-b925-ff96945517e8.png)
![image](https://user-images.githubusercontent.com/51344005/162182954-2aef1228-e0a7-40e4-aec3-772328b1ee26.png)
![image](https://user-images.githubusercontent.com/51344005/162183027-6656f1a4-cefa-4949-8699-84b86ea35a83.png)
