### PR TITLE
Add day metrics for billing

### DIFF
--- a/src/components/FlutterwaveHook/index.js
+++ b/src/components/FlutterwaveHook/index.js
@@ -67,6 +67,7 @@ export default function FlutterWaveHook(props) {
     <div>
       <PrimaryButton
         label={"Pay Bill"}
+        disable = {true}
         onClick={() => {
           handleFlutterPayment({
             callback: (response) => {

--- a/src/components/FlutterwaveHook/index.js
+++ b/src/components/FlutterwaveHook/index.js
@@ -67,7 +67,6 @@ export default function FlutterWaveHook(props) {
     <div>
       <PrimaryButton
         label={"Pay Bill"}
-        disable = {true}
         onClick={() => {
           handleFlutterPayment({
             callback: (response) => {

--- a/src/components/ProjectBillingPage/ProjectBillingPage.module.css
+++ b/src/components/ProjectBillingPage/ProjectBillingPage.module.css
@@ -178,6 +178,12 @@
   gap: 3rem;
   border-bottom: 1px solid #cccccc;
 }
+.UsageHistoryHeading {
+  padding: .5rem 0 1rem 0rem;
+  display: flex;
+  flex-direction: row;
+  gap: .5rem;
+}
 
 .CurrentTab {
   background-color: #d9d9d9;

--- a/src/components/ProjectBillingPage/index.jsx
+++ b/src/components/ProjectBillingPage/index.jsx
@@ -297,7 +297,7 @@ const ProjectBillingPage = (props) => {
                         </div>
                         <div className={styles.ResourcePrice}>
                           {/**display in dollars, covert back form percentages to dollars*/}
-                          {((data1[index % data1.length].value)*(newObject.totalCost/100)).toFixed(2)}
+                          ${((data1[index % data1.length].value)*(newObject.totalCost/100)).toFixed(2)}
                         </div>
                       </div>
                     ))}
@@ -306,7 +306,7 @@ const ProjectBillingPage = (props) => {
                       <div className={styles.ResourcePrice}>
                         {Object.keys(newObject).length === 0
                           ? "n/a"
-                          : `${(newObject.totalCost).toFixed(2)}`}
+                          : `$${(newObject.totalCost).toFixed(2)}`}
                       </div>
                     </div>
                   </div>
@@ -413,7 +413,7 @@ const ProjectBillingPage = (props) => {
                             </span>
                           </div>
                           <div className={styles.TransactionHistoryCell}>
-                            {entry.amount.toLocaleString("en-US")}
+                            UGX {entry.amount.toLocaleString("en-US")}
                           </div>
                           <div className={styles.TransactionHistoryCell}>
                             <button

--- a/src/components/SpendingPeriod/index.js
+++ b/src/components/SpendingPeriod/index.js
@@ -80,9 +80,10 @@ const SpendingPeriod = (props) => {
   }, []);
 
   return (
-
+   
     <div className="SprendPeriodContainer">
       <div className="SpendPeriodButtonsSection">
+        {props.period === "months" && <>
         <div
           className={`${period === "5m" && "PeriodButtonActive"} PeriodButton`}
           name="5m"
@@ -112,6 +113,46 @@ const SpendingPeriod = (props) => {
         >
           custom
         </div>
+         </>}
+         {props.period === "days" && <>
+        <div
+          className={`${period === "14d" && "PeriodButtonActive"} PeriodButton`}
+          name="14d"
+          value="14d"
+          role="presentation"
+          onClick={handleChange}
+        >
+          14 D
+        </div>
+        <div
+          className={`${period === "7d" && "PeriodButtonActive"} PeriodButton`}
+          name="7d"
+          value="7d"
+          role="presentation"
+          onClick={handleChange}
+        >
+          7 D
+        </div>
+        <div
+          className={`${period === "3d" && "PeriodButtonActive"} PeriodButton`}
+          name="3d"
+          value="3d"
+          role="presentation"
+          onClick={handleChange}
+        >
+          3 D
+        </div>
+        <div
+          className={`${period === "all" && "PeriodButtonActive"} PeriodButton`}
+          name="all"
+          value="all"
+          role="presentation"
+          onClick={handleChange}
+        >
+          all
+        </div>
+       
+         </>}
         {showModal && (
           <div ref={openModalRef} className="SpendCalendarModal">
               <div className="SpendSelectDate">


### PR DESCRIPTION
# Description

Due to kubecost limitations, the data returned is limitted to a few days so metrics had to be adjusted to cater for a day. it was also agued that a user would like to see the matrics they used in a day.  

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Trello Ticket ID

https://trello.com/c/VScuJoBj

## How Can This Been Tested?

Pull the branch and checkout the metrics bar graph on billing


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

![image](https://user-images.githubusercontent.com/69305400/170105260-52d8aa77-4213-4851-9fd9-44b180c84ab9.png)
