### PR TITLE
Added the password visibility toggle icon on the app form creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
- 
-# use an official node runtime as the base image
+ # use an official node runtime as the base image
 FROM node:10.16.0-alpine
 
 # set the (container) working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-  
+ 
 # use an official node runtime as the base image
 FROM node:10.16.0-alpine
 

--- a/src/components/CreateApp/index.js
+++ b/src/components/CreateApp/index.js
@@ -19,6 +19,8 @@ import Tabs from "../Tabs";
 import styles from "./CreateApp.module.css";
 import { validateName } from "../../helpers/validation";
 import MiraPage from "../../pages/MiraPage";
+import { ReactComponent as Open } from "../../assets/images/open.svg";
+import { ReactComponent as Closed } from "../../assets/images/close.svg";
 
 const dockerEmail = process.env.REACT_APP_DOCKER_EMAIL;
 const dockerPassword = process.env.REACT_APP_DOCKER_PASSWORD;
@@ -50,6 +52,7 @@ class CreateApp extends React.Component {
         password: "",
         server: "",
         error: "",
+        passwordShown: false,
       },
       replicas: 1,
       multiCluster: false,
@@ -77,6 +80,7 @@ class CreateApp extends React.Component {
       this.changeMultiSelectionOption.bind(this);
     this.handleOnChange = this.handleOnChange.bind(this);
     this.createNewApp = this.createNewApp.bind(this);
+    this.togglePassword = this.togglePassword.bind(this);
   }
   handleOnChange(position) {
     const { SelectedClusters } = this.state;
@@ -121,6 +125,11 @@ class CreateApp extends React.Component {
 
   hideForm() {
     this.setState(this.initialState);
+  }
+
+  togglePassword() {
+    //this.setState({ hidden: !this.state.hidden });
+    this.setState({ passwordShown: !this.state.passwordShown });
   }
 
   validateDomainName(domainName) {
@@ -378,6 +387,7 @@ class CreateApp extends React.Component {
       addingApp,
       addErrorCode,
       addAppError,
+      passwordShown,
     } = this.state;
 
     const replicaOptions = [
@@ -489,17 +499,25 @@ class CreateApp extends React.Component {
                               this.handleDockerCredentialsChange(e);
                             }}
                           />
+                          <div className="password-wrappers">
+                            <BlackInputText
+                              required
+                              placeholder="Password"
+                              name="password"
+                              type={passwordShown ? "text" : "password"}
+                              value={password}
+                              onChange={(e) => {
+                                this.handleDockerCredentialsChange(e);
+                              }}
+                            />
 
-                          <BlackInputText
-                            required
-                            placeholder="Password"
-                            type="password"
-                            name="password"
-                            value={password}
-                            onChange={(e) => {
-                              this.handleDockerCredentialsChange(e);
-                            }}
-                          />
+                            <div
+                              className="password"
+                              onClick={this.togglePassword}
+                            >
+                              {passwordShown ? <Open /> : <Closed />}
+                            </div>
+                          </div>
                           <div className={styles.InputFieldWithTooltip}>
                             <BlackInputText
                               required


### PR DESCRIPTION
# Description

This PR aims to add the hide and show functionality for the password field under the private image section


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Trello Ticket ID
https://trello.com/c/unNefFUU

## How Can This Been Tested?

Run this branch locally and checkout the private image section under app deployment form


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot from 2023-07-04 22-41-21](https://github.com/crane-cloud/frontend/assets/108899937/4c83b83c-d9be-4b23-a090-f9c8037c96f3)
