### PR TITLE
Add provision for description in credits modal

### DIFF
--- a/src/components/AdminProjectsPage/AdminProjectsPage.css
+++ b/src/components/AdminProjectsPage/AdminProjectsPage.css
@@ -10,3 +10,11 @@
     justify-content: space-between;
     padding-top: 2rem;
 }
+
+.CreditsTitle{
+    padding-top: 1rem;
+}
+
+.TextArea > ::placeholder{
+    padding-left: 1rem;
+}

--- a/src/components/AdminProjectsPage/index.js
+++ b/src/components/AdminProjectsPage/index.js
@@ -136,9 +136,19 @@ const AdminProjectsPage = () => {
               <Modal showModal={addCredits} onClickAway={() => hideModal()}>
                 <div className="ModalHeader">
                   <h5 className="ModalTitle">Add Credits</h5>
+
+                  <div className="">Number of credits</div>
                   <div className="ModalContent">
                     <BlackInputText required placeholder="Number of credits" />
                   </div>
+                  <div className="CreditsTitle">Description</div>
+                  <textarea
+                    className="TextArea"
+                    type="text"
+                    placeholder="Credits description"
+                    rows="4"
+                    cols="50"
+                  />
                 </div>
                 <div className="ModalFooter">
                   <div className="ModalButtons">


### PR DESCRIPTION
# Description

This PR adds a provision in the credits allocation modal thereby allowing a admin/organization to add a message.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?

Pull and run this branch locally, then visit the admins' projects dashboard and try allocating credits to a specific project

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

Before
![image](https://user-images.githubusercontent.com/84501941/177589095-f387b08a-e722-4f83-b892-3a9c0de98490.png)

After
![image](https://user-images.githubusercontent.com/84501941/177589469-43952272-aa59-4315-a409-e6503b17204c.png)

