### PR TITLE
Remove  strict validation on project organisation

### DIFF
--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -46,11 +46,9 @@ export const validateProjectDescription = (description) => {
 
 export const validateOrganizationName = (name) => {
   if (
-    !name ||
-    validateName(name) === false ||
-    validateName(name) === "false_convention"
+    !name
   ) {
-    return "Remove spaces and Project organisation must start with a letter and may only contain letters and a hypen -";
+    return "Organisation field can't be an empty";
   }
 };
 


### PR DESCRIPTION
# Description

Enables users add organisation names with spaces

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Trello Ticket ID
https://trello.com/c/TkeVLqKc

## How Can This Been Tested?

try to create a new project and user an organisation name you would like say "makerere university"


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

not needed