### PR TITLE
give users new profile identity

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -112,6 +112,43 @@
   color: #000;
   text-decoration: none;
 }
+.UserInformation{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+.UserInformation:hover,
+.UserInformation:active {
+  background-color: #f1f1f1;
+}
+.UserInformation,
+.UserInformation:visited {
+  color: #000;
+  text-decoration: none;
+}
+.UserDetails{
+  text-align: center;
+  font-size: .7rem;
+  font-weight: 300;
+  overflow-wrap: break-word;
+  inline-size:90%;
+  justify-content: center;
+}
+.UserAvatar {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  text-align: center;
+  font-weight: bold;
+  font-size: .9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 a.HeaderLinkBackToConsole {
   text-transform: uppercase;
   border: 2px solid #ffffff;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, withRouter, matchPath } from "react-router-dom";
 import { connect } from "react-redux";
+import Avatar from "../Avatar";
 import PropTypes from "prop-types";
 import Logo from "../Logo";
 import { ReactComponent as DownArrow } from "../../assets/images/downarrow.svg";
@@ -54,6 +55,7 @@ const Header = (props) => {
   }, []);
 
   const { credits } = props;
+
   return (
     <header className={`${styles.Header} SmallContainer`}>
       <Logo />
@@ -103,6 +105,13 @@ const Header = (props) => {
             <DownArrow className={styles.DropdownArrowSvg} />
             {hidden && (
               <div className={styles.BelowHeader}>
+                <div className={styles.UserInformation}>
+                <Avatar name={user.data.name} className={styles.UserAvatar} />
+                  <div className={styles.UserDetails}>
+                    {user.data.name.split(' ').slice(-1).join(' ')}</div>
+                  <div className={styles.UserDetails}>
+                    {user.data.email}</div>
+                </div>
                 <div className={styles.DropDownContent}>
                   <Link to={`/profile`} className={styles.DropDownLink}>
                     Profile

--- a/src/components/RegisterPage/index.js
+++ b/src/components/RegisterPage/index.js
@@ -18,6 +18,7 @@ export default class RegisterPage extends Component {
 
     this.state = {
       name: "",
+      username:"",
       email: "",
       password: "",
       passwordConfirm: "",
@@ -88,15 +89,16 @@ export default class RegisterPage extends Component {
   handleSubmit(e) {
     e.preventDefault();
 
-    const { name, email, password, passwordConfirm, hasAgreed } = this.state;
+    const { name,username, email, password, passwordConfirm, hasAgreed } = this.state;
 
     const userData = {
       name,
+      username,
       email,
       password,
     };
 
-    if (!email || !password || !name || !passwordConfirm) {
+    if (!email || !password || !name || !username ||!passwordConfirm) {
       this.setState({
         error: "Please enter all fields",
       });
@@ -123,7 +125,6 @@ export default class RegisterPage extends Component {
       this.setState({
         loading: true,
       });
-
       axios
         .post(`${API_BASE_URL}/users`, userData)
         .then((response) => {
@@ -151,6 +152,7 @@ export default class RegisterPage extends Component {
       passwordConfirm,
       loading,
       registered,
+      username,
       error,
       hasAgreed,
       gitLoading,
@@ -172,6 +174,13 @@ export default class RegisterPage extends Component {
                     placeholder="Name"
                     name="name"
                     value={name}
+                    onChange={this.handleOnChange}
+                  />
+                   <InputText
+                    required
+                    placeholder="Username"
+                    name="username"
+                    value={username}
                     onChange={this.handleOnChange}
                   />
                   <InputText

--- a/src/components/UserProfile/UserProfile.module.css
+++ b/src/components/UserProfile/UserProfile.module.css
@@ -10,7 +10,9 @@
     align-items: center;
     padding: 12rem;
   }
-  
+  .Page{
+    background-color: #F1F1F1;
+  }
   .ButtonPlusSmall {
     width: 1rem;
     height: 1rem;
@@ -22,11 +24,12 @@
 
   }
   .MainColumn{
-    padding: .5rem 2rem 0rem 2rem;
+    padding: .5rem 5rem 0rem 4rem;
   }
   .BackButton {
     color: #fff;
     width: fit-content;
+    height: 2rem;
     background-color: #008ac1;
     outline: 1px solid #008ac1;
   }
@@ -34,6 +37,19 @@
     color: #008ac1;
     background-color: #fff;
     outline: 1px solid #008ac1;
+  }
+  .PairButtonCancel{
+    color: #fff;
+    width: fit-content;
+    height: 2rem;
+    padding-bottom: .5rem;
+    background-color: #000;
+    outline: 1px solid #000;
+  }
+  .PairButtonCancel:hover{
+    color: #000;
+    background-color: #fff;
+    outline: 1px solid #000;
   }
   .CreditsContainer{
     display: flex;
@@ -43,9 +59,14 @@
   }
   .rowContentYes{
     color: #008ac1;
+    font-weight: 700;
+  }
+  .RowContent{
+    font-weight: 700;
   }
   .rowContentNo{
     color: #d80000;
+    font-weight: 700;
   }
   .FooterRow {
     padding: 1rem 3rem;
@@ -54,23 +75,29 @@
   .UserContainer{
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     padding-bottom: 3rem;
+    padding-left: 5rem;
     padding-top: 1rem;
   }
- 
-  
+
   .UserAvatar {
-    width: 3rem;
-    height: 3rem;
+    width: 3.5rem;
+    height: 3.5rem;
     border-radius: 50%;
     text-align: center;
     font-weight: bold;
-    font-size: 1.5rem;
+    font-size: 2rem;
     display: flex;
     align-items: center;
     justify-content: center;
   }
+  .CardInfor{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
   .CustomInput{
     height: 2.5rem;
     padding: .3rem;
@@ -84,10 +111,41 @@
   }
   .InputDiv{
     display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1.5rem;
+    width: 100%;
+    padding: .3rem .3rem .7rem .3rem;
+  }
+  .PasswordChange{
+    display: flex;
     flex-direction: column;
+    align-items: flex-start;
     gap: .3rem;
     width: 100%;
-    padding: .3rem;
+    padding: .3rem .3rem .7rem .3rem;
+  }
+  .ExtraContentDiv{
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1rem 1rem 0;
+  }
+  .ContainerCard{
+    padding-left: 1rem;
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+    gap:.4rem;
+    flex-direction: column;
+    border-radius: 10px;
+    background-color: #fff;
+  }
+  .ButtonsDiv{
+    display: flex;
+    flex-direction: row;
+    gap:.5rem
   }
   
   .SectionTitle{
@@ -102,14 +160,98 @@
   
 
   .ContainerSection{
-    display: grid;
-    width: 100%;
-    grid-template-columns: 2fr 3fr;
+    display: flex;
+    width: 50rem;
+    padding-top: .5rem;
+    flex-direction: row;
+    justify-content: space-between;
     padding-bottom: .5rem;
     border-bottom: 1px solid #ccc;
   }
+  .ContainerHeadSection{
+    display: flex;
+    width: 50rem;
+    padding-bottom: .5rem;
+    border-bottom: 1px solid #ccc;
+  }
+  .ProfileCard{
+    display: flex;
+    width: 30rem;
+    height: 12rem;
+    gap:1rem;
+    padding-left: 1rem;
+    flex-direction: column;
+    border-radius: 10px;
+    background-color: #fff;
+    min-width: 20rem;
+    padding-right: 1rem;
+  }
+  .AvatarDiv{
+    display: flex;
+    flex-direction: row;
+    padding-top: .5rem;
+    height: 5rem;
+    align-items: center;
+  }
+  .Identity{
+    display: flex;
+    flex-direction: column;
+    padding-left: 1rem;
+  }
+  .IdentityName{
+    font-size: 2rem;
+    font-weight: 700;
+    color: #000;
+  }
+  .BackgroundInfor{
+    display: flex;
+    flex-direction: column;
+    width: 20rem;
+  }
+  .ProjectDeleteModel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+  .ProjectDeleteModel .ModalChildWrap {
+    z-index: 3;
+  }
+  .ProjectDeleteModel .ModalChildWrap {
+    min-width: 21rem;
+    max-width: 25rem;
+  }
+.ProjectDeleteModel .ModalParentWrap {
+  background-color: inherit;
+}
+.UpdateProjectModelButtons {
+  display: flex;
+  justify-content: space-between;
+}
+.ModelContent {
+  width: 23rem;
+}
+.ModelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 2rem;
+}
+.UpdateForm {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1.3rem;
+  grid-template-rows: 2fr;
+}
+.InformationText {
+  width: 20rem;
+}
   aside{
-    width: 70%;
+    width: 30rem;
   }
   .HeaderSection{
     display: flex;
@@ -123,6 +265,12 @@
     flex-direction: column;
     gap: 1.3rem;
     align-items: flex-start;
+  }
+  .FeedBackDiv{
+    color: rgb(28, 255, 28);
+  }
+  .ErrorDiv{
+    color: red;
   }
   
   
@@ -139,8 +287,23 @@
   @media only screen and (max-width: 900px)  {
     .ContainerSection{
       display: flex;
-      width: 100%;
       flex-direction: column;
+      width: auto;
+    }
+    .ContainerHeadSection{
+      width: auto;
+    }
+    .ProfileCard{
+      width: auto;
+    }
+    .MainColumn{
+      padding: .5rem 3rem 0rem 1rem;
+    }
+    .UserContainer{
+      padding-left: 0rem;
+    }
+    aside{
+      width: 23rem;
     }
   }
   

--- a/src/components/UserProfile/index.js
+++ b/src/components/UserProfile/index.js
@@ -3,16 +3,18 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import Avatar from "../Avatar";
 import styles from "./UserProfile.module.css";
+import { API_BASE_URL } from "../../config";
+import axios from "axios";
+import Modal from "../../components/Modal";
 import InformationBar from "../../components/InformationBar";
 import { Link } from "react-router-dom";
 import Header from "../../components/Header";
 import BlackInputText from "../BlackInputText";
-import InputPassword from "../InputPassword";
 import Spinner from "../../components/Spinner";
 import PrimaryButton from "../PrimaryButton";
 import getUserDetail from "../../redux/actions/userDetails";
 import BackButton from "../../assets/images/backButton.svg";
-import {updateProfile , clearUpdateProfileState} from "../../redux/actions/updateProfile";
+import { updateProfile, clearUpdateProfileState } from "../../redux/actions/updateProfile";
 import "../../index.css";
 import { ReactComponent as Coin } from "../../assets/images/coin.svg";
 
@@ -22,27 +24,54 @@ class UserProfile extends React.Component {
     super(props);
     const { name } = props.user
     this.initialState = {
-     username:name,
-     currentPassword:"",
-     newPassword:"",
-     confirmPassword:"",
+      username: name,
+      editMode: false,
+      showSaveModel: false,
+      passwordModel: false,
+      passwordChangeLoading: false,
+      passwordChangeError: "",
+      passwordChangeSuccess: ""
     };
     this.state = this.initialState;
     this.handleChange = this.handleChange.bind(this)
-    this.handleNameEdit = this.handleNameEdit.bind(this)
+    this.handleChangeSaving = this.handleChangeSaving.bind(this)
+    this.closeEditMode = this.closeEditMode.bind(this)
+    this.openEditMode = this.openEditMode.bind(this)
+    this.showSaveChangesModel = this.showSaveChangesModel.bind(this)
+    this.hideSaveChangesModel = this.hideSaveChangesModel.bind(this)
+    this.showPasswordWarningModel = this.showPasswordWarningModel.bind(this)
+    this.hidePasswordWarningModel = this.hidePasswordWarningModel.bind(this)
+    this.handlePasswordChanage = this.handlePasswordChanage.bind(this)
   }
 
   componentDidMount() {
     const { getUserDetail, data } =
       this.props;
-      clearUpdateProfileState();
-      getUserDetail(data.id);
-
+    clearUpdateProfileState();
+    getUserDetail(data.id);
   }
-  handleChange=(e)=>{
+  handleChange = (e) => {
     this.setState({
       [e.target.name]: e.target.value,
     });
+  }
+  showSaveChangesModel = () => {
+    this.setState({ showSaveModel: true })
+  }
+  hideSaveChangesModel = () => {
+    this.setState({ showSaveModel: false })
+  }
+  showPasswordWarningModel = () => {
+    this.setState({ passwordModel: true })
+  }
+  hidePasswordWarningModel = () => {
+    this.setState({ passwordModel: false })
+  }
+  closeEditMode() {
+    this.setState({ editMode: false })
+  }
+  openEditMode() {
+    this.setState({ editMode: true })
   }
   componentDidUpdate(prevProps) {
     const {
@@ -54,178 +83,270 @@ class UserProfile extends React.Component {
       window.location.href = "/";
     }
     if (user !== prevProps.user) {
-      this.setState({username:user.name})
+      this.setState({ username: user.name })
     }
   }
 
-  handleNameEdit(){
+  handleChangeSaving() {
     const { updateProfile, user } =
-    this.props;
-    const {username} = this.state
-   if(user.name !== username){
-     const update ={
-       name: username
-     }
+      this.props;
+    const { username } = this.state
+    if (user.name !== username) {
+      const update = {
+        name: username
+      }
       updateProfile(user.id, update)
-   }  
+    }
   }
+  handlePasswordChanage() {
+    const { user } = this.props;
+    const userResetEmail = { email: user.email };
+    this.setState({
+      passwordChangeLoading: true,
+    });
+    axios
+      .post(`${API_BASE_URL}/users/forgot_password`, userResetEmail)
+      .then((response) => {
+        if (response.data.status === "success") {
+          this.setState({
+            loading: false,
+            passwordChangeSuccess: "Please check your email. If you cant find the email, check the spam folder",
+          });
+          setTimeout(() => {
+            this.hidePasswordWarningModel()
+          }, 2000);
+        }
+      })
+      .catch((err) => {
+        this.setState({
+          passwordChangeLoading: false,
+          passwordChangeError: "Something went wrong",
+        });
+      });
 
-
+  }
   render() {
-    const { username,newPassword,confirmPassword,currentPassword } = this.state;
+    const options = { weekday: 'short', year: 'numeric', month: 'long', day: 'numeric' };
+    const { username, editMode, showSaveModel, passwordModel, passwordChangeError, passwordChangeSuccess, passwordChangeLoading } = this.state;
     const {
       user,
       isFetching,
       isFetched,
-      profileUpdating
+      profileUpdating,
+
     } = this.props;
 
     return (
       <div className={styles.Page}>
-          <div>
-            <div className={styles.TopRow}>
-              <Header />
-              <InformationBar
-                header="Profile"
-              />
-            </div>
-            <div className={styles.MainColumn}>
-              <Link
-                  to={`/projects`}>
-                    <img src={BackButton} alt="Back Button" />
-                  </Link>
-              {isFetching ? (
-                <div className={styles.NoResourcesMessage}>
-                  <div className={styles.SpinnerWrapper}>
-                    <Spinner size="big" />
-                  </div>
+        <div>
+          <div className={styles.TopRow}>
+            <Header />
+            <InformationBar
+              header="Profile"
+            />
+          </div>
+          <div className={styles.MainColumn}>
+            <Link
+              to={`/projects`}>
+              <img src={BackButton} alt="Back Button" />
+            </Link>
+            {isFetching ? (
+              <div className={styles.NoResourcesMessage}>
+                <div className={styles.SpinnerWrapper}>
+                  <Spinner size="big" />
                 </div>
-              ) : isFetched ? (
-                <div className={`${styles.ProjectList}  SmallContainer`}>
-                  {isFetched &&(
+              </div>
+            ) : isFetched ? (
+              <div className={`${styles.ProjectList}  SmallContainer`}>
+                {isFetched && (
                   <div className={styles.UserContainer}>
+                    <section className={styles.ContainerHeadSection}>
+                      <div className={styles.ProfileCard}>
+                        <div className={styles.AvatarDiv}>
+                          <Avatar name={user.name} className={styles.UserAvatar} />
+                          <div className={styles.Identity}>
+                            <div className={styles.IdentityName}>
+                              {user.name}
+                            </div>
+                            <div className={styles.IdentityInfor}>
+                              <div>{user.name.split(' ').slice(-1).join(' ')}</div>
+                              {user.email}
+                            </div>
+                          </div>
+                        </div>
+                        <div className={styles.BackgroundInfor}>
+                          <div>Joined crane cloud on {new Date(user.date_created).toLocaleDateString("en-US", options)}
+                          </div>
+                          <div className={styles.CardInfor}>
+                            <div>Created 3 projects</div> <div>Shares 2 projects</div>
+                          </div>
+                        </div>
+                      </div>
+                    </section>
                     <section className={styles.ContainerSection}>
                       <div className={styles.HeaderSection}>
                         <div className={styles.SectionTitle}>Information</div>
                         <div className={styles.SectionSubTitle}>Your identity on crane cloud</div>
                       </div>
                       <aside>
-                         <div className={styles.EmailHead}>
-                         <Avatar name={user.name} className={styles.UserAvatar}/>
-                         {/* not editable */}
-                         <div className={styles.InputDiv}>
-                         Email
-                         <BlackInputText 
-                         className={styles.CustomInput}
-                         name={user.email}
-                         value={user.email}
-                         />
-                         </div>
-                         </div>   
-                         <div className={styles.InputDiv}>
-                          Name
-                         <BlackInputText
-                          className={styles.CustomInput} 
-                          placeholder=""
-                           name="username"
-                          value={username}
-                          onChange={(e) => {
-                             this.handleChange(e);
-                         }}
-                        />{user.name!==username?.trim() && <PrimaryButton
-                         label= { profileUpdating ? <Spinner /> :"EDIT NAME"}
-                         onClick={()=>{this.handleNameEdit()}}
-                         className={styles.BackButton} 
-                         />}
-                         </div>  
+                        <div className={styles.ContainerCard}>
+                          <div className={styles.EmailHead}>
+                            <Avatar name={user.name} className={styles.UserAvatar} />
+                            {/* not editable */}
+                            <div className={styles.InputDiv}>
+                              Email
+                              <div>{user.email}</div>
+                            </div>
+                          </div>
+                          <div className={styles.InputDiv}>
+                            Name
+                            {editMode ? <BlackInputText
+                              className={styles.CustomInput}
+                              placeholder=""
+                              name="username"
+                              value={username}
+                              onChange={(e) => {
+                                this.handleChange(e);
+                              }}
+                            /> : <div>{user.name}</div>}
+                          </div>
+                          {editMode && <div className={styles.PasswordChange}>
+                            <div>Change Password</div>
+                            <PrimaryButton
+                              label={"Reset password by email"}
+                              onClick={() => {this.showPasswordWarningModel()}}
+                              className={styles.BackButton}
+                            />
+                          </div>}
+                          {editMode ? <div className={styles.ButtonsDiv}>
+                            <PrimaryButton
+                              label={"Save"}
+                              onClick={() => { user.name !== username && this.showSaveChangesModel() }}
+                              className={styles.BackButton}
+                            />
+                            <PrimaryButton
+                              label={"Cancel"}
+                              onClick={() => { this.closeEditMode() }}
+                              className={styles.PairButtonCancel}
+                            />
+                          </div> :
+                            <PrimaryButton
+                              label={"Edit profile"}
+                              onClick={() => { this.openEditMode() }}
+                              className={styles.BackButton}
+                            />}
+                        </div>
                       </aside>
                     </section>
                     <section className={styles.ContainerSection}>
                       <div className={styles.HeaderSection}>
-                        <div className={styles.SectionTitle}>Password</div>
-                        <div className={styles.SectionSubTitle}>Change your password</div>
+                        <div className={styles.SectionTitle}>More information</div>
+                        <div className={styles.SectionSubTitle}>More information about a user</div>
                       </div>
                       <aside>
-                         <div className={styles.InputDiv}>
-                         Current password
-                         <InputPassword
-                          className={styles.CustomPasswordInput} 
-                          placeholder=""
-                           name="currentPassword"
-                          value={currentPassword}
-                          onChange={(e) => {
-                             this.handleChange(e);
-                         }}
-                        />
-                        <div className={styles.SectionSubTitle}> You should provide old password first</div>
-                         </div>    
-                         <div className={styles.InputDiv}>
-                         New password
-                         <InputPassword
-                          className={styles.CustomPasswordInput} 
-                          placeholder=""
-                           name="newPassword"
-                          value={newPassword}
-                          onChange={(e) => {
-                             this.handleChange(e);
-                         }}
-                        />
-                         </div> 
-                         <div className={styles.InputDiv}>
-                         Confirm password
-                         <InputPassword
-                          className={styles.CustomPasswordInput} 
-                          placeholder=""
-                          name="confirmPassword"
-                          value={confirmPassword}
-                          onChange={(e) => {
-                             this.handleChange(e);
-                         }}
-                        />
-                         </div> 
-                         {<div className={styles.ButtonDiv}>
-                         {(newPassword !=="" && confirmPassword !=="" && currentPassword!=="") && <PrimaryButton
-                         label= { profileUpdating ? <Spinner /> :"CHANGE PASSWORD"}
-                         onClick={()=>{}}
-                         className={styles.BackButton} 
-                         />}
-                         </div>} 
+                        <div className={styles.ContainerCard}>
+
+                          <div className={styles.ExtraContentDiv}>
+                            <div>
+                              <div className={styles.SectionTitle}>Credits</div>
+                              <div className={styles.SectionSubTitle}>Assigned by Admin for billing purporses</div>
+                            </div>
+                            <div className={styles.RowContent}>{user.credits.length === 0 ? "0 credits" : <div className={styles.CreditsContainer}> {user.credits[0].amount}
+                              <div className={styles.CoinSize}>
+                                <Coin />
+                              </div></div>}</div>
+                          </div>
+                          <div className={styles.ExtraContentDiv}>
+                            <div className={styles.SectionTitle}>Beta User</div>
+                            <div className={user.is_beta_user === true ?
+                              styles.rowContentYes : styles.rowContentNo}>{user.is_beta_user === true ? "Yes" : "No"}</div>
+                          </div>
+                        </div>
                       </aside>
                     </section>
-                    <section className={styles.ContainerSection}>
-                    <div className={styles.HeaderSection}>
-                      <div className={styles.SectionTitle}>More information</div>
-                      <div className={styles.SectionSubTitle}>More information about a user</div>
-                    </div>
-                    <aside>
-                       <div className={styles.InputDiv}>
-                       <div className={styles.SectionTitle}>Beta User</div>
-                       <div className={user.is_beta_user ===true ?
-                        styles.rowContentYes:styles.rowContentNo}>{user.is_beta_user ===true ? "Yes":"No"}</div>
-                       </div>   
-                       <div className={styles.InputDiv}>
-                       <div className={styles.SectionTitle}>Credits</div>
-                       <div className={styles.SectionSubTitle}>Assigned by Admin for billing purporses</div>
-                       <div className={styles.RowContent}>{user.credits.length===0? "No credits":<div className={styles.CreditsContainer}> {user.credits[0].amount}
-                       <div className={styles.CoinSize}>
-                       <Coin/>
-                       </div></div>}</div>
-                       </div> 
-                    </aside>
-                  </section>
                   </div>)
-                   }
-                </div>
-              ): null}
-              
-              {!isFetching && !isFetched && (
-                <div className={styles.NoResourcesMessage}>
-                  Oops! Something went wrong! Failed to retrieve user.
-                </div>
-              )}
-            </div>
+                }
+              </div>
+            ) : null}
+
+            {!isFetching && !isFetched && (
+              <div className={styles.NoResourcesMessage}>
+                Oops! Something went wrong! Failed to retrieve user.
+              </div>
+            )}
           </div>
-     
+        </div>
+        {showSaveModel === true && (
+          <div className={styles.ProjectDeleteModel}>
+            <Modal
+              showModal={showSaveModel}
+              onClickAway={() => { this.hideSaveChangesModel() }}
+            >
+              <div className={styles.ModelContent}>
+                <div className={styles.ModelHeader}>
+                  Save Changes
+                </div>
+                <div className={styles.UpdateForm}>
+                  <div className={styles.InformationText}>
+                    Confirm you want to save new changes, this will log you out automatically.
+                  </div>
+                  <div className={styles.UpdateProjectModelButtons}>
+                    <PrimaryButton
+                      label={profileUpdating ? <Spinner /> : "Confirm"}
+                      className={styles.BackButton}
+                      onClick={() => { this.handleChangeSaving() }}
+                    />
+                    <PrimaryButton
+                      label="Cancel"
+                      className={styles.PairButtonCancel}
+                      onClick={() => { this.hideSaveChangesModel() }}
+                    />
+                  </div>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        )}
+        {passwordModel === true && (
+          <div className={styles.ProjectDeleteModel}>
+            <Modal
+              showModal={passwordModel}
+              onClickAway={() => { this.hidePasswordWarningModel() }}
+            >
+              <div className={styles.ModelContent}>
+                <div className={styles.ModelHeader}>
+                  Change Password
+                </div>
+                <div className={styles.UpdateForm}>
+                  <div className={styles.InformationText}>
+                    Confirm and an email to edit your password will be sent to you.
+                    Redo the process in case you don't recieve the email
+                  </div>
+                  <div className={styles.UpdateProjectModelButtons}>
+                    <PrimaryButton
+                      label={passwordChangeLoading ? <Spinner /> : "Confirm"}
+                      className={styles.BackButton}
+                      onClick={() => { this.handlePasswordChanage() }}
+                    />
+                    <PrimaryButton
+                      label="Cancel"
+                      className={styles.PairButtonCancel}
+                      onClick={() => { this.hidePasswordWarningModel() }}
+                    />
+                  </div>
+                  <div>
+                    {passwordChangeSuccess && (
+                      <div className={styles.FeedBackDiv}>{passwordChangeSuccess}</div>
+                    )}
+                    {passwordChangeError && (
+                      <div className={styles.ErrorDiv}>{passwordChangeError}</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        )}
         <div className={styles.FooterRow}>
           <div>
             Copyright {new Date().getFullYear()} Crane Cloud. All Rights
@@ -250,9 +371,9 @@ UserProfile.propTypes = {
   isFetched: PropTypes.bool,
   message: PropTypes.string,
   isFetching: PropTypes.bool,
-  profileUpdated:PropTypes.bool,
-  profileUpdating:PropTypes.bool,
-  profileUpdateFailed:PropTypes.bool,
+  profileUpdated: PropTypes.bool,
+  profileUpdating: PropTypes.bool,
+  profileUpdateFailed: PropTypes.bool,
 };
 
 UserProfile.defaultProps = {
@@ -260,19 +381,19 @@ UserProfile.defaultProps = {
   message: "",
   isFetched: false,
   isFetching: false,
-  profileUpdated:false,
-  profileUpdating:false,
-  profileUpdateFailed:false,
+  profileUpdated: false,
+  profileUpdating: false,
+  profileUpdateFailed: false,
 };
 
 export const mapStateToProps = (state) => {
-    const { data } = state.user;
-  const { isFetching, user, isFetched,message } = state.userDetailReducer;
-  const{profileUpdateFailed,
+  const { data } = state.user;
+  const { isFetching, user, isFetched, message } = state.userDetailReducer;
+  const { profileUpdateFailed,
     profileUpdated,
     profileUpdating,
     errorMessage,
-  }= state.updateProfileReducer;
+  } = state.updateProfileReducer;
   return {
     isFetching,
     user,


### PR DESCRIPTION
# Description

Give the user profile page a new look according to the design and password reset functionality.
Also adds dropdown profile view and username field on registration

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID
https://trello.com/c/iRkWbLSJ
## How Can This Been Tested?
 
check this branch out, navigate to the profile page and attempt to interact with it. Check out the register page for a new username field.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots
profile page in edit mode
![image](https://user-images.githubusercontent.com/69305400/200617845-e0bbe08c-953b-4a41-aa54-08b4b79faa82.png)
profile page not in edit mode
![image](https://user-images.githubusercontent.com/69305400/200617925-d8acddc9-6c22-419a-b034-307da22af3d5.png)
new drop down look
![image](https://user-images.githubusercontent.com/69305400/200618050-7a4a8424-e54f-4a05-9607-70e126380a63.png)
new username field
![image](https://user-images.githubusercontent.com/69305400/200618161-3ccafc21-a7ef-45dd-adcd-1b78dcbaeb84.png)


