### PR TITLE
Move non cluster bound items out of the side navigation

### DIFF
--- a/src/components/InformationBar/index.js
+++ b/src/components/InformationBar/index.js
@@ -21,6 +21,7 @@ const InformationBar = ({
   placeholder,
   searchAction,
   adminRoute,
+  dashboard,
   adminProjects,
   selectedProjects,
   handleTabChange,
@@ -37,7 +38,7 @@ const InformationBar = ({
     setSearchword(value);
     searchAction(value);
   };
-return (
+  return (
     <div className="InformationBar SmallContainer">
       {status ? (
         <div className="InformationBarWithButton">
@@ -77,7 +78,9 @@ return (
                         ? "InfoCurrentTab"
                         : "InfoTab"
                     }
-                    onClick={() => handleSharedProjectsTabChange("SharedProjects")}
+                    onClick={() =>
+                      handleSharedProjectsTabChange("SharedProjects")
+                    }
                   >
                     <span>
                       <Users className="SmallerIcon" />
@@ -106,29 +109,30 @@ return (
                 </div>
               </div>
               <div className="ButtonWrap">
-                {adminRoute &&
-                  (adminProjects ? (
-                    <Link
-                      to={{
-                        pathname: `/projects`,
-                      }}
-                    >
-                      <PrimaryButton color="primary">
-                        Admin Projects
-                      </PrimaryButton>
-                    </Link>
-                  ) : (
-                    <Link
-                      to={{
-                        pathname: `/clusters`,
-                      }}
-                    >
-                      <PrimaryButton color="primary">Dashboard</PrimaryButton>
-                    </Link>
-                  ))}
-                <PrimaryButton btntype={btntype} onClick={btnAction}>
-                  {buttontext}
-                </PrimaryButton>
+                {adminRoute && adminProjects ? (
+                  <Link
+                    to={{
+                      pathname: `/projects`,
+                    }}
+                  >
+                    <PrimaryButton color="primary">
+                      Admin Projects
+                    </PrimaryButton>
+                  </Link>
+                ) : (
+                  <>
+                  <Link
+                    to={{
+                      pathname: `/clusters`,
+                    }}
+                  >
+                    <PrimaryButton color="primary">Dashboard</PrimaryButton>
+                  </Link>
+                  <PrimaryButton btntype={btntype} onClick={btnAction}>
+                            {buttontext}
+                                </PrimaryButton></>
+                )}
+
               </div>
             </div>
           </div>

--- a/src/components/UserAccounts/index.js
+++ b/src/components/UserAccounts/index.js
@@ -9,7 +9,6 @@ import "./UserAccounts.css";
 import Header from "../Header";
 import Spinner from "../Spinner";
 import InformationBar from "../InformationBar";
-import SideNav from "../SideNav";
 import Modal from "../Modal";
 import { ReactComponent as Coin } from "../../assets/images/coin.svg";
 import { ReactComponent as MoreIcon } from "../../assets/images/more-verticle.svg";
@@ -23,8 +22,6 @@ import { useSelector, useDispatch } from "react-redux";
 // import { useParams } from "react-router-dom";
 
 const UserAccounts = () => {
-  const clusterName = localStorage.getItem("clusterName");
-  const clusterID = localStorage.getItem("clusterID");
   const [currentPage, handleChangePage] = usePaginator();
 
   const [actionsMenu, setActionsMenu] = useState(false);
@@ -47,7 +44,7 @@ const UserAccounts = () => {
   );
   const dispatch = useDispatch();
   const gettingUsers = useCallback(
-    (page,keyword='') => dispatch(getUsersList(page,keyword)),
+    (page, keyword = "") => dispatch(getUsersList(page, keyword)),
     [dispatch]
   );
 
@@ -146,267 +143,251 @@ const UserAccounts = () => {
   };
 
   return (
-    <div className="MainPage">
+    <div className="Page">
       {isAdded ? renderRedirect() : null}
-      <div className="TopBarSection">
+      <div className="TopRow">
         <Header />
+        <InformationBar
+          header={
+            <>
+              <Link className="breadcrumb" to={`/accounts`}>
+                Overview
+              </Link>
+              <span> / Users Listing</span>
+            </>
+          }
+          showBtn={true}
+          adminRoute={true}
+          dashboard={false}
+        />
       </div>
-      <div className="MainSection">
-        <div className="SideBarSection">
-          <SideNav clusterName={clusterName} clusterId={clusterID} />
-        </div>
-        <div className="MainContentSection">
-          <div className="InformationBarSection">
-            <InformationBar
-              header={
-                <>
-                  <Link className="breadcrumb" to={`/accounts`}>
-                    Overview
-                  </Link>
-                  <span> / Users Listing</span>
-                </>
-              }
-              showBtn={false}
+
+      <div className="ContentSection">
+        <div className="SearchBar">
+          <div className="AdminSearchInput">
+            <input
+              type="text"
+              className="searchTerm"
+              name="Searchword"
+              placeholder="Search for account"
+              value={word}
+              onChange={(e) => {
+                handleCallbackSearchword(e);
+              }}
             />
+            <SearchButton className="SearchIcon" />
           </div>
-          <div className="ContentSection">
-            <div className="SearchBar">
-              <div className="AdminSearchInput">
-                <input
-                  type="text"
-                  className="searchTerm"
-                  name="Searchword"
-                  placeholder="Search for account"
-                  value={word}
-                  onChange={(e) => {
-                    handleCallbackSearchword(e);
-                  }}
-                />
-                <SearchButton className="SearchIcon" />
-              </div>
-            </div>
-            <div
-              className={
-                isFetching
-                  ? "ResourcesTable LoadingResourcesTable"
-                  : "ResourcesTable"
-              }
-            >
-              <table className="UsersTable">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Beta User</th>
-                    <th>Credits</th>
-                    <th>Email</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                {isFetching ? (
-                  <tbody>
-                    <tr className="TableLoading">
-                      <td className="TableTdSpinner">
-                        <div className="SpinnerWrapper">
-                          <Spinner size="big" />
-                        </div>
+        </div>
+        <div
+          className={
+            isFetching
+              ? "ResourcesTable LoadingResourcesTable"
+              : "ResourcesTable"
+          }
+        >
+          <table className="UsersTable">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Beta User</th>
+                <th>Credits</th>
+                <th>Email</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            {isFetching ? (
+              <tbody>
+                <tr className="TableLoading">
+                  <td className="TableTdSpinner">
+                    <div className="SpinnerWrapper">
+                      <Spinner size="big" />
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            ) : (
+              <tbody>
+                {isFetched &&
+                  users !== undefined &&
+                  users?.map((user) => (
+                    <tr key={users.indexOf(user)}>
+                      <td>{user?.name}</td>
+                      <td>{user.is_beta_user ? "True" : "False"}</td>
+                      <td>
+                        {user?.credits.length === 0 ? (
+                          "No credits"
+                        ) : (
+                          <div className="creditSection">
+                            {user?.credits[0]?.amount}
+                            <div className="creditCoin">
+                              {" "}
+                              <Coin title="credits" />
+                            </div>
+                          </div>
+                        )}
+                      </td>
+                      <td>{user?.email}</td>
+                      <td
+                        onClick={(e) => {
+                          showMenu(user.id);
+                          handleClick(e);
+                        }}
+                      >
+                        <MoreIcon />
+                        {actionsMenu && user.id === selectedUser && (
+                          <div className="BelowHeader bg-light">
+                            <div className="context-menu">
+                              <div
+                                className="DropDownLink"
+                                role="presentation"
+                                onClick={() => {
+                                  showBetaUserModal();
+                                }}
+                              >
+                                Add Beta User
+                              </div>
+                              <div
+                                className="DropDownLink"
+                                role="presentation"
+                                onClick={() => {
+                                  showCreditsModal();
+                                }}
+                              >
+                                Assign Credits
+                              </div>
+                              <div className="DropDownLink" role="presentation">
+                                <Link
+                                  to={{
+                                    pathname: `/accounts/${selectedUser}`,
+                                  }}
+                                >
+                                  View User Profile
+                                </Link>
+                              </div>
+                              <div className="DropDownLink" role="presentation">
+                                <Link
+                                  to={{
+                                    pathname: `/accounts/${selectedUser}/logs`,
+                                  }}
+                                >
+                                  View User Logs
+                                </Link>
+                              </div>
+                            </div>
+                          </div>
+                        )}
                       </td>
                     </tr>
-                  </tbody>
-                )  : (
-                  <tbody>
-                    {isFetched &&
-                      users !== undefined &&
-                      users?.map((user) => (
-                        <tr key={users.indexOf(user)}>
-                          <td>{user?.name}</td>
-                          <td>{user.is_beta_user ? "True" : "False"}</td>
-                          <td>
-                            {user?.credits.length === 0 ? (
-                              "No credits"
-                            ) : (
-                              <div className="creditSection">
-                                {user?.credits[0]?.amount}
-                                <div className="creditCoin">
-                                  {" "}
-                                  <Coin title="credits" />
-                                </div>
-                              </div>
-                            )}
-                          </td>
-                          <td>{user?.email}</td>
-                          <td
-                            onClick={(e) => {
-                              showMenu(user.id);
-                              handleClick(e);
-                            }}
-                          >
-                            <MoreIcon />
-                            {actionsMenu && user.id === selectedUser && (
-                              <div className="BelowHeader bg-light">
-                                <div className="context-menu">
-                                  <div
-                                    className="DropDownLink"
-                                    role="presentation"
-                                    onClick={() => {
-                                      showBetaUserModal();
-                                    }}
-                                  >
-                                    Add Beta User
-                                  </div>
-                                  <div
-                                    className="DropDownLink"
-                                    role="presentation"
-                                    onClick={() => {
-                                      showCreditsModal();
-                                    }}
-                                  >
-                                    Assign Credits
-                                  </div>
-                                  <div
-                                    className="DropDownLink"
-                                    role="presentation"
-                                  >
-                                    <Link
-                                      to={{
-                                        pathname: `/accounts/${selectedUser}`,
-                                      }}
-                                    >
-                                      View User Profile
-                                    </Link>
-                                  </div>
-                                  <div
-                                    className="DropDownLink"
-                                    role="presentation"
-                                  >
-                                    <Link
-                                      to={{
-                                        pathname: `/accounts/${selectedUser}/logs`,
-                                      }}
-                                    >
-                                      View User Logs
-                                    </Link>
-                                  </div>
-                                </div>
-                              </div>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                  </tbody>
-                )}
-              </table>
-              {isFetched && users.length === 0 && (
-                <div className="AdminNoResourcesMessage">
-                  <p>No Users Available</p>
-                </div>
-              )}
-              {!isFetching && !isFetched && (
-                <div className="AdminNoResourcesMessage">
-                  <p>
-                    Oops! Something went wrong! Failed to retrieve Available
-                    Users.
-                  </p>
-                </div>
-              )}
-            </div>
-            {pagination?.pages > 1 && (
-              <div className="AdminPaginationSection">
-                <Pagination
-                  total={pagination.pages}
-                  current={currentPage}
-                  onPageChange={handlePageChange}
-                />
-              </div>
+                  ))}
+              </tbody>
             )}
-          </div>
-          <Modal showModal={addCredits} onClickAway={() => hideCreditsModal()}>
-            <div className="ModalHeader">
-              <h5 className="ModalTitle">Add Credits</h5>
-
-              <div className="">Number of credits</div>
-              <div className="ModalContent">
-                <BlackInputText
-                  required
-                  placeholder="Number of credits"
-                  name="credits"
-                  type="number"
-                  value={credits}
-                  onChange={(e) => {
-                    setCredits(e.target.value);
-                  }}
-                />
-              </div>
-              <div className="CreditsTitle">Description</div>
-              <textarea
-                className="TextArea"
-                type="text"
-                placeholder="Credits description"
-                rows="4"
-                cols="50"
-                name="creditDescription"
-                value={creditDescription}
-                onChange={(e) => {
-                  setCreditDescription(e.target.value);
-                }}
-              />
+          </table>
+          {isFetched && users.length === 0 && (
+            <div className="AdminNoResourcesMessage">
+              <p>No Users Available</p>
             </div>
-            <div className="ModalFooter">
-              <div className="ModalButtons">
-                <PrimaryButton
-                  className="CancelBtn"
-                  onClick={() => hideCreditsModal()}
-                >
-                  Cancel
-                </PrimaryButton>
-
-                <PrimaryButton
-                  type="button"
-                  onClick={() => handleCreditSubmittion()}
-                >
-                  {Adding ? <Spinner /> : "Add"}
-                </PrimaryButton>
-              </div>
-              {Failed && (
-                <Feedback message={"failed to add credits"} type={"error"} />
-              )}
+          )}
+          {!isFetching && !isFetched && (
+            <div className="AdminNoResourcesMessage">
+              <p>
+                Oops! Something went wrong! Failed to retrieve Available Users.
+              </p>
             </div>
-          </Modal>
-          <Modal showModal={betaUserModal} onClickAway={closeBetaUserModal}>
-            <div class="modal-content">
-              <div class="modal-header">
-                <h5 class="modal-title BetaUserText" id="exampleModalLongTitle">
-                  Add user as Beta user?
-                </h5>
-              </div>
-              <div class="modal-footer BetaUser">
-                <PrimaryButton
-                  type="button"
-                  className="CancelBtn"
-                  onClick={() => {
-                    closeBetaUserModal();
-                  }}
-                >
-                  Cancel
-                </PrimaryButton>
-                <PrimaryButton
-                  type="button"
-                  onClick={() => {
-                    handleBetaUserSubmit();
-                  }}
-                >
-                  {isAdding ? <Spinner /> : "Confirm"}
-                </PrimaryButton>
-              </div>
-              {isFailed && (
-                <Feedback
-                  message={error !== "" ? error : null}
-                  type={"error"}
-                />
-              )}
-            </div>
-          </Modal>
+          )}
         </div>
+        {pagination?.pages > 1 && (
+          <div className="AdminPaginationSection">
+            <Pagination
+              total={pagination.pages}
+              current={currentPage}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        )}
       </div>
+      <Modal showModal={addCredits} onClickAway={() => hideCreditsModal()}>
+        <div className="ModalHeader">
+          <h5 className="ModalTitle">Add Credits</h5>
+
+          <div className="">Number of credits</div>
+          <div className="ModalContent">
+            <BlackInputText
+              required
+              placeholder="Number of credits"
+              name="credits"
+              type="number"
+              value={credits}
+              onChange={(e) => {
+                setCredits(e.target.value);
+              }}
+            />
+          </div>
+          <div className="CreditsTitle">Description</div>
+          <textarea
+            className="TextArea"
+            type="text"
+            placeholder="Credits description"
+            rows="4"
+            cols="50"
+            name="creditDescription"
+            value={creditDescription}
+            onChange={(e) => {
+              setCreditDescription(e.target.value);
+            }}
+          />
+        </div>
+        <div className="ModalFooter">
+          <div className="ModalButtons">
+            <PrimaryButton
+              className="CancelBtn"
+              onClick={() => hideCreditsModal()}
+            >
+              Cancel
+            </PrimaryButton>
+
+            <PrimaryButton
+              type="button"
+              onClick={() => handleCreditSubmittion()}
+            >
+              {Adding ? <Spinner /> : "Add"}
+            </PrimaryButton>
+          </div>
+          {Failed && (
+            <Feedback message={"failed to add credits"} type={"error"} />
+          )}
+        </div>
+      </Modal>
+      <Modal showModal={betaUserModal} onClickAway={closeBetaUserModal}>
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title BetaUserText" id="exampleModalLongTitle">
+              Add user as Beta user?
+            </h5>
+          </div>
+          <div class="modal-footer BetaUser">
+            <PrimaryButton
+              type="button"
+              className="CancelBtn"
+              onClick={() => {
+                closeBetaUserModal();
+              }}
+            >
+              Cancel
+            </PrimaryButton>
+            <PrimaryButton
+              type="button"
+              onClick={() => {
+                handleBetaUserSubmit();
+              }}
+            >
+              {isAdding ? <Spinner /> : "Confirm"}
+            </PrimaryButton>
+          </div>
+          {isFailed && (
+            <Feedback message={error !== "" ? error : null} type={"error"} />
+          )}
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/src/pages/AdminUserOverviewPage/index.jsx
+++ b/src/pages/AdminUserOverviewPage/index.jsx
@@ -22,8 +22,6 @@ import AdminInactiveUsers from "../../components/AdminInactiveUsers";
 
 const AdminUserOverviewPage = () => {
   const history = useHistory();
-  const clusterID = localStorage.getItem("clusterID");
-  const clusterName = localStorage.getItem("clusterName");
   const [users, setUsers] = useState([]);
   const [feedback, setFeedback] = useState("");
   const [loading, setLoading] = useState(false);
@@ -120,213 +118,206 @@ const AdminUserOverviewPage = () => {
 
   // view user account listing
   const viewUsersListing = () => {
-    history.push(`/clusters/${clusterID}/users-listing`);
+    history.push(`/users-listing`);
   };
 
   return (
-    <div className="MainPage">
-      <div className="TopBarSection">
+    <div className="Page">
+      <div className="TopRow">
         <Header />
+        <InformationBar
+          header="Users Overview"
+          showBtn
+          buttontext="View Listing"
+          btnAction={viewUsersListing}
+          adminRoute={true}
+        />
       </div>
-      <div className="MainSection">
-        <div className="SideBarSection">
-          <SideNav clusterName={clusterName} clusterId={clusterID} />
+      <div className="ContentSection">
+        <div className="TitleArea">
+          <div className="SectionTitle">Users Summary</div>
         </div>
-        <div className="MainContentSection">
-          <div className="InformationBarSection">
-            <InformationBar
-              header="Users Overview"
-              showBtn
-              buttontext="View Listing"
-              btnAction={viewUsersListing}
-            />
+        {loading ? (
+          <div className="ResourceSpinnerWrapper">
+            <Spinner size="big" />
           </div>
-          <div className="ContentSection">
-            <div className="TitleArea">
-              <div className="SectionTitle">Users Summary</div>
-            </div>
-            {loading ? (
-              <div className="ResourceSpinnerWrapper">
-                <Spinner size="big" />
-              </div>
-            ) : feedback !== "" ? (
-              <div className="NoResourcesMessage">{feedback}</div>
-            ) : Object.keys(userCounts).length > 0 ? (
-              <div className="ClusterContainer">
-                {Object.keys(userCounts).map((countType) => (
-                  <ResourceCard
-                    key={countType}
-                    title={countType}
-                    count={userCounts[countType]}
-                  />
-                ))}
-              </div>
-            ) : null}
+        ) : feedback !== "" ? (
+          <div className="NoResourcesMessage">{feedback}</div>
+        ) : Object.keys(userCounts).length > 0 ? (
+          <div className="ClusterContainer">
+            {Object.keys(userCounts).map((countType) => (
+              <ResourceCard
+                key={countType}
+                title={countType}
+                count={userCounts[countType]}
+              />
+            ))}
+          </div>
+        ) : null}
 
-            <div className="TitleArea">
-              <div className="SectionTitle">Graph Summary</div>
-            </div>
+        <div className="TitleArea">
+          <div className="SectionTitle">Graph Summary</div>
+        </div>
 
-            <div className="SummaryCardContainer">
-              <div className="UserSection">
-                <div className="LeftDBSide">
-                  <div className="MetricsGraph">
-                    <MetricsCard
-                      className="ClusterMetricsCardGraph"
-                      title={
-                        <div className="GraphSummaryTitle">
-                          <span className="SummaryTitleText">
-                            Verified Users
-                          </span>
-                          <span>
-                            <div className="PeriodContainer">
-                              <div className="PeriodButtonsSection">
-                                <div
-                                  className={`${
-                                    period === "3" && "PeriodButtonActive"
-                                  } PeriodButton`}
-                                  name="3month"
-                                  value="3"
-                                  role="presentation"
-                                  onClick={handleChange}
-                                >
-                                  3m
-                                </div>
-                                <div
-                                  className={`${
-                                    period === "4" && "PeriodButtonActive"
-                                  } PeriodButton`}
-                                  name="4months"
-                                  value="4"
-                                  role="presentation"
-                                  onClick={handleChange}
-                                >
-                                  4m
-                                </div>
-                                <div
-                                  className={`${
-                                    period === "6" && "PeriodButtonActive"
-                                  } PeriodButton`}
-                                  name="6months"
-                                  value="6"
-                                  role="presentation"
-                                  onClick={handleChange}
-                                >
-                                  6m
-                                </div>
-                                <div
-                                  className={`${
-                                    period === "8" && "PeriodButtonActive"
-                                  } PeriodButton`}
-                                  name="8months"
-                                  value="8"
-                                  role="presentation"
-                                  onClick={handleChange}
-                                >
-                                  8m
-                                </div>
-                                <div
-                                  className={`${
-                                    period === "12" && "PeriodButtonActive"
-                                  } PeriodButton`}
-                                  name="1year"
-                                  value="12"
-                                  role="presentation"
-                                  onClick={handleChange}
-                                >
-                                  1y
-                                </div>
-                                <div
-                                  className={`${
-                                    period === "all" && "PeriodButtonActive"
-                                  } PeriodButton`}
-                                  name="all"
-                                  value="all"
-                                  role="presentation"
-                                  onClick={handleChange}
-                                >
-                                  all
-                                </div>
-                              </div>
+        <div className="SummaryCardContainer">
+          <div className="UserSection">
+            <div className="LeftDBSide">
+              <div className="MetricsGraph">
+                <MetricsCard
+                  className="ClusterMetricsCardGraph"
+                  title={
+                    <div className="GraphSummaryTitle">
+                      <span className="SummaryTitleText">
+                        Verified Users
+                      </span>
+                      <span>
+                        <div className="PeriodContainer">
+                          <div className="PeriodButtonsSection">
+                            <div
+                              className={`${
+                                period === "3" && "PeriodButtonActive"
+                              } PeriodButton`}
+                              name="3month"
+                              value="3"
+                              role="presentation"
+                              onClick={handleChange}
+                            >
+                              3m
                             </div>
-                          </span>
+                            <div
+                              className={`${
+                                period === "4" && "PeriodButtonActive"
+                              } PeriodButton`}
+                              name="4months"
+                              value="4"
+                              role="presentation"
+                              onClick={handleChange}
+                            >
+                              4m
+                            </div>
+                            <div
+                              className={`${
+                                period === "6" && "PeriodButtonActive"
+                              } PeriodButton`}
+                              name="6months"
+                              value="6"
+                              role="presentation"
+                              onClick={handleChange}
+                            >
+                              6m
+                            </div>
+                            <div
+                              className={`${
+                                period === "8" && "PeriodButtonActive"
+                              } PeriodButton`}
+                              name="8months"
+                              value="8"
+                              role="presentation"
+                              onClick={handleChange}
+                            >
+                              8m
+                            </div>
+                            <div
+                              className={`${
+                                period === "12" && "PeriodButtonActive"
+                              } PeriodButton`}
+                              name="1year"
+                              value="12"
+                              role="presentation"
+                              onClick={handleChange}
+                            >
+                              1y
+                            </div>
+                            <div
+                              className={`${
+                                period === "all" && "PeriodButtonActive"
+                              } PeriodButton`}
+                              name="all"
+                              value="all"
+                              role="presentation"
+                              onClick={handleChange}
+                            >
+                              all
+                            </div>
+                          </div>
                         </div>
-                      }
-                    >
-                      <div className="ChartsArea">
-                        <div>
-                          <AreaChart
-                            width={800}
-                            height={300}
-                            syncId="anyId"
-                            data={
-                              period !== "all"
-                                ? filteredGraphData
-                                : graphDataArray
+                      </span>
+                    </div>
+                  }
+                >
+                  <div className="ChartsArea">
+                    <div>
+                      <AreaChart
+                        width={800}
+                        height={300}
+                        syncId="anyId"
+                        data={
+                          period !== "all"
+                            ? filteredGraphData
+                            : graphDataArray
+                        }
+                      >
+                        <Line
+                          type="monotone"
+                          dataKey="Value"
+                          stroke="#8884d8"
+                        />
+                        <CartesianGrid stroke="#ccc" />
+                        <XAxis dataKey="Month" />
+                        <XAxis
+                          xAxisId={1}
+                          dx={10}
+                          label={{
+                            value: "Time",
+                            angle: 0,
+                            position: "bottom",
+                          }}
+                          interval={12}
+                          dataKey="Year"
+                          tickLine={false}
+                          tick={{ fontSize: 12, angle: 0 }}
+                        />
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <YAxis
+                          label={{
+                            value: "Number of Users",
+                            angle: 270,
+                            position: "outside",
+                          }}
+                          width={100}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="Value"
+                          stroke="#82ca9d"
+                          fill="#82ca9d"
+                        />
+                        <Tooltip
+                          labelFormatter={(value) => {
+                            const monthNames = retrieveMonthNames();
+                            const month = parseInt(value) - 1;
+                            return monthNames[month].name;
+                          }}
+                          formatter={(value) => {
+                            if (value === 1) {
+                              return [`${value} user`];
+                            } else {
+                              return [`${value} users`];
                             }
-                          >
-                            <Line
-                              type="monotone"
-                              dataKey="Value"
-                              stroke="#8884d8"
-                            />
-                            <CartesianGrid stroke="#ccc" />
-                            <XAxis dataKey="Month" />
-                            <XAxis
-                              xAxisId={1}
-                              dx={10}
-                              label={{
-                                value: "Time",
-                                angle: 0,
-                                position: "bottom",
-                              }}
-                              interval={12}
-                              dataKey="Year"
-                              tickLine={false}
-                              tick={{ fontSize: 12, angle: 0 }}
-                            />
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <YAxis
-                              label={{
-                                value: "Number of Users",
-                                angle: 270,
-                                position: "outside",
-                              }}
-                              width={100}
-                            />
-                            <Area
-                              type="monotone"
-                              dataKey="Value"
-                              stroke="#82ca9d"
-                              fill="#82ca9d"
-                            />
-                            <Tooltip
-                              labelFormatter={(value) => {
-                                const monthNames = retrieveMonthNames();
-                                const month = parseInt(value) - 1;
-                                return monthNames[month].name;
-                              }}
-                              formatter={(value) => {
-                                if (value === 1) {
-                                  return [`${value} user`];
-                                } else {
-                                  return [`${value} users`];
-                                }
-                              }}
-                            />
-                          </AreaChart>
-                        </div>
-                      </div>
-                    </MetricsCard>
+                          }}
+                        />
+                      </AreaChart>
+                    </div>
                   </div>
-                </div>
+                </MetricsCard>
               </div>
             </div>
-
-            <AdminInactiveUsers />
           </div>
         </div>
+
+        <AdminInactiveUsers />
       </div>
+        
     </div>
   );
 };

--- a/src/router.js
+++ b/src/router.js
@@ -238,7 +238,7 @@ const Routes = () => (
       />
       <ProtectedRoute
         isAllowed={hasToken}
-        path="/clusters/:clusterID/users-listing"
+        path="/users-listing"
         component={UsersAccounts}
       />
       <ProtectedRoute


### PR DESCRIPTION
# Description

Move non cluster bound  items out of the side navigation. Checking out non-cluster related items on the admin side like Users won't raise null cluster errors as users are not cluster based.
## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/KkASRMAw
## How Can This Been Tested?
Checking out non-cluster related items on the admin side like Users won't raise null cluster errors as users are not cluster based. Check out the users lists and other non cluster bound items on the admin side.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots
