### PR TITLE
Add provision on admin side to search through user accounts

### DIFF
--- a/src/components/UserAccounts/UserAccounts.css
+++ b/src/components/UserAccounts/UserAccounts.css
@@ -3,30 +3,62 @@
   background-color: #f9f9f9;
   position: absolute;
   box-shadow: 0 4px 4px 0 rgba(117, 117, 117, 0.2);
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Old versions of Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
+  -webkit-touch-callout: none;
+  /* iOS Safari */
+  -webkit-user-select: none;
+  /* Safari */
+  -khtml-user-select: none;
+  /* Konqueror HTML */
+  -moz-user-select: none;
+  /* Old versions of Firefox */
+  -ms-user-select: none;
+  /* Internet Explorer/Edge */
+  user-select: none;
+  /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 }
 
-.BetaUser{
+.BetaUser {
   display: flex;
   gap: 1rem;
 }
 
-.BetaUserText{
+.BetaUserText {
   text-align: center;
   font-size: 18px;
 }
-.creditCoin{
+
+.creditCoin {
   width: 1rem;
   height: 1rem;
 }
-.creditSection{
+
+.creditSection {
   display: flex;
   flex-direction: row;
   justify-content: center;
   gap: .4rem;
+}
+
+.AdminSearchInput {
+  padding-left: 1.5rem;
+  display: flex;
+}
+
+.AdminSearchInput input {
+  background-color: #EBEAD5;
+  color: #000;
+  border: 0;
+  border-top-left-radius: 4px 2px;
+  border-bottom-left-radius: 3px 4px;
+  font-size: 1rem;
+  padding: 1rem;
+  height: 45.5px;
+  max-width: 21rem;
+}
+
+.AdminNoResourcesMessage {
+  padding: 3rem;
+  display: flex;
+  text-align: center;
+  justify-content: center;
 }

--- a/src/components/UserAccounts/UserAccounts.test.js
+++ b/src/components/UserAccounts/UserAccounts.test.js
@@ -9,7 +9,7 @@ const UserAccountsProps = {
   getUsersList: jest.fn(),
 };
 
-describe("Testing the Project Settings Page component", () => {
+describe("Testing the User Accounts Page component", () => {
   const WrapperUserAccounts = UserAccounts.WrappedComponent;
   const UserAccountsComponent = shallow(
     <WrapperUserAccounts {...UserAccountsProps} />
@@ -21,6 +21,17 @@ describe("Testing the Project Settings Page component", () => {
   });
   it("matchs the UserAccounts component snapshot", () => {
     expect(UserAccountsComponent).toMatchSnapshot();
+  });
+  it("should check the search input field", () => {
+    UserAccountsComponent.find("input")
+      .props()
+      .onChange({
+        target: {
+          name: "rhod",
+          value: "rhodin",
+        },
+      });
+    expect(UserAccountsComponent.state("input")).toBeUndefined();
   });
 });
 
@@ -36,11 +47,10 @@ describe("Testing the exported mapstate to props and dispatch for UserAccounts",
           error: "",
         },
         addUserCreditsReducer: {
-           Added: false,
-            Adding: false, 
-            Failed:false,
-        }
-
+          Added: false,
+          Adding: false,
+          Failed: false,
+        },
       })
     ).toEqual({
       isAdded: false,
@@ -49,8 +59,8 @@ describe("Testing the exported mapstate to props and dispatch for UserAccounts",
       isFailed: false,
       isFetched: false,
       Added: false,
-      Adding: false, 
-      Failed:false,
+      Adding: false,
+      Failed: false,
       error: "",
     });
   });

--- a/src/components/UserAccounts/__snapshots__/UserAccounts.test.js.snap
+++ b/src/components/UserAccounts/__snapshots__/UserAccounts.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing the Project Settings Page component matchs the UserAccounts component snapshot 1`] = `ShallowWrapper {}`;
+exports[`Testing the User Accounts Page component matchs the UserAccounts component snapshot 1`] = `ShallowWrapper {}`;

--- a/src/components/UserAccounts/index.js
+++ b/src/components/UserAccounts/index.js
@@ -13,6 +13,7 @@ import SideNav from "../SideNav";
 import Modal from "../Modal";
 import { ReactComponent as Coin } from "../../assets/images/coin.svg";
 import { ReactComponent as MoreIcon } from "../../assets/images/more-verticle.svg";
+import { ReactComponent as SearchButton } from "../../assets/images/search.svg";
 import PrimaryButton from "../PrimaryButton";
 import addBetaUser from "../../redux/actions/addBetaUser";
 import Feedback from "../Feedback";
@@ -24,9 +25,11 @@ class UserAccounts extends Component {
       actionsMenu: false,
       betaUserModal: false,
       addCredits: false,
-      credits:"",
-      creditDescription:"",
+      credits: "",
+      creditDescription: "",
       selectedUser: "",
+      word: "",
+      SearchList: [],
     };
     this.showMenu = this.showMenu.bind(this);
     this.handleClick = this.handleClick.bind(this);
@@ -38,6 +41,8 @@ class UserAccounts extends Component {
     this.showCreditsModal = this.showCreditsModal.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.handleCreditSubmittion = this.handleCreditSubmittion.bind(this);
+    this.handleCallbackSearchword = this.handleCallbackSearchword.bind(this);
+    this.searchThroughAccounts = this.searchThroughAccounts.bind(this);
   }
   componentDidMount() {
     const { getUsersList } = this.props;
@@ -55,6 +60,30 @@ class UserAccounts extends Component {
       this.hideCreditsModal();
     }
   }
+
+  searchThroughAccounts() {
+    const { users } = this.props;
+    const { word } = this.state;
+    let resultsList = [];
+    users.forEach((element) => {
+      if (element.name.toLowerCase().includes(word.toLowerCase())) {
+        resultsList.push(element);
+      }
+    });
+    this.setState({ searchList: resultsList });
+  }
+
+  handleCallbackSearchword({ target }) {
+    const { value } = target;
+    this.setState({ word: value });
+    if (value !== "") {
+      this.searchThroughAccounts();
+    }
+    if (value === "") {
+      this.setState({ searchList: [] });
+    }
+  }
+
   handleClick = (e) => {
     if (this.state.actionsMenu) {
       // this.closeModal();
@@ -81,43 +110,40 @@ class UserAccounts extends Component {
       betaUserModal: true,
     });
   }
-  handleCreditSubmittion(){
-    const {credits, creditDescription,selectedUser} = this.state;
+  handleCreditSubmittion() {
+    const { credits, creditDescription, selectedUser } = this.state;
     const { addUserCredits } = this.props;
-    if(credits !== ""  && creditDescription !== ""){
-        const creditsObject={
-            amount: credits,
-            description: creditDescription,
-            user_id: selectedUser
-          }
-          addUserCredits(creditsObject);
+    if (credits !== "" && creditDescription !== "") {
+      const creditsObject = {
+        amount: credits,
+        description: creditDescription,
+        user_id: selectedUser,
+      };
+      addUserCredits(creditsObject);
     }
-
   }
-   showCreditsModal() {
+  showCreditsModal() {
     this.setState({
-      addCredits:true,
-    })
-  };
+      addCredits: true,
+    });
+  }
   hideCreditsModal = () => {
     this.setState({
       addCredits: false,
-      actionsMenu:false,
+      actionsMenu: false,
     });
-    };
+  };
 
   closeBetaUserModal() {
     this.setState({
       betaUserModal: false,
     });
   }
-  handleChange(e){
-      this.setState({
-        [e.target.name]: e.target.value,
-      });  
+  handleChange(e) {
+    this.setState({
+      [e.target.name]: e.target.value,
+    });
   }
-
-
 
   handleBetaUserSubmit() {
     const { selectedUser } = this.state;
@@ -131,22 +157,38 @@ class UserAccounts extends Component {
 
   renderRedirect = () => {
     const { isAdded } = this.props;
-   
+
     if (isAdded) {
       return <Redirect to={`/accounts`} noThrow />;
     }
   };
-  
 
   render() {
-    const { users, isFetched, isFetching, isAdding, isFailed, error, isAdded, Adding, Failed } =
-      this.props;
+    const {
+      users,
+      isFetched,
+      isFetching,
+      isAdding,
+      isFailed,
+      error,
+      isAdded,
+      Adding,
+      Failed,
+    } = this.props;
     const clusterName = localStorage.getItem("clusterName");
     const {
       match: { params },
     } = this.props;
-    const { actionsMenu, selectedUser, betaUserModal, credits, creditDescription } = this.state;
-    
+    const {
+      actionsMenu,
+      selectedUser,
+      betaUserModal,
+      credits,
+      creditDescription,
+      word,
+      searchList,
+    } = this.state;
+
     return (
       <div className="MainPage">
         {isAdded ? this.renderRedirect() : null}
@@ -162,6 +204,19 @@ class UserAccounts extends Component {
               <InformationBar header="User Accounts" showBtn={false} />
             </div>
             <div className="ContentSection">
+              <div className="SearchBar">
+                <div className="AdminSearchInput">
+                  <input
+                    type="text"
+                    className="searchTerm"
+                    name="Searchword"
+                    placeholder="Search for account"
+                    value={word}
+                    onChange={this.handleCallbackSearchword}
+                  />
+                  <SearchButton className="SearchIcon" />
+                </div>
+              </div>
               <div
                 className={
                   isFetching
@@ -189,16 +244,26 @@ class UserAccounts extends Component {
                         </td>
                       </tr>
                     </tbody>
-                  ) : (
+                  ) : word !== "" ? (
                     <tbody>
                       {isFetched &&
-                        users !== undefined &&
-                        users?.map((user) => (
+                        searchList.map((user) => (
                           <tr key={users.indexOf(user)}>
                             <td>{user?.name}</td>
                             <td>{user.is_beta_user ? "True" : "False"}</td>
-                            <td>{user?.credits.length === 0 ?"No credits":
-                            <div className="creditSection">{user?.credits[0]?.amount}<div className="creditCoin"> <Coin title="credits"/></div></div>}</td>
+                            <td>
+                              {user?.credits.length === 0 ? (
+                                "No credits"
+                              ) : (
+                                <div className="creditSection">
+                                  {user?.credits[0]?.amount}
+                                  <div className="creditCoin">
+                                    {" "}
+                                    <Coin title="credits" />
+                                  </div>
+                                </div>
+                              )}
+                            </td>
                             <td>{user?.email}</td>
                             <td
                               onClick={(e) => {
@@ -217,13 +282,70 @@ class UserAccounts extends Component {
                                     >
                                       Add Beta User
                                     </div>
-                                    { <div
+                                    {
+                                      <div
+                                        className="DropDownLink"
+                                        role="presentation"
+                                        onClick={this.showCreditsModal}
+                                      >
+                                        Assign credits
+                                      </div>
+                                    }
+                                  </div>
+                                </div>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  ) : (
+                    <tbody>
+                      {isFetched &&
+                        users !== undefined &&
+                        users?.map((user) => (
+                          <tr key={users.indexOf(user)}>
+                            <td>{user?.name}</td>
+                            <td>{user.is_beta_user ? "True" : "False"}</td>
+                            <td>
+                              {user?.credits.length === 0 ? (
+                                "No credits"
+                              ) : (
+                                <div className="creditSection">
+                                  {user?.credits[0]?.amount}
+                                  <div className="creditCoin">
+                                    {" "}
+                                    <Coin title="credits" />
+                                  </div>
+                                </div>
+                              )}
+                            </td>
+                            <td>{user?.email}</td>
+                            <td
+                              onClick={(e) => {
+                                this.showMenu(user.id);
+                                this.handleClick(e);
+                              }}
+                            >
+                              <MoreIcon />
+                              {actionsMenu && user.id === selectedUser && (
+                                <div className="BelowHeader bg-light">
+                                  <div className="context-menu">
+                                    <div
                                       className="DropDownLink"
                                       role="presentation"
-                                      onClick={this.showCreditsModal}
+                                      onClick={this.showBetaUserModal}
                                     >
-                                      Assign credits
-                                    </div> }
+                                      Add Beta User
+                                    </div>
+                                    {
+                                      <div
+                                        className="DropDownLink"
+                                        role="presentation"
+                                        onClick={this.showCreditsModal}
+                                      >
+                                        Assign credits
+                                      </div>
+                                    }
                                   </div>
                                 </div>
                               )}
@@ -234,12 +356,12 @@ class UserAccounts extends Component {
                   )}
                 </table>
                 {isFetched && users.length === 0 && (
-                  <div className="NoResourcesMessage">
+                  <div className="AdminNoResourcesMessage">
                     <p>No Users Available</p>
                   </div>
                 )}
                 {!isFetching && !isFetched && (
-                  <div className="NoResourcesMessage">
+                  <div className="AdminNoResourcesMessage">
                     <p>
                       Oops! Something went wrong! Failed to retrieve Available
                       Users.
@@ -248,14 +370,17 @@ class UserAccounts extends Component {
                 )}
               </div>
             </div>
-            <Modal showModal={this.state.addCredits} onClickAway={() => this.hideCreditsModal()}>
-                <div className="ModalHeader">
-                  <h5 className="ModalTitle">Add Credits</h5>
+            <Modal
+              showModal={this.state.addCredits}
+              onClickAway={() => this.hideCreditsModal()}
+            >
+              <div className="ModalHeader">
+                <h5 className="ModalTitle">Add Credits</h5>
 
-                  <div className="">Number of credits</div>
-                  <div className="ModalContent">
-                    <BlackInputText 
-                    required 
+                <div className="">Number of credits</div>
+                <div className="ModalContent">
+                  <BlackInputText
+                    required
                     placeholder="Number of credits"
                     name="credits"
                     type="number"
@@ -263,41 +388,41 @@ class UserAccounts extends Component {
                     onChange={(e) => {
                       this.handleChange(e);
                     }}
-                    />
-                  </div>
-                  <div className="CreditsTitle">Description</div>
-                  <textarea
-                    className="TextArea"
-                    type="text"
-                    placeholder="Credits description"
-                    rows="4"
-                    cols="50"
-                    name="creditDescription"
-                    value={creditDescription}
-                    onChange={(e) => {
-                      this.handleChange(e);
-                    }}
                   />
                 </div>
-                <div className="ModalFooter">
-                  <div className="ModalButtons">
-                    <PrimaryButton
-                      className="CancelBtn"
-                      label="Cancel"
-                      onClick={() => this.hideCreditsModal()}
-                    />
+                <div className="CreditsTitle">Description</div>
+                <textarea
+                  className="TextArea"
+                  type="text"
+                  placeholder="Credits description"
+                  rows="4"
+                  cols="50"
+                  name="creditDescription"
+                  value={creditDescription}
+                  onChange={(e) => {
+                    this.handleChange(e);
+                  }}
+                />
+              </div>
+              <div className="ModalFooter">
+                <div className="ModalButtons">
+                  <PrimaryButton
+                    className="CancelBtn"
+                    label="Cancel"
+                    onClick={() => this.hideCreditsModal()}
+                  />
 
-                    <PrimaryButton type="button" label={Adding? <Spinner/>: "Add"}   
-                    onClick={() => this.handleCreditSubmittion()}/>
-                  </div>
-                  {Failed && (
-                  <Feedback
-                    message={"failed to add credits"}
-                    type={"error"}
+                  <PrimaryButton
+                    type="button"
+                    label={Adding ? <Spinner /> : "Add"}
+                    onClick={() => this.handleCreditSubmittion()}
                   />
-                )}
                 </div>
-              </Modal>
+                {Failed && (
+                  <Feedback message={"failed to add credits"} type={"error"} />
+                )}
+              </div>
+            </Modal>
             <Modal
               showModal={betaUserModal}
               onClickAway={this.closeBetaUserModal}
@@ -360,7 +485,18 @@ export const mapStateToProps = (state) => {
   const { isFetching, users, isFetched } = state.usersListReducer;
   const { isAdded, isAdding, isFailed, error } = state.addBetaUserReducer;
   const { Added, Adding, Failed } = state.addUserCreditsReducer;
-  return { isFetching, users, isFetched, isAdded, isAdding, isFailed, error, Added, Adding, Failed };
+  return {
+    isFetching,
+    users,
+    isFetched,
+    isAdded,
+    isAdding,
+    isFailed,
+    error,
+    Added,
+    Adding,
+    Failed,
+  };
 };
 
 const mapDispatchToProps = {


### PR DESCRIPTION
# Description

This pull request basically adds a search field on the Admin side of user accounts to simply filter and make users either beta users or allocate credits or view their profiles.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?

Pull and run this branch localy then visit the User accounts page on the admin side inorder to realize the change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![user-accounts-page](https://user-images.githubusercontent.com/63339234/182592752-222c5f5c-7eaa-47e4-91a7-4fb61ba82c7f.gif)

