### PR TITLE
feat: add database overview page and database details page on admin side

### DIFF
--- a/src/components/AdminDB/index.jsx
+++ b/src/components/AdminDB/index.jsx
@@ -1,152 +1,456 @@
 import React, { useEffect, useState, useCallback } from "react";
 import Header from "../Header";
 import InformationBar from "../InformationBar";
-import { ReactComponent as ButtonPlus } from "../../assets/images/buttonplus.svg";
-import SideNav from "../SideNav";
 import Spinner from "../Spinner";
 import CreateAdminDB from "./CreateAdminDB";
 import adminGetDatabases from "../../redux/actions/getAdminDatabases";
-import styles from "./AdminDB.module.css";
+// import styles from "./AdminDB.module.css";
 import usePaginator from "../../hooks/usePaginator";
-import Pagination from "../../components/Pagination"
+import Pagination from "../../components/Pagination";
 import { useSelector, useDispatch } from "react-redux";
+import NewResourceCard from "../NewResourceCard";
+import {
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  AreaChart,
+  Area,
+  Tooltip,
+  PieChart,
+  Pie,
+  Cell,
+} from "recharts";
+import { createDatabasesPieChartData } from "../../helpers/databasesPieChartData";
+import { createDatabaseGraphData } from "../../helpers/databasesGraphData";
+import { filterGraphData } from "../../helpers/filterGraphData";
+import { retrieveMonthNames } from "../../helpers/monthNames";
+import { handleGetRequest } from "../../apis/apis";
+import Select from "../Select";
+import { getDatabaseFlavors } from "../../helpers/databaseCategories";
+import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
 
 const AdminDBList = () => {
-  const [openCreateComponent, setOpenCreateComponent] = useState(false)
-  const dispatch = useDispatch();
+  const history = useHistory();
   const [currentPage, handleChangePage] = usePaginator();
-  const clusterName = localStorage.getItem("clusterName");
-  const clusterID = localStorage.getItem("clusterID");
+  const [databaseSummary, setDatabaseSummary] = useState([]);
+  const [feedback, setFeedback] = useState("");
+  const [openCreateComponent, setOpenCreateComponent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [period, setPeriod] = useState("all");
+  //const [sectionValue, setSectionValue] = useState("all");
+
+  const dispatch = useDispatch();
+
+  const COLORS = ["#0088FE", "#0DBC00", "#F9991A"];
+
+  let graphDataArray = [];
+  let filteredGraphData = [];
+
   const databaseResources = useCallback(
     () => dispatch(adminGetDatabases(currentPage)),
     [dispatch, currentPage]
   );
   useEffect(() => {
+    getAllDatabases();
     databaseResources();
   }, [databaseResources]);
 
-  const { databases, databasesFetched, isFetchingDatabases, pagination } = useSelector(
-    (state) => state.adminDatabasesReducer
-  );
-  const { isCreated } = useSelector(
-    (state) => state.adminCreateDBReducer
-  );
+  const getAllDatabases = async () => {
+    setLoading(true);
 
-  useEffect(() => { 
+    try {
+      const response = await handleGetRequest("/databases");
+      if (response.data.data.databases.length > 0) {
+        const totalNumberOfDatabases = response.data.data.pagination.total;
+        handleGetRequest(`/databases?per_page=${totalNumberOfDatabases}`)
+          .then((response) => {
+            if (response.data.data.databases.length > 0) {
+              setDatabaseSummary(response.data.data.databases);
+              setLoading(false);
+            } else {
+              throw new Error("No databases found");
+            }
+          })
+          .catch(() => {
+            setFeedback("Failed to fetch all databases, please try again");
+          });
+      } else {
+        setFeedback("No databases found");
+      }
+    } catch (error) {
+      setFeedback("Failed to fetch databases, please try again");
+    }
+  };
+
+  const { databases, databasesFetched, isFetchingDatabases, pagination } =
+    useSelector((state) => state.adminDatabasesReducer);
+  const { isCreated } = useSelector((state) => state.adminCreateDBReducer);
+
+  useEffect(() => {
     callbackCreateComponent();
-    dispatch(adminGetDatabases(currentPage))
-  }, [currentPage,isCreated,dispatch]);
-  
+    dispatch(adminGetDatabases(currentPage));
+  }, [currentPage, isCreated, dispatch]);
+
   const showCreateComponent = () => {
-    setOpenCreateComponent(true)
-  }
+    setOpenCreateComponent(true);
+  };
 
   const callbackCreateComponent = () => {
-    setOpenCreateComponent(false)
-  }
+    setOpenCreateComponent(false);
+  };
 
   const handlePageChange = (currentPage) => {
     handleChangePage(currentPage);
-    databaseResources()
+    databaseResources();
   };
-
 
   const sortedDbs = databases.sort((a, b) =>
     b.date_created > a.date_created ? 1 : -1
   );
