### PR TITLE
added css for select drop border-radius

### DIFF
--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -7,6 +7,7 @@
 
 .SelectElementMain {
   border: 1px solid #000000;
+  border-radius: 0.3rem;
 }
 
 .SelectElementValue {


### PR DESCRIPTION
# Description

Changed border-radius to the select drop-down  to 0.3rem
## Type of change



- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/ssmXWUnS

## How Can This Been Tested?

you can check it out on your local machines and the try to create the new app and observe the new design on the select drop-down.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2022-11-01 at 12-45-48 Crane Cloud Automated Application Deployment Scaling and Management](https://user-images.githubusercontent.com/110970478/199216016-3fa91ea1-2aeb-40d4-a396-070112117865.png)
