### PR TITLE
fix apps rendering

### DIFF
--- a/src/components/AppsCard/AppsCard.css
+++ b/src/components/AppsCard/AppsCard.css
@@ -6,7 +6,7 @@
   color: #000000;
   border: 1px solid rgba(0, 0, 0, 0.125);
   height: 10rem;
-  max-width: 19rem;
+ 
 }
 
 .AppCardHeader {

--- a/src/components/AppsList/index.jsx
+++ b/src/components/AppsList/index.jsx
@@ -95,7 +95,7 @@ class AppsList extends Component {
           </div>
         ) : word !== "" ? (
           <div className={styles.AppList}>
-            {isRetrieved &&
+            {(isRetrieved && !isRetrieving) &&
               SearchList.map((app) => (
                 <div key={app.id} className="AppCardItem">
                   <AppsCard
@@ -111,7 +111,7 @@ class AppsList extends Component {
           </div>
         ) : (
           <div className={styles.AppList}>
-            { (apps.apps.length !== 0) &&
+            { (apps.apps.length !== 0 && !isRetrieving && isRetrieved) && 
               sortedApps.map((app) => (
                 <div key={app.id} className="AppCardItem">
                   <AppsCard
@@ -139,7 +139,7 @@ class AppsList extends Component {
             )}
           </div>
         )}
-        {!isRetrieving && !isRetrieved && (apps.apps.length === 0) && (
+        {!isRetrieving && !isRetrieved  && (
           <div className={styles.NoResourcesMessage}>
             Oops! Something went wrong! Failed to retrieve Apps.
           </div>

--- a/src/components/ProjectDashboardPage/ProjectDashboardPage.css
+++ b/src/components/ProjectDashboardPage/ProjectDashboardPage.css
@@ -12,7 +12,6 @@
 }
 
 .CardDimensions {
-  max-width: 21rem;
   height: 15rem;
   color: initial;
 }


### PR DESCRIPTION
# Description

A bug at the frontend where applications on one project  could be accessed in another, this is because the apps in states are never cleared and this has to be considered on rendering

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Trello Ticket ID

https://trello.com/c/bXJO0Qxm

## How Can This Been Tested?

check develop out and click on a project that has apps, in case you have a project that does not recover apps anymore, click on that next, you will realise apps of the previous project appearing in the new one
 this branch fixes that issue


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots
in this case, it appears as though two projects have the same apps
![image](https://user-images.githubusercontent.com/69305400/162200071-852afa43-7c41-425a-979c-231c8cf3b610.png)
![image](https://user-images.githubusercontent.com/69305400/162200347-34c22407-3c09-43aa-a13f-67dd8ea464f9.png)

