### PR TITLE
Create tabs for transactions and invoice history

### DIFF
--- a/src/components/ProjectBillingPage/ProjectBillingPage.module.css
+++ b/src/components/ProjectBillingPage/ProjectBillingPage.module.css
@@ -6,9 +6,11 @@
   grid-template-rows: auto 1fr auto;
   /* overflow: hidden; */
 }
+
 .TopBarSection {
   background-color: black;
 }
+
 .MainSection {
   /* divided into two columns */
   background-color: #f1f1f1;
@@ -16,6 +18,7 @@
   grid-template-columns: 1.3fr 6fr;
   overflow: hidden;
 }
+
 .SideBarSection {
   overflow: hidden;
   overflow-y: scroll;
@@ -42,6 +45,7 @@
 .SmallContainer {
   padding: 0 2rem 2rem 2rem;
 }
+
 @media (max-width: 580px) {
   .SmallContainer {
     padding: 0 1rem 1rem 2rem;
@@ -53,6 +57,7 @@
   flex-direction: row;
   gap: 1rem;
 }
+
 .DonutChatContainer {
   display: flex;
   flex-direction: column;
@@ -61,11 +66,13 @@
   border: 1px solid #cccccc;
   background-color: #ffffff;
 }
+
 .InsideHeading {
   display: flex;
   justify-content: center;
   border-bottom: 1px solid #cccccc;
 }
+
 .Heading,
 .TransactionHistoryHeading {
   padding: 0.3rem;
@@ -76,13 +83,16 @@
 .Subtext2 {
   font-weight: 800;
 }
+
 .MonthSummary {
   display: flex;
   flex-direction: column;
 }
+
 .InnerContainer {
   padding: 0 1rem;
 }
+
 .ResourseDetail {
   display: grid;
   grid-template-columns: 1fr 3fr 1fr;
@@ -90,24 +100,29 @@
   border-bottom: 1px solid #000000;
   padding: 0.2rem;
 }
+
 .Cube {
   display: flex;
   width: 1rem;
   height: 1rem;
 }
+
 .ResourcePrice {
   font-weight: 700;
   text-align: end;
 }
+
 .Total {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-gap: 0.5rem;
   padding: 0.8rem 0.3rem;
 }
+
 .TotalTxt {
   text-align: start;
 }
+
 .paymentButton {
   display: flex;
   align-items: center;
@@ -129,11 +144,13 @@
   width: 100%;
   background-color: #ffffff;
 }
+
 .MetricsCardGraph {
   width: 90%;
   height: 25rem;
   align-self: flex-start;
 }
+
 .MetricContainer {
   display: flex;
   padding-bottom: 1rem;
@@ -148,61 +165,101 @@
 .TransactionHistoryWrapper {
   padding-top: 1.5rem;
 }
+
 .TransactionHistoryContainer {
   border: 1px solid #cccccc;
   background-color: white;
 }
+
 .TransactionHistoryHeading {
-  padding: 1rem;
-  padding: 1rem;
+  padding: 1rem 0 1rem 2rem;
+  display: flex;
+  flex-direction: row;
+  gap: 3rem;
   border-bottom: 1px solid #cccccc;
 }
-.TransactionHistoryBody {
+
+.CurrentTab {
+  background-color: #d9d9d9;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+
+.CurrentTab:hover,
+.Tab:hover {
+  cursor: pointer;
+}
+
+.Tab {
+  padding: 0.5rem;
+}
+
+.TransactionHistoryBody,
+.InvoiceHistoryBody {
   padding: 2rem;
 }
+
 .TransactionHistoryRow,
-.TransactionHistoryHead {
+.TransactionHistoryHead,
+.InvoiceHistoryHead,
+.InvoiceHistoryRow {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-gap: 10px;
   border-bottom: 1px solid #ccc;
   padding: 1rem;
 }
-.TransactionHistoryCell {
+
+.TransactionHistoryCell,
+.InoviceHistoryCell {
   overflow-wrap: break-word;
 }
-.TransactionHistoryHead .TransactionHistoryCell {
+
+.TransactionHistoryHead .TransactionHistoryCell,
+.InvoiceHistoryHead {
   text-transform: uppercase;
   color: #008ac1;
 }
+
 .TransactionHistoryCell .PaymentStatus {
   padding: 0.3rem;
   border-radius: 0.3rem;
   background-color: #408140;
   color: #ffffff;
 }
+
 .TransactionHistoryRow .TransactionHistoryCell:first-child,
-.TransactionHistoryHead .TransactionHistoryCell:first-child {
+.TransactionHistoryHead .TransactionHistoryCell:first-child,
+.InvoiceHistoryRow .InvoiceHistoryCell:first-child,
+.InvoiceHistoryHead .InvoiceHistoryCell:first-child {
   text-align: left;
 }
+
 .TransactionHistoryRow .TransactionHistoryCell:last-child,
-.TransactionHistoryHead .TransactionHistoryCell:last-child {
+.TransactionHistoryHead .TransactionHistoryCell:last-child,
+.InvoiceHistoryRow .InvoiceHistoryCell:last-child,
+.InvoiceHistoryHead .InvoiceHistoryCell:last-child {
   text-align: right;
 }
-.PaymentDetailsButton {
+
+.PaymentDetailsButton,
+.InvoiceDownloadButton {
   color: #008ac1;
   outline: none;
   border: none;
   cursor: pointer;
   background: transparent;
 }
-.PaymentDetailsButton:hover {
+
+.PaymentDetailsButton:hover,
+.InvoiceDownloadButton:hover {
   text-decoration: underline;
 }
 
 .ReceiptModal .TotalTxt {
   font-weight: 700;
 }
+
 .ReceiptDetailContainer {
   display: grid;
   grid-template-rows: 1fr 1fr;
@@ -210,14 +267,17 @@
   padding: 0 1rem;
   padding-bottom: 0.5rem;
 }
+
 .ReceiptLabel {
   font-size: 0.8rem;
   color: #9b9b9b;
 }
+
 .ReceiptDetail {
   font-weight: 700;
 }
-.ReceiptDetail .PaymentStatus{
+
+.ReceiptDetail .PaymentStatus {
   font-weight: normal;
   padding: 0.3rem;
   border-radius: 0.3rem;
@@ -225,10 +285,12 @@
   background: #408140;
   color: #ffffff;
 }
+
 .ReceiptModal .ResourseDetail,
 .ReceiptModal .Total {
   padding: 0.8rem;
 }
+
 .ReceiptButton {
   display: flex;
   justify-content: center;
@@ -241,6 +303,7 @@
     min-width: 0;
     height: fit-content;
   }
+
   .DonutChatContainer {
     max-width: 100%;
   }

--- a/src/components/ProjectBillingPage/index.jsx
+++ b/src/components/ProjectBillingPage/index.jsx
@@ -38,6 +38,8 @@ const ProjectBillingPage = (props) => {
 
   const [transactionDetails, setTransactionDetails] = useState({});
   const [viewReceipt, setViewReceipt] = useState(false);
+  const [currentTab, setCurrentTab] = useState(true);
+  const [nextTab, setNextTab] = useState(false);
   const [months, setMonths] = useState(data2);
 
   useEffect(() => {
@@ -52,6 +54,15 @@ const ProjectBillingPage = (props) => {
     setViewReceipt(false);
   };
 
+  const viewTransactions = () => {
+    setCurrentTab(true);
+    setNextTab(false);
+  };
+  const viewInvoices = () => {
+    setNextTab(true);
+    setCurrentTab(false);
+  };
+
   const getBill = useCallback(
     () => dispatch(getProjectBill(projectID, { series: true })),
     [dispatch, projectID]
@@ -60,14 +71,14 @@ const ProjectBillingPage = (props) => {
   // create a function that takes in a array and returns a new array of objects with the data 2 format
   const getData2Format = (data) => {
     const newData = [];
-    if (Array.isArray(data)){
-    data.forEach((element) => {
-      newData.push({
-        date: moment(element.start).utc().format('YYYY-MM-DD'),
-        amount: element.totalCost,
+    if (Array.isArray(data)) {
+      data.forEach((element) => {
+        newData.push({
+          date: moment(element.start).utc().format("YYYY-MM-DD"),
+          amount: element.totalCost,
+        });
       });
-    });
-   }
+    }
     // let newData2 = newData.slice(4)
     return newData;
   };
@@ -75,17 +86,17 @@ const ProjectBillingPage = (props) => {
   // create a function that takes in a array and sums all the object key values to create one object
   const summationObject = (data) => {
     const newData = {};
-    if (Array.isArray(data)){
-    data?.forEach((element) => {
-      Object.keys(element).forEach((key) => {
-        if (newData[key]) {
-          newData[key] += element[key];
-        } else {
-          newData[key] = element[key];
-        }
+    if (Array.isArray(data)) {
+      data?.forEach((element) => {
+        Object.keys(element).forEach((key) => {
+          if (newData[key]) {
+            newData[key] += element[key];
+          } else {
+            newData[key] = element[key];
+          }
+        });
       });
-    });
-  }
+    }
     return newData;
   };
 
@@ -95,20 +106,41 @@ const ProjectBillingPage = (props) => {
 
   const billInfo = useSelector((state) => state.getProjectBillReducer);
   const { projectBill } = billInfo;
-  
+
   useEffect(() => {
     setMonths(getData2Format(projectBill?.data?.cost_data));
   }, [projectBill.data]);
 
   let newObject = summationObject(projectBill?.data?.cost_data);
   const data1 = [
-    { name: "CPU / $1 per 1K seconds", value: (Object.keys(newObject).length === 0) ? "n/a" : ((newObject.cpuCost + 1) * 10), color: "#0088FE" },
-    { name: "RAM / $4 per GB", value: (Object.keys(newObject).length === 0) ?"n/a" : ((newObject.ramCost + 1) * 10), color: "#00C49F" },
-    { name: "Network / $1 per request", value: (Object.keys(newObject).length === 0) ? "n/a" :((newObject.networkCost + 1)* 10), color: "#FFBB28" },
-    { name: "Storage/ $1 per GB",  value: "n/a", color: "#FF8042" },
+    {
+      name: "CPU / $1 per 1K seconds",
+      value:
+        Object.keys(newObject).length === 0
+          ? "n/a"
+          : (newObject.cpuCost + 1) * 10,
+      color: "#0088FE",
+    },
+    {
+      name: "RAM / $4 per GB",
+      value:
+        Object.keys(newObject).length === 0
+          ? "n/a"
+          : (newObject.ramCost + 1) * 10,
+      color: "#00C49F",
+    },
+    {
+      name: "Network / $1 per request",
+      value:
+        Object.keys(newObject).length === 0
+          ? "n/a"
+          : (newObject.networkCost + 1) * 10,
+      color: "#FFBB28",
+    },
+    { name: "Storage/ $1 per GB", value: "n/a", color: "#FF8042" },
     { name: "Database/ $1 per GB", value: "n/a", color: "#99D2E9" },
   ];
-  
+
   const getProjectName = (id) => {
     return projects.find((project) => project.id === id).name;
   };
@@ -218,7 +250,11 @@ const ProjectBillingPage = (props) => {
                     ))}
                     <div className={styles.Total}>
                       <div className={styles.TotalTxt}>Total</div>
-                      <div className={styles.ResourcePrice}>{(Object.keys(newObject).length === 0) ? "n/a" : `${(newObject.totalCost + 1)* 10}` }</div>
+                      <div className={styles.ResourcePrice}>
+                        {Object.keys(newObject).length === 0
+                          ? "n/a"
+                          : `${(newObject.totalCost + 1) * 10}`}
+                      </div>
                     </div>
                   </div>
                   <div className={styles.paymentButton}>
@@ -240,8 +276,10 @@ const ProjectBillingPage = (props) => {
                     below
                   </div>
                   <div className={styles.Subtext2}>
-                    Current Month-to-Date balance is {(Object.keys(newObject).length !== 0) ? "Not computed":
-                    `${((newObject.totalCost + 1)* 10)}` }
+                    Current Month-to-Date balance is{" "}
+                    {Object.keys(newObject).length !== 0
+                      ? "Not computed"
+                      : `${(newObject.totalCost + 1) * 10}`}
                   </div>
                   <div className={styles.MetricContainer}>
                     <MetricsCard
@@ -264,54 +302,100 @@ const ProjectBillingPage = (props) => {
             <div className={styles.TransactionHistoryWrapper}>
               <div className={styles.TransactionHistoryContainer}>
                 <div className={styles.TransactionHistoryHeading}>
-                  Transaction History
+                  <span
+                    className={currentTab ? styles.CurrentTab : styles.Tab}
+                    onClick={() => viewTransactions()}
+                  >
+                    Transactions
+                  </span>
+                  <span
+                    className={nextTab ? styles.CurrentTab : styles.Tab}
+                    onClick={() => viewInvoices()}
+                  >
+                    Invoices
+                  </span>
                 </div>
-                <div className={styles.TransactionHistoryBody}>
-                  <div className={styles.TransactionHistoryTable}>
-                    <div className={styles.TransactionHistoryHead}>
-                      <div className={styles.TransactionHistoryCell}>
-                        Transaction Id
+
+                {currentTab && (
+                  <div className={styles.TransactionHistoryBody}>
+                    <div className={styles.TransactionHistoryTable}>
+                      <div className={styles.TransactionHistoryHead}>
+                        <div className={styles.TransactionHistoryCell}>
+                          Transaction Id
+                        </div>
+                        <div className={styles.TransactionHistoryCell}>
+                          Status
+                        </div>
+                        <div className={styles.TransactionHistoryCell}>
+                          Amount
+                        </div>
+                        <div className={styles.TransactionHistoryCell}>
+                          Details
+                        </div>
                       </div>
-                      <div className={styles.TransactionHistoryCell}>
-                        Status
-                      </div>
-                      <div className={styles.TransactionHistoryCell}>
-                        Amount
-                      </div>
-                      <div className={styles.TransactionHistoryCell}>
-                        Details
-                      </div>
+                      {transactions?.map((entry, index) => (
+                        <div
+                          className={styles.TransactionHistoryRow}
+                          key={index}
+                        >
+                          <div className={styles.TransactionHistoryCell}>
+                            {entry.transaction_id}
+                          </div>
+                          <div className={styles.TransactionHistoryCell}>
+                            <span className={styles.PaymentStatus}>
+                              {entry.status}
+                            </span>
+                          </div>
+                          <div className={styles.TransactionHistoryCell}>
+                            {entry.amount.toLocaleString("en-US")}
+                          </div>
+                          <div className={styles.TransactionHistoryCell}>
+                            <button
+                              onClick={() =>
+                                openReceiptModal(
+                                  transactions,
+                                  entry.transaction_id
+                                )
+                              }
+                              className={styles.PaymentDetailsButton}
+                            >
+                              View
+                            </button>
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                    {transactions?.map((entry, index) => (
-                      <div className={styles.TransactionHistoryRow} key={index}>
-                        <div className={styles.TransactionHistoryCell}>
-                          {entry.transaction_id}
+                  </div>
+                )}
+
+                {nextTab && (
+                  <div className={styles.InvoiceHistoryBody}>
+                    <div className={styles.InvoiceHistoryTable}>
+                      <div className={styles.InvoiceHistoryHead}>
+                        <div className={styles.InvoiceHistoryCell}>Date</div>
+                        <div className={styles.InvoiceHistoryCell}>
+                          Invoice ID
                         </div>
-                        <div className={styles.TransactionHistoryCell}>
-                          <span className={styles.PaymentStatus}>
-                            {entry.status}
-                          </span>
+                        <div className={styles.InvoiceHistoryCell}>Amount</div>
+                        <div className={styles.InvoiceHistoryCell}>Details</div>
+                      </div>
+                      <div className={styles.InvoiceHistoryRow}>
+                        <div className={styles.InvoiceHistoryCell}>
+                          31-01-2022
                         </div>
-                        <div className={styles.TransactionHistoryCell}>
-                          {entry.amount.toLocaleString("en-US")}
+                        <div className={styles.InvoiceHistoryCell}>
+                          87546947
                         </div>
-                        <div className={styles.TransactionHistoryCell}>
-                          <button
-                            onClick={() =>
-                              openReceiptModal(
-                                transactions,
-                                entry.transaction_id
-                              )
-                            }
-                            className={styles.PaymentDetailsButton}
-                          >
-                            View
+                        <div className={styles.InvoiceHistoryCell}>200,000</div>
+                        <div className={styles.InvoiceHistoryCell}>
+                          <button className={styles.InvoiceDownloadButton}>
+                            Download
                           </button>
                         </div>
                       </div>
-                    ))}
+                    </div>
                   </div>
-                </div>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
# Description

A user should be able to ideally switch between transaction history and invoice history quite easily.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Trello Ticket ID

https://trello.com/c/VfOOZhb2

## How Can This Been Tested?

Checkout and run this branch locally and navigate to the project billing dashboard to test the added functionality.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshot

![Tabs](https://user-images.githubusercontent.com/63339234/169764561-51f0dd9a-b28c-4912-8bb3-d8bce4f3cef1.gif)