+
+  // these counts will get actual values from data provided by backend
+  const databaseCounts = {
+    total: 149,
+    mysql: 100,
+    postgres: 49,
+    active: 145,
+    disabled: 4,
+  };
+
+  const handleChange = ({ target }) => {
+    setPeriod(target.getAttribute("value"));
+  };
+
+  const handleSectionChange = (selectedOption) => {
+    //const selectedValue = selectedOption.value;
+    //setSectionValue(selectedValue);
+  };
+
+  graphDataArray = createDatabaseGraphData(databaseSummary);
+
+  filteredGraphData = filterGraphData(graphDataArray, period);
+
+  const availableFlavors = getDatabaseFlavors();
+
   return (
-    <div className={styles.MainPage}>
-      <div className="TopBarSection">
-        <Header />
-      </div>
-      <div className={styles.MainSection}>
-        <div className="SideBarSection">
-          <SideNav clusterName={clusterName} clusterId={clusterID} />
-        </div>
-        {openCreateComponent ? (
-          <CreateAdminDB closeComponent={callbackCreateComponent} />
-        ) : (
-          <div className={styles.MainContentSection}>
-            <div className={styles.InformationBarSection}>
-              <InformationBar
-                header="Databases"
-                showBtn
-                buttontext="+ new database"
-                btnAction={showCreateComponent}
-              />
-            </div>
-            <div className={styles.ContentSection}>
-              {isFetchingDatabases ? (
-                <div className={styles.NoResourcesMessageSection}>
-                  <div className={styles.SpinnerWrapper}>
-                    <Spinner size="big" />
-                  </div>
+    <div className="APage">
+      <Header />
+      {openCreateComponent ? (
+        <CreateAdminDB closeComponent={callbackCreateComponent} />
+      ) : (
+        <>
+          <div className="TopRow">
+            <InformationBar
+              header="Databases Overview"
+              showBackBtn={true}
+              showBtn
+              buttontext="+ new database"
+              btnAction={showCreateComponent}
+            />
+          </div>
+
+          <div className="AMainSection">
+            <div className="ContentSection">
+              <div className="TitleArea">
+                <div className="SectionTitle">Databases Summary</div>
+              </div>
+              {loading ? (
+                <div className="ResourceSpinnerWrapper">
+                  <Spinner size="big" />
                 </div>
-              ) : (
-                databasesFetched &&
-                databases.length > 0 && (
-                  <div
-                    className={`${styles.DatabaseTable} MetricsCardContainer`}
-                  >
-                    <div
-                      className={`${styles.DatabaseTableRow} CardHeaderSection`}
-                    >
-                      <div className={styles.DatabaseTableHead}>
-                        Type
-                        </div>
-                      <div className={styles.DatabaseTableHead}>Name</div>
-                      <div className={styles.DatabaseTableHead}>Host</div>
-                      <div className={styles.DatabaseTableHead}>Age</div>
-                    </div>
-                    {databasesFetched &&
-                      sortedDbs !== undefined &&
-                      sortedDbs.map((database, index) => (
-                        <div className={styles.DatabaseBody} key={index}>
+              ) : feedback !== "" ? (
+                <div className="NoResourcesMessage">{feedback}</div>
+              ) : Object.keys(databaseCounts).length > 0 ? (
+                <div className="ClusterContainer">
+                  {Object.keys(databaseCounts).map((countType) => (
+                    <NewResourceCard
+                      key={countType}
+                      title={countType}
+                      count={databaseCounts[countType]}
+                    />
+                  ))}
+                </div>
+              ) : null}
+
+              <div className="TitleArea">
+                <div className="SectionTitle">
+                  Graph and Pie Chart Summary on Databases
+                </div>
+              </div>
+              <div className="ChartContainer">
+                <div className="VisualArea">
+                  <div className="VisualAreaHeader">
+                    <span className="SectionTitle">Platform Databases</span>
+                    <span>
+                      <div className="PeriodContainer">
+                        <div className="PeriodButtonsSection">
                           <div
-                            key={database.id}
-                            className={styles.DatabaseTableRow}
+                            className={`${
+                              period === "3" && "PeriodButtonActive"
+                            } PeriodButton`}
+                            name="3month"
+                            value="3"
+                            role="presentation"
+                            onClick={handleChange}
                           >
-                            <div className={styles.DatabaseTableCell}>
-                              {database.database_flavour_name}
-                            </div>
-                            <div className={styles.DatabaseTableCell}>
-                              {database.name}
-                            </div>
-                            <div className={styles.DatabaseTableCell}>
-                              {database.host}
-                            </div>
-                            <div className={styles.DatabaseTableCell}>
-                              {database.age}
-                            </div>
+                            3m
+                          </div>
+                          <div
+                            className={`${
+                              period === "4" && "PeriodButtonActive"
+                            } PeriodButton`}
+                            name="4months"
+                            value="4"
+                            role="presentation"
+                            onClick={handleChange}
+                          >
+                            4m
+                          </div>
+                          <div
+                            className={`${
+                              period === "6" && "PeriodButtonActive"
+                            } PeriodButton`}
+                            name="6months"
+                            value="6"
+                            role="presentation"
+                            onClick={handleChange}
+                          >
+                            6m
+                          </div>
+                          <div
+                            className={`${
+                              period === "8" && "PeriodButtonActive"
+                            } PeriodButton`}
+                            name="8months"
+                            value="8"
+                            role="presentation"
+                            onClick={handleChange}
+                          >
+                            8m
+                          </div>
+                          <div
+                            className={`${
+                              period === "12" && "PeriodButtonActive"
+                            } PeriodButton`}
+                            name="1year"
+                            value="12"
+                            role="presentation"
+                            onClick={handleChange}
+                          >
+                            1y
+                          </div>
+                          <div
+                            className={`${
+                              period === "all" && "PeriodButtonActive"
+                            } PeriodButton`}
+                            name="all"
+                            value="all"
+                            role="presentation"
+                            onClick={handleChange}
+                          >
+                            all
                           </div>
                         </div>
-                      ))}
+                      </div>
+                    </span>
                   </div>
-                )
-              )}
+                  <AreaChart
+                    width={600}
+                    height={350}
+                    margin={{
+                      top: 20,
+                      right: 30,
+                      left: 0,
+                      bottom: 0,
+                    }}
+                    syncId="anyId"
+                    data={period !== "all" ? filteredGraphData : graphDataArray}
+                  >
+                    <Line type="monotone" dataKey="Value" stroke="#8884d8" />
+                    <CartesianGrid stroke="#ccc" />
+                    <XAxis dataKey="Month" />
+                    <XAxis
+                      xAxisId={1}
+                      dx={10}
+                      label={{
+                        value: "Months",
+                        angle: 0,
+                        position: "outside",
+                      }}
+                      height={70}
+                      interval={12}
+                      dataKey="Year"
+                      tickLine={false}
+                      tick={{ fontSize: 12, angle: 0 }}
+                    />
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <YAxis
+                      label={{
+                        value: "Number of Databases",
+                        angle: 270,
+                        position: "outside",
+                      }}
+                      width={80}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="Value"
+                      stroke="#82ca9d"
+                      fill="#82ca9d"
+                    />
+                    <Tooltip
+                      labelFormatter={(value) => {
+                        const monthNames = retrieveMonthNames();
+                        const month = parseInt(value) - 1;
+                        return monthNames[month].name;
+                      }}
+                      formatter={(value) => {
+                        if (value === 1) {
+                          return [`${value} database`];
+                        } else {
+                          return [`${value} databases`];
+                        }
+                      }}
+                    />
+                  </AreaChart>
+                </div>
 
-              {databasesFetched && databases.length === 0 && (
-                <div className={styles.NoResourcesMessageSection}>
-                  <div className={styles.NoResourcesMessage}>
-                    You haven’t created any databases yet.
+                <div className="VisualArea">
+                  <div className="VisualAreaHeader">
+                    <span className="SectionTitle">
+                      Pie Chart for Database Flavors
+                    </span>
                   </div>
-                  <br></br>
-                  <div className={styles.NoResourcesMessage}>
-                    Click the &nbsp;{" "}
-                    <ButtonPlus
-                      className={styles.ButtonPlusSmall}
-                      onClick={showCreateComponent}
-                    />{" "}
-                    &nbsp; button to create one.
+                  <div className="PieContainer">
+                    <div className="ChartColumn">
+                      <PieChart width={300} height={300}>
+                        <Pie
+                          data={createDatabasesPieChartData(databaseCounts)}
+                          dataKey="value"
+                          nameKey="category"
+                          cx="50%"
+                          cy="50%"
+                          outerRadius={140}
+                          paddingAngle={3}
+                        >
+                          {createDatabasesPieChartData(databaseCounts).map(
+                            (entry, index) => (
+                              <Cell
+                                key={`cell-${index}`}
+                                fill={COLORS[index % COLORS.length]}
+                              />
+                            )
+                          )}
+                        </Pie>
+                        <Tooltip />
+                      </PieChart>
+                    </div>
+                    <div className="PercentageColumn">
+                      <ul className="KeyItems">
+                        {createDatabasesPieChartData(databaseCounts).map(
+                          (entry, index) => (
+                            <>
+                              {" "}
+                              <li key={`list-item-${index}`}>
+                                <span
+                                  style={{
+                                    color: COLORS[index % COLORS.length],
+                                  }}
+                                >
+                                  {entry.category}:
+                                </span>{" "}
+                                {(
+                                  (entry.value / databaseCounts.total) *
+                                  100
+                                ).toFixed(0)}
+                                %
+                              </li>
+                              <hr style={{ width: "100%" }} />
+                            </>
+                          )
+                        )}
+                      </ul>
+                    </div>
                   </div>
                 </div>
-              )}
+              </div>
 
-              {!isFetchingDatabases && !databasesFetched && (
-                <div className={styles.NoResourcesMessage}>
-                  Oops! Something went wrong! Failed to retrieve Databases.
+              <div className="TitleArea">
+                <div className="SectionTitle">
+                  <span>Databases Listing</span>
+                  <span>
+                    <Select
+                      placeholder="All Databases"
+                      options={availableFlavors}
+                      onChange={(selectedOption) =>
+                        handleSectionChange(selectedOption)
+                      }
+                    />
+                  </span>
                 </div>
-              )}
+              </div>
+
+              <div
+                className={
+                  isFetchingDatabases
+                    ? "ResourcesTable LoadingResourcesTable"
+                    : "ResourcesTable"
+                }
+              >
+                <table className="UsersTable">
+                  <thead>
+                    <tr>
+                      <th>Database Flavor</th>
+                      <th>Name</th>
+                      <th>Host</th>
+                      <th>Age</th>
+                    </tr>
+                  </thead>
+                  {isFetchingDatabases ? (
+                    <tbody>
+                      <tr className="TableLoading">
+                        <td className="TableTdSpinner">
+                          <div className="SpinnerWrapper">
+                            <Spinner size="big" />
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  ) : (
+                    <tbody>
+                      {databasesFetched &&
+                        sortedDbs !== undefined &&
+                        sortedDbs?.map((database) => (
+                          <tr
+                            key={sortedDbs.indexOf(database)}
+                            onClick={() => {
+                              history.push(`/databases/${database?.id}`);
+                            }}
+                          >
+                            <td>{database?.database_flavour_name}</td>
+                            <td>{database?.name}</td>
+                            <td>{database?.host}</td>
+                            <td>{database?.age}</td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  )}
+                </table>
+                {databasesFetched && databases.length === 0 && (
+                  <div className="AdminNoResourcesMessage">
+                    <p>No Databases Available</p>
+                  </div>
+                )}
+                {!isFetchingDatabases && !databasesFetched && (
+                  <div className="AdminNoResourcesMessage">
+                    <p>
+                      Oops! Something went wrong! Failed to retrieve Available
+                      Databases.
+                    </p>
+                  </div>
+                )}
+              </div>
               {pagination?.pages > 1 && (
                 <div className="AdminPaginationSection">
                   <Pagination
@@ -158,11 +462,10 @@ const AdminDBList = () => {
               )}
             </div>
           </div>
-        )}
-      </div>
+        </>
+      )}
     </div>
   );
-
-}
+};
 
 export default AdminDBList;

--- a/src/components/AdminDB/index.jsx
+++ b/src/components/AdminDB/index.jsx
@@ -38,18 +38,19 @@ const AdminDBList = () => {
   const [openCreateComponent, setOpenCreateComponent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [period, setPeriod] = useState("all");
-  //const [sectionValue, setSectionValue] = useState("all");
+  const [metadata, setMetaData] = useState({});
+  const [sectionValue, setSectionValue] = useState("all");
 
   const dispatch = useDispatch();
 
-  const COLORS = ["#0088FE", "#0DBC00", "#F9991A"];
+  const COLORS = ["#0088FE", "#0DBC00"];
 
   let graphDataArray = [];
   let filteredGraphData = [];
 
   const databaseResources = useCallback(
-    () => dispatch(adminGetDatabases(currentPage)),
-    [dispatch, currentPage]
+    () => dispatch(adminGetDatabases(sectionValue, currentPage)),
+    [dispatch, sectionValue, currentPage]
   );
   useEffect(() => {
     getAllDatabases();
@@ -67,6 +68,7 @@ const AdminDBList = () => {
           .then((response) => {
             if (response.data.data.databases.length > 0) {
               setDatabaseSummary(response.data.data.databases);
+              setMetaData(response.data.data.metadata);
               setLoading(false);
             } else {
               throw new Error("No databases found");
@@ -89,8 +91,8 @@ const AdminDBList = () => {
 
   useEffect(() => {
     callbackCreateComponent();
-    dispatch(adminGetDatabases(currentPage));
-  }, [currentPage, isCreated, dispatch]);
+    dispatch(adminGetDatabases(sectionValue, currentPage));
+  }, [sectionValue, currentPage, isCreated, dispatch]);
 
   const showCreateComponent = () => {
     setOpenCreateComponent(true);
@@ -111,11 +113,9 @@ const AdminDBList = () => {
 
   // these counts will get actual values from data provided by backend
   const databaseCounts = {
-    total: 149,
-    mysql: 100,
-    postgres: 49,
-    active: 145,
-    disabled: 4,
+    total: metadata.total,
+    mysql: metadata.mysql_total,
+    postgres: metadata.postgres_total,
   };
 
   const handleChange = ({ target }) => {
@@ -123,8 +123,8 @@ const AdminDBList = () => {
   };
 
   const handleSectionChange = (selectedOption) => {
-    //const selectedValue = selectedOption.value;
-    //setSectionValue(selectedValue);
+    const selectedValue = selectedOption.value;
+    setSectionValue(selectedValue);
   };
 
   graphDataArray = createDatabaseGraphData(databaseSummary);

--- a/src/components/AdminDatabaseDetails/AdminDatabaseDetails.css
+++ b/src/components/AdminDatabaseDetails/AdminDatabaseDetails.css
@@ -2,3 +2,63 @@
     display: flex;
     justify-content: space-between;
 }
+
+@media (max-width: 768px) {
+    .AdminProfileRowInfo {
+        flex-direction: column;
+        /* Stack items vertically */
+        align-items: flex-start;
+        /* Align items to the left */
+        gap: 0.5rem;
+        /* Reduce the gap between items */
+        font-size: 0.9rem;
+        /* Adjust font size for smaller screens */
+    }
+}
+
+@media (max-width: 768px) {
+    .AdminUserProfileCard {
+        flex-direction: column;
+        /* Stack items vertically */
+        align-items: flex-start;
+        /* Align items to the left */
+        gap: 1rem;
+        /* Keep some gap between stacked items */
+        padding: 1rem;
+        /* Adjust padding for smaller screens */
+    }
+}
+
+@media (max-width: 768px) {
+    .AdminUserProfileInfoSect {
+        padding: 0;
+    }
+}
+
+@media (max-width: 768px) {
+    .ProjectInstructions {
+        padding: 0.5rem;
+        /* Adjust padding for smaller screens */
+        border-radius: 10px;
+        /* Adjust border radius for smaller screens */
+        border: none;
+        /* Remove border on smaller screens */
+        gap: 0.5rem;
+        /* Adjust gap between grid items */
+    }
+
+    .SettingsSectionRow {
+        display: flex;
+        flex-direction: column;
+        padding: 0.5rem;
+    }
+
+    .SectionButtons {
+        padding-top: 1rem;
+        justify-content: flex-start;
+    }
+
+    .AdminProfileName {
+        display: none;
+    }
+}

--- a/src/components/AdminDatabaseDetails/AdminDatabaseDetails.css
+++ b/src/components/AdminDatabaseDetails/AdminDatabaseDetails.css
@@ -1,0 +1,4 @@
+.ProjectInstructions .SettingsSectionRow {
+    display: flex;
+    justify-content: space-between;
+}

--- a/src/components/AdminDatabaseDetails/index.jsx
+++ b/src/components/AdminDatabaseDetails/index.jsx
@@ -91,7 +91,9 @@ const AdminDatabaseDetails = () => {
                               />
                               <div className={userProfleStyles.Identity}>
                                 <div className={userProfleStyles.IdentityName}>
-                                  {details?.name}
+                                  <div className="AdminProfileName">
+                                    {details?.name}
+                                  </div>
                                   {details?.db_status === true && (
                                     <div
                                       className={userProfleStyles.BetaUserDiv}

--- a/src/components/AdminDatabaseDetails/index.jsx
+++ b/src/components/AdminDatabaseDetails/index.jsx
@@ -1,0 +1,179 @@
+/* eslint-disable no-unused-vars */
+import React, { useState, useEffect, useCallback } from "react";
+import { useParams, Link } from "react-router-dom";
+import { handleGetRequest } from "../../apis/apis";
+import Header from "../Header";
+import InformationBar from "../InformationBar";
+import Avatar from "../Avatar";
+import moment from "moment";
+import PrimaryButton from "../PrimaryButton";
+import userProfleStyles from "../UserProfile/UserProfile.module.css";
+import "./AdminDatabaseDetails.css";
+import Spinner from "../Spinner";
+
+const AdminDatabaseDetails = () => {
+  const { databaseID } = useParams();
+  const [loading, setLoading] = useState(false);
+  const [details, setDetails] = useState([]);
+  const [projectName, setProjectName] = useState("");
+  const [error, setError] = useState("");
+
+  const fetchDatabaseDetails = useCallback(() => {
+    setLoading(true);
+    handleGetRequest(`/databases/${databaseID}`)
+      .then((response) => {
+        setDetails(response.data.data.database);
+        setLoading(false);
+      })
+      .catch((error) => {
+        setError("Failed to fetch database detail please refresh");
+        setLoading(false);
+      });
+  }, [databaseID]);
+
+  const fetchProjectSummary = useCallback(() => {
+    setLoading(true);
+    handleGetRequest(`/projects/${details?.project_id}`)
+      .then((response) => {
+        setProjectName(response.data.data.project.name);
+        setLoading(false);
+      })
+      .catch((error) => {
+        setError("Failed to fetch project detail please refresh");
+        setLoading(false);
+      });
+  }, [details?.project_id]);
+
+  useEffect(() => {
+    fetchProjectSummary();
+    fetchDatabaseDetails();
+  }, [fetchDatabaseDetails, fetchProjectSummary]);
+
+  return (
+    <div className="MainPage">
+      <div className="TopBarSection">
+        <Header />
+      </div>
+      <div className="Mainsection">
+        <div className="MainContentSection">
+          <div className="InformationBarSection">
+            <InformationBar
+              header={
+                <span>
+                  <Link className="breadcrumb" to={`/databases`}>
+                    Databases
+                  </Link>
+                  / {details?.name}
+                </span>
+              }
+              showBtn={false}
+              showBackBtn={true}
+            />
+          </div>
+          <div className="ShortContainer">
+            <div className="ContentSection">
+              <div className="AdminUserPageContainer">
+                <section>
+                  <div className="SectionTitle">Database information</div>
+                  <div className="AdminCardArea">
+                    <div className="AdminUserProfileCard">
+                      {projectName === "" ? (
+                        <div className="ResourceSpinnerWrapper">
+                          <Spinner size="small" />
+                        </div>
+                      ) : (
+                        <>
+                          <div className="AdminUserProfileInfoSect">
+                            <div className="AdminUserProfileInfoHeader">
+                              <Avatar
+                                name={details?.name}
+                                className={userProfleStyles.UserAvatarLarge}
+                              />
+                              <div className={userProfleStyles.Identity}>
+                                <div className={userProfleStyles.IdentityName}>
+                                  {details?.name}
+                                  {details?.db_status === true && (
+                                    <div
+                                      className={userProfleStyles.BetaUserDiv}
+                                    >
+                                      Active
+                                    </div>
+                                  )}
+                                </div>
+                                <div className={userProfleStyles.IdentityEmail}>
+                                  Database Type:{" "}
+                                  {details?.database_flavour_name}
+                                </div>
+                              </div>
+                            </div>
+
+                            <div className="AdminProfileRowInfo">
+                              <div className="AdminProfileRowItem">
+                                Parent Project:
+                                <span className="AdminProfileRowValue">
+                                  {projectName}
+                                </span>
+                              </div>
+                              |
+                              <div className="AdminProfileRowItem">
+                                Host:
+                                <span>{details?.host}</span>
+                              </div>
+                              |
+                              <div className="AdminProfileRowItem">
+                                Port:
+                                <span>{details?.port}</span>
+                              </div>
+                              |
+                              <div className="AdminProfileRowItem">
+                                Date Created:
+                                <span>
+                                  {moment(details?.date_created)
+                                    .utc()
+                                    .format("ddd, MMMM DD, yyyy")}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </section>
+
+                <div className="AdminDBSections">
+                  <div className="SectionTitle">Manage Database</div>
+                  <div className="ProjectInstructions">
+                    <div className="MemberBody">
+                      <div className="MemberTableRow">
+                        <div className="SettingsSectionRow">
+                          <div className="SubTitle">
+                            Disable Database
+                            <br />
+                            <div className="SubTitleContent">
+                              This will temporary disable the database.
+                            </div>
+                          </div>
+                          <div className="SectionButtons">
+                            <PrimaryButton
+                              color="red-outline"
+                              //onClick={this.showDisableAlert}
+                            >
+                              Disable
+                            </PrimaryButton>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminDatabaseDetails;

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -2,12 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import "./Avatar.css";
 
-const Avatar = ({ name,className }) => {
+const Avatar = ({ name, className }) => {
   const nameStringToHslColor = (name) => {
     let hash = 0;
     let i = 0;
     for (i; i < name?.length; i += 1) {
-      hash = name.charCodeAt(i) + ((hash << 5) - hash); // eslint-disable-line no-bitwise
+      hash = name?.charCodeAt(i) + ((hash << 5) - hash); // eslint-disable-line no-bitwise
     }
     const h = hash % 360;
     return `hsl(${h}, 80%, 70%)`; // syntax: hsl(h, s%, l%)
@@ -15,10 +15,10 @@ const Avatar = ({ name,className }) => {
 
   return (
     <div
-      className={className? className: "UserAvatar"}
+      className={className ? className : "UserAvatar"}
       style={{ backgroundColor: nameStringToHslColor(name), color: "#000" }}
     >
-      {name.charAt(0).toUpperCase()}
+      {name?.charAt(0).toUpperCase()}
     </div>
   );
 };

--- a/src/components/UserListing/index.jsx
+++ b/src/components/UserListing/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
 import Pagination from "../../components/Pagination";
 import Spinner from "../Spinner";
@@ -6,9 +6,8 @@ import { ReactComponent as Coin } from "../../assets/images/coin.svg";
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
 
 const UserListing = (props) => {
-  const { currentPage, gettingUsers, handlePageChange } = props;
-  const [actionsMenu, setActionsMenu] = useState(false);
- 
+  const { currentPage, gettingUsers, handlePageChange } = props; 
+  const history = useHistory();
 
   const { isFetching, users, isFetched, pagination } = useSelector(
     (state) => state.usersListReducer
@@ -17,17 +16,6 @@ const UserListing = (props) => {
   useEffect(() => {
     gettingUsers(currentPage);
   }, [gettingUsers, currentPage]);
-
-  const history = useHistory();
-
-  
-
-  const hideModal = () => {
-    setActionsMenu(false);
-    document.removeEventListener("click", hideModal);
-  };
-
-  
 
   return (
     <div className="APage">

--- a/src/components/UserProfile/UserProfile.module.css
+++ b/src/components/UserProfile/UserProfile.module.css
@@ -1,296 +1,326 @@
+.NoResourcesMessage {
+  flex-grow: 1;
+  display: flex;
+  font-size: 16px;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  padding: 12rem;
+}
 
+.Page {
+  background-color: #F1F1F1;
+  position: relative;
+}
 
- 
-  .NoResourcesMessage {
-    flex-grow: 1;
-    display: flex;
-    font-size: 16px;
-    text-align: center;
-    justify-content: center;
-    align-items: center;
-    padding: 12rem;
-  }
-  .Page{
-    background-color: #F1F1F1;
-    position: relative;
-  }
-  .ButtonPlusSmall {
-    width: 1rem;
-    height: 1rem;
-  }
- 
-  .CoinSize{
-    display: flex;
-    width: 1.5rem;
+.ButtonPlusSmall {
+  width: 1rem;
+  height: 1rem;
+}
 
-  }
-  .MainColumn{
-    padding: .5rem 5rem 0rem 4rem;
-  }
+.CoinSize {
+  display: flex;
+  width: 1.5rem;
 
-  .BackButton {
-    width: fit-content;
-    color: var(--primary-color);
-    height: 2rem;
-    background-color: #fff;
-    border: 1px solid var(--primary-color);
-  }
+}
 
-  .BackButton:hover {
-    color: #fff;
-    background-color: var(--primary-color);
-    border: 1px solid var(--primary-color);
-  }
-  .PairButtonCancel{
-    color: #fff;
-    width: fit-content;
-    height: 2rem;
-    padding-bottom: .5rem;
-    background-color: #000;
-    border: 1px solid #000;
-  }
-  .PairButtonCancel:hover{
-    color: #000;
-    background-color: #fff;
-    border: 1px solid #000;
-  }
-  .CreditsContainer{
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: .3rem;
-  }
-  .rowContentYes{
-    color: var(--primary-color);
-    font-weight: 700;
-  }
-  .RowContent{
-    font-weight: 700;
-  }
-  .rowContentNo{
-    color: #d80000;
-    font-weight: 700;
-  }
-  .FooterRow {
-    padding: 1rem 3rem;
-    background-color: var( --gray-bg-light-color);
-    position: absolute;
-    bottom: 10px;
-    left: 0;
-  }
+.MainColumn {
+  padding: .5rem 5rem 0rem 4rem;
+}
 
-  .UserContainer{
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    flex: 1;
-    max-width: 51rem;
-  }
+.BackButton {
+  width: fit-content;
+  color: var(--primary-color);
+  height: 2rem;
+  background-color: #fff;
+  border: 1px solid var(--primary-color);
+}
 
-  .SecondMainSection{
-    flex: 1;
-  }
+.BackButton:hover {
+  color: #fff;
+  background-color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+}
 
-  .UserAvatar {
-    width: 3.5rem;
-    height: 3.5rem;
-    border-radius: 50%;
-    text-align: center;
-    font-weight: bold;
-    font-size: 2.7rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-  }
+.PairButtonCancel {
+  color: #fff;
+  width: fit-content;
+  height: 2rem;
+  padding-bottom: .5rem;
+  background-color: #000;
+  border: 1px solid #000;
+}
 
-  .UserAvatarLarge {
-    width: 7rem;
-    height: 7rem;
-    border-radius: 50%;
-    text-align: center;
-    font-weight: bold;
-    font-size: 2.7rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-  }
-  .CardInfor{
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    font-size: 0.95rem;
-    gap: 0.5rem;
-    color: #4d4d4d;
-  }
+.PairButtonCancel:hover {
+  color: #000;
+  background-color: #fff;
+  border: 1px solid #000;
+}
 
-  .CustomInput{
-    height: 2.5rem;
-    padding: .3rem;
-    width: 70%;
-  }
-  .CustomPasswordInput{
-    border: 1px solid #000;
-    height: 2.5rem;
-    padding: .3rem;
-    width: 70%;
-  }
-  .InputDiv{
-    display: grid;
-    grid-template-columns: 1fr 4fr;
-    align-items: center;
-    gap: 1rem;
-    width: 100%;
-    padding: .3rem .3rem .3rem 0;
-  }
-  .PasswordChange{
-    display: flex;
-    align-items: center;
-    gap: 4em;
-    width: 100%;
-    padding: .3rem .3rem .7rem .3rem;
-  }
-  .ExtraContentDiv{
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1rem 1rem 1rem 0;
-  }
-  .ContainerCard{
-    padding-left: 1rem;
-    padding-top: .5rem;
-    padding-bottom: .5rem;
-    gap:.4rem;
-    flex-direction: column;
-    border-radius: 10px;
-    padding: 1rem 2rem;
-    background-color: #fff;
-  }
-  .ButtonsDiv{
-    display: flex;
-    flex-direction: row;
-    gap:.5rem
-  }
-  
-  .UserSectionTitle{
-    font-weight: 700;
-    font-size: 24px;
-    color: #000;
-  }
-  .UserSectionSubTitle{
-    font-style: normal;
-    font-weight: 300;
-    font-size: .8rem;
-    color: #000;
-  }
-  
-  .ProfileActionBtns{
-    display: flex;
-    justify-content: flex-end;
-  }
+.CreditsContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: .3rem;
+}
 
-  .ContainerSection{
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    gap: 1rem;
-    padding-bottom: 2rem;
-    border-bottom: 1px solid rgba(204, 204, 204, 0.69);
-    margin-bottom: 1rem;
-  }
-  .ContainerHeadSection{
-    /* display: flex; */
-    border-bottom: 1px solid rgba(204, 204, 204, 0.69);
-    padding-bottom: 2rem;
-  }
+.rowContentYes {
+  color: var(--primary-color);
+  font-weight: 700;
+}
+
+.RowContent {
+  font-weight: 700;
+}
+
+.rowContentNo {
+  color: #d80000;
+  font-weight: 700;
+}
+
+.FooterRow {
+  padding: 1rem 3rem;
+  background-color: var(--gray-bg-light-color);
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+}
+
+.UserContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+  max-width: 51rem;
+}
+
+.SecondMainSection {
+  flex: 1;
+}
+
+.UserAvatar {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  text-align: center;
+  font-weight: bold;
+  font-size: 2.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.UserAvatarLarge {
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  text-align: center;
+  font-weight: bold;
+  font-size: 2.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.CardInfor {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  font-size: 0.95rem;
+  gap: 0.5rem;
+  color: #4d4d4d;
+}
+
+.CustomInput {
+  height: 2.5rem;
+  padding: .3rem;
+  width: 70%;
+}
+
+.CustomPasswordInput {
+  border: 1px solid #000;
+  height: 2.5rem;
+  padding: .3rem;
+  width: 70%;
+}
+
+.InputDiv {
+  display: grid;
+  grid-template-columns: 1fr 4fr;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  padding: .3rem .3rem .3rem 0;
+}
+
+.PasswordChange {
+  display: flex;
+  align-items: center;
+  gap: 4em;
+  width: 100%;
+  padding: .3rem .3rem .7rem .3rem;
+}
+
+.ExtraContentDiv {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1rem 1rem 0;
+}
+
+.ContainerCard {
+  padding-left: 1rem;
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+  gap: .4rem;
+  flex-direction: column;
+  border-radius: 10px;
+  padding: 1rem 2rem;
+  background-color: #fff;
+}
+
+.ButtonsDiv {
+  display: flex;
+  flex-direction: row;
+  gap: .5rem
+}
+
+.UserSectionTitle {
+  font-weight: 700;
+  font-size: 24px;
+  color: #000;
+}
+
+.UserSectionSubTitle {
+  font-style: normal;
+  font-weight: 300;
+  font-size: .8rem;
+  color: #000;
+}
+
+.ProfileActionBtns {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.ContainerSection {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(204, 204, 204, 0.69);
+  margin-bottom: 1rem;
+}
+
+.ContainerHeadSection {
+  /* display: flex; */
+  border-bottom: 1px solid rgba(204, 204, 204, 0.69);
+  padding-bottom: 2rem;
+}
+
 /*increased width to 48rem from 30rem*/
-  .ProfileCard{
-    display: flex;
-    gap:1rem;
-    flex-direction: column;
-    border-radius: 10px;
-    background-color: #fff;
-    padding: 1.3rem 1rem 1rem 2.5rem;
-  }
+.ProfileCard {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+  border-radius: 10px;
+  background-color: #fff;
+  padding: 1.3rem 1rem 1rem 2.5rem;
+}
 
-  .UserProfileCard{
-    display: flex;
-    gap:1rem;
-    flex-direction: row;
-    border-radius: 10px;
-    background-color: #fff;
-    padding: 2rem;
-    align-items: center;
-    justify-content: space-between;
-  }
+.UserProfileCard {
+  display: flex;
+  gap: 1rem;
+  flex-direction: row;
+  border-radius: 10px;
+  background-color: #fff;
+  padding: 2rem;
+  align-items: center;
+  justify-content: space-between;
+}
 
-  .AvatarDiv{
-    display: flex;
-    flex-direction: row;
-    height: 5rem;
-    align-items: center;
-    margin-bottom: 0.3rem;
-  }
-  .ProfileContainer{
-    display: flex;
-    justify-content: center;
-    margin-top: 1rem;
-  }
-  .Title2{
-   padding: .4rem;
-  }
-  .Title2Name{
-    text-transform: capitalize;
-    padding: .4rem;
-  }
-  .Identity{
-    display: flex;
-    flex-direction: column;
-    padding-left: 1rem;
-  }
-  .IdentityName{
-    font-size: 1.8rem;
-    font-weight: 700;
-    color: #000;
-    display: flex;
-    align-items: center;
-    gap: 3rem;
-    text-transform: capitalize;
-  }
-  .BackgroundInfor{
-    display: flex;
-    flex-direction: column;
-    width: 20rem;
-  }
-  .ProjectDeleteModel {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 2;
-    background-color: rgba(0, 0, 0, 0.5);
-  }
-  .ProjectDeleteModel .ModalChildWrap {
-    z-index: 3;
-  }
-  .ProjectDeleteModel .ModalChildWrap {
-    min-width: 21rem;
-    max-width: 25rem;
-  }
+.AvatarDiv {
+  display: flex;
+  flex-direction: row;
+  height: 5rem;
+  align-items: center;
+  margin-bottom: 0.3rem;
+}
+
+.ProfileContainer {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.Title2 {
+  padding: .4rem;
+}
+
+.Title2Name {
+  text-transform: capitalize;
+  padding: .4rem;
+}
+
+.Identity {
+  display: flex;
+  flex-direction: column;
+  padding-left: 1rem;
+}
+
+.IdentityName {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #000;
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+  text-transform: capitalize;
+}
+
+.BackgroundInfor {
+  display: flex;
+  flex-direction: column;
+  width: 20rem;
+}
+
+.ProjectDeleteModel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.ProjectDeleteModel .ModalChildWrap {
+  z-index: 3;
+}
+
+.ProjectDeleteModel .ModalChildWrap {
+  min-width: 21rem;
+  max-width: 25rem;
+}
+
 .ProjectDeleteModel .ModalParentWrap {
   background-color: inherit;
 }
+
 .UpdateProjectModelButtons {
   display: flex;
   justify-content: space-between;
 }
+
 .ModelContent {
   width: 23rem;
 }
+
 .ModelHeader {
   display: flex;
   align-items: center;
@@ -298,131 +328,160 @@
   font-weight: 700;
   font-size: 2rem;
 }
+
 .UpdateForm {
   display: grid;
   gap: 1rem;
   padding: 1rem 1.3rem;
   grid-template-rows: 2fr;
 }
+
 .InformationText {
   width: 20rem;
 }
 
-  .HeaderSection{
-    display: flex;
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 0.3rem;
-    justify-content: flex-start;
-  }
-  .EmailHead{
-    display: flex;
-    flex-direction: column;
-    gap: 1.3rem;
-    align-items: flex-start;
-  }
-  .FeedBackDiv{
-    color: rgb(28, 255, 28);
-  }
-  .ErrorDiv{
-    color: red;
-  }
+.HeaderSection {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 0.3rem;
+  justify-content: flex-start;
+}
 
-  .BetaUserDiv{
-    display: inline;
-    padding: 0.3rem 0.5rem;
-    border-radius: 999px;
-    background-color: rgba(128, 0, 128, 0.217);
-    color: purple;
-    cursor: pointer;
-    font-size: 0.8rem;
-    font-weight: normal;
-  }
-  .IdentityEmail{
-    color: #686868;
-    font-size: 0.95rem;
-  }
-  
-  
-  @media (max-width: 500px) {
-  
-    
-  }
-  /* @media only screen and (max-width: 1100px) and (min-width: 901px) {
+.EmailHead {
+  display: flex;
+  flex-direction: column;
+  gap: 1.3rem;
+  align-items: flex-start;
+}
+
+.FeedBackDiv {
+  color: rgb(28, 255, 28);
+}
+
+.ErrorDiv {
+  color: red;
+}
+
+.BetaUserDiv {
+  display: inline;
+  padding: 0.3rem 0.5rem;
+  border-radius: 999px;
+  background-color: rgba(128, 0, 128, 0.217);
+  color: purple;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: normal;
+}
+
+.IdentityEmail {
+  color: #686868;
+  font-size: 0.95rem;
+}
+
+
+@media (max-width: 500px) {}
+
+/* @media only screen and (max-width: 1100px) and (min-width: 901px) {
     .ProjectList {
       grid-template-columns: repeat(4, 1fr);
     }
   }*/
-  @media only screen and (max-width: 1070px)  {
-    .ProfileContainer{
-       margin-left: 2rem;
-       margin-right: 2rem;
-    }
-    .UserContainer{
-      padding-left: 2rem;
-    }
+@media only screen and (max-width: 1070px) {
+  .ProfileContainer {
+    margin-left: 2rem;
+    margin-right: 2rem;
   }
-  @media only screen and (max-width: 900px)  {
-    .ProfileContainer{
-       margin-left: .5rem;
-       margin-right: .5rem;
-    }
-    .UserContainer{
-      padding-left: 1rem;
-    }
+
+  .UserContainer {
+    padding-left: 2rem;
   }
-  
-  @media only screen and (max-width: 700px)  {
-    .ContainerSection{
-      display: flex;
-      flex-direction: column;
-      width: auto;
-    }
-    .ContainerHeadSection{
-      width: auto;
-      margin-left: 2rem;
-      margin-right: 1rem;
-    }
-    .ProfileCard{
-      width: auto;
-    }
-    .MainColumn{
-      padding: .5rem 3rem 0rem 1rem;
-    }
-    .UserContainer{
-      padding-left: 0rem;
-    }
-    .InputDiv{
-      gap: 2rem;
-    }
-    .SecondMainSection{
-      flex: 0;
-      margin-left: 2rem;
-      margin-right: 1rem;
-    }
-    aside{
-      width: 23rem;
-    }
-    .Page{
-      min-width: 40rem;
-      height: 180vh;
-    }
-    .UserAvatar {
-      display:  none;
-    }
-    .UserAvatarLarge {
-      display:  none;
-    }
-    .IdentityName{
-      font-size: 22px;
-    }
-    .FooterRow {
-      font-size: 14px;
-    }
-    .ProfileActionBtns {
-      flex-direction: column-reverse;
-    }
+}
+
+@media only screen and (max-width: 900px) {
+  .ProfileContainer {
+    margin-left: .5rem;
+    margin-right: .5rem;
   }
-  
-  
-  
+
+  .UserContainer {
+    padding-left: 1rem;
+  }
+}
+
+@media only screen and (max-width: 700px) {
+  .ContainerSection {
+    display: flex;
+    flex-direction: column;
+    width: auto;
+  }
+
+  .ContainerHeadSection {
+    width: auto;
+    margin-left: 2rem;
+    margin-right: 1rem;
+  }
+
+  .ProfileCard {
+    width: auto;
+  }
+
+  .MainColumn {
+    padding: .5rem 3rem 0rem 1rem;
+  }
+
+  .UserContainer {
+    padding-left: 0rem;
+  }
+
+  .InputDiv {
+    gap: 2rem;
+  }
+
+  .SecondMainSection {
+    flex: 0;
+    margin-left: 2rem;
+    margin-right: 1rem;
+  }
+
+  aside {
+    width: 23rem;
+  }
+
+  .Page {
+    min-width: 40rem;
+    height: 180vh;
+  }
+
+  .UserAvatar {
+    display: none;
+  }
+
+  .UserAvatarLarge {
+    display: none;
+  }
+
+  .IdentityName {
+    font-size: 22px;
+  }
+
+  .FooterRow {
+    font-size: 14px;
+  }
+
+  .ProfileActionBtns {
+    flex-direction: column-reverse;
+  }
+
+  .Identity {
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+  }
+
+  .IdentityName{
+    display: flex;
+    flex-wrap: wrap;
+  }
+}

--- a/src/helpers/databaseCategories.js
+++ b/src/helpers/databaseCategories.js
@@ -1,0 +1,8 @@
+export const getDatabaseFlavors = () => {
+  const databaseFlavors = [
+    { id: 1, name: "All Databases", value: "all" },
+    { id: 2, name: "MySQL", value: "mysql" },
+    { id: 3, name: "PostgresSQL", value: "postgress" },
+  ];
+  return databaseFlavors;
+};

--- a/src/helpers/databaseCategories.js
+++ b/src/helpers/databaseCategories.js
@@ -2,7 +2,7 @@ export const getDatabaseFlavors = () => {
   const databaseFlavors = [
     { id: 1, name: "All Databases", value: "all" },
     { id: 2, name: "MySQL", value: "mysql" },
-    { id: 3, name: "PostgresSQL", value: "postgress" },
+    { id: 3, name: "PostgreSQL", value: "postgres" },
   ];
   return databaseFlavors;
 };

--- a/src/helpers/databasesGraphData.js
+++ b/src/helpers/databasesGraphData.js
@@ -1,0 +1,35 @@
+export const createDatabaseGraphData = (databases) => {
+  const graphDataArray = [];
+
+  databases.forEach((database) => {
+    const date = new Date(database.date_created);
+    const year = date.getFullYear();
+    const month = parseInt(
+      date.toLocaleString("default", { month: "2-digit" }),
+      10
+    );
+
+    // Check if an entry with the same year and month already exists
+    const existingEntryIndex = graphDataArray.findIndex(
+      (entry) => entry.Year === year.toString() && entry.Month === month
+    );
+
+    if (existingEntryIndex !== -1) {
+      // If entry exists, increment the Value
+      graphDataArray[existingEntryIndex].Value += 1;
+    } else {
+      // Otherwise, create a new entry
+      graphDataArray.push({ Year: year.toString(), Month: month, Value: 1 });
+    }
+  });
+
+  return graphDataArray.sort((a, b) => {
+    if (a.Year === b.Year) {
+      // Sort by month if years are equal
+      return a.Month - b.Month;
+    } else {
+      // Sort by year
+      return a.Year.localeCompare(b.Year);
+    }
+  });
+};

--- a/src/helpers/databasesPieChartData.js
+++ b/src/helpers/databasesPieChartData.js
@@ -1,0 +1,7 @@
+export const createDatabasesPieChartData = (databaseCounts) => {
+  const pieChartData = [
+    { category: "MySQL", value: databaseCounts.mysql },
+    { category: "PostgreSQL", value: databaseCounts.postgres },
+  ];
+  return pieChartData;
+};

--- a/src/redux/actions/getAdminDatabases.js
+++ b/src/redux/actions/getAdminDatabases.js
@@ -1,8 +1,8 @@
 import axios from "../../axios";
 import {
-    ADMIN_GETTING_ALL_DATABASES,
-    ADMIN_ALL_DATABASES_SUCCESS,
-    ADMIN_ALL_DATABASES_FAIL,
+  ADMIN_GETTING_ALL_DATABASES,
+  ADMIN_ALL_DATABASES_SUCCESS,
+  ADMIN_ALL_DATABASES_FAIL,
 } from "./actionTypes";
 
 const startFetchingDatabases = () => ({
@@ -22,11 +22,18 @@ const adminGetDatabasesFailed = (error) => ({
   },
 });
 
-const adminGetDatabases = (page) => (dispatch) => {
+const adminGetDatabases = (sectionValue, page) => (dispatch) => {
   dispatch(startFetchingDatabases());
 
+  let link;
+  if (sectionValue !== "all") {
+    link = `/databases?db_flavour=${sectionValue}&page=${page}`;
+  } else {
+    link = `/databases?page=${page}`;
+  }
+
   return axios
-    .get(`/databases?page=${page}`)
+    .get(link)
     .then((response) => {
       dispatch(adminGetDatabasesSuccess(response));
     })

--- a/src/router.js
+++ b/src/router.js
@@ -64,7 +64,8 @@ import UserActivity from "./pages/UserActivity";
 import ProjectLogs from "./pages/ProjectLogs";
 import store from "./redux/store";
 import AdminUserOverviewPage from "./pages/AdminUserOverviewPage";
-import AdminProjectsList from "./components/ProjectListing/ProjectList"; 
+import AdminProjectsList from "./components/ProjectListing/ProjectList";
+import AdminDatabaseDetails from "./components/AdminDatabaseDetails";
 
 // Protected route should have token. If not, login.
 const ProtectedRoute = ({ isAllowed, ...props }) =>
@@ -302,6 +303,12 @@ const Routes = () => (
         exact
         path="/databases"
         component={AdminDBList}
+      />
+      <ProtectedRoute
+        isAllowed={hasToken}
+        exact
+        path="/databases/:databaseID"
+        component={AdminDatabaseDetails}
       />
       <ProtectedRoute
         isAllowed={hasToken}


### PR DESCRIPTION
# Description

Using the same layout from the other admin overview pages, the Database overview will also pick the same layout with the first section with summary counts on database types[active/disabled].

The second section has the graphs showing databases created over time and pie chart summary of the available types compared with the total count!

The last section is for the listing of databases and should allow the admin to filter basing on the available database types.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

https://trello.com/c/fi9y6z1C

## How Can This Been Tested?

Run this branch locally and from the cluster's overview page on the admin side proceed to click on the database card to checkout the database overview page.
To view a single database's details, scroll to the listing and select any.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![chrome-capture-2023-7-29 (1)](https://github.com/crane-cloud/frontend/assets/63339234/d2f662b7-7c5a-4d91-9d69-7f3873673bfb)

![image](https://github.com/crane-cloud/frontend/assets/63339234/833d9213-2bff-4e96-9dfa-1618cc907383)
