### PR TITLE
used ellipsis for long project names in sidebar

### DIFF
--- a/src/components/SideBar/SideBar.module.css
+++ b/src/components/SideBar/SideBar.module.css
@@ -21,7 +21,16 @@
   flex-direction: column;
   position: fixed;
 }
-
+.SideBarProjectName{
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 200px;
+  margin-left: auto;
+  margin-right: auto;
+  cursor: pointer;
+  font-size: 1rem;
+}
 .SideBarTopSection {
   padding: 2rem 1rem;
   display: flex;

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -85,7 +85,7 @@ const SideBar = (props) => {
                 className={styles.SideBarTopSection}
               >
                 <BackButton color="#fff" />
-                {name}
+                <div className={styles.SideBarProjectName}>{name}</div>
               </Link>
             ) : (
               <Link
@@ -93,7 +93,7 @@ const SideBar = (props) => {
                 className={styles.SideBarTopSection}
               >
                 <BackButton color="#fff" />
-                {name}
+                <div className={styles.SideBarProjectName}>{name}</div>
               </Link>
             )}
           </div>


### PR DESCRIPTION
# Description

- Added ellipsis styling for very long project names in the sidebar

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Trello Ticket ID

https://trello.com/c/yU3qK6dJ

## How Can This Been Tested?

Access this branch and see the changes in the sidebar incase you create a project with a long name


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


# Screenshots

![Screenshot from 2023-08-02 20-23-46](https://github.com/crane-cloud/frontend/assets/108899937/e9e69345-b4c2-4924-bb51-c7e4b71382b4)
