### PR TITLE
Add no-resources message for no receipts and invoices returned

### DIFF
--- a/src/components/ProjectBillingPage/index.jsx
+++ b/src/components/ProjectBillingPage/index.jsx
@@ -114,8 +114,8 @@ const ProjectBillingPage = (props) => {
   const { projects } = useSelector((state) => state.userProjectsReducer);
   const { data } = useSelector((state) => state.user);
   const { transactions, isRetrieving, isFetched } = useSelector((state) => state.getTransactionsReducer);
-  const { invoices } = useSelector((state) => state.getInvoicesReducer);
-  const { receipts } = useSelector((state) => state.getReceiptsReducer);
+  const { invoices, isRetrievingInvoices, invoicesFetched } = useSelector((state) => state.getInvoicesReducer);
+  const { receipts, isRetrievingReceipts, receiptsFetched } = useSelector((state) => state.getReceiptsReducer);
 
   const handleConversion = () => {
     axios
@@ -640,7 +640,7 @@ const ProjectBillingPage = (props) => {
                 </>
                 }
 
-                {currentTab === "invoices" && (
+                {currentTab === "invoices" && !isRetrievingInvoices && invoicesFetched ? (
                   <div className={styles.InvoiceHistoryBody}>
                     <div className={styles.InvoiceHistoryTable}>
                       <div className={styles.InvoiceHistoryHead}>
@@ -683,9 +683,17 @@ const ProjectBillingPage = (props) => {
                       ))}
                     </div>
                   </div>
+                ):
+                <>
+                {currentTab === "invoices" && !isFetched && (
+                  <div className={styles.NoResourcesMesssage}>
+                      No invoices found under this project.
+                  </div>
                 )}
+                </>
+                }
 
-                {currentTab === "receipts" && (
+                {currentTab === "receipts" && !isRetrievingReceipts && receiptsFetched ? (
                   <div className={styles.ReceiptHistoryBody}>
                     <div className={styles.ReceiptHistoryTable}>
                       <div className={styles.ReceiptHistoryHead}>
@@ -737,7 +745,15 @@ const ProjectBillingPage = (props) => {
                       ))}
                     </div>
                   </div>
-                )}
+                ):
+                <>
+                 {currentTab === "receipts" && !receiptsFetched && (
+                  <div className={styles.NoResourcesMesssage}>
+                    No receipts found under this project.
+                  </div>
+                 )}
+                </>
+                }
               </div>
             </div>
 


### PR DESCRIPTION
# Description

This pull request hides table details when no receipts and invoices are returned

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?

Run this branch locally and checkout the `fx-invoice-receipts-tables` to notice change

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots
Before
![image](https://user-images.githubusercontent.com/84501941/180246515-3d43e34c-1243-437b-a4c2-418dc6a1d058.png)

After
![image](https://user-images.githubusercontent.com/84501941/180246728-d84d5f51-25a7-46e1-8d3a-628a02d36ece.png)

