### PR TITLE
chore: re-route to admin projects details page on click from overview

### DIFF
--- a/src/components/AdminProjectDetails/AdminProjectDetails.module.css
+++ b/src/components/AdminProjectDetails/AdminProjectDetails.module.css
@@ -23,6 +23,11 @@
   grid-template-columns: 1.3fr 6fr;
   overflow: hidden;
 }
+.CenterSection {
+  background-color: var(--gray-bg-light-color);
+  display: flex;
+  width: 100vw;
+}
 
 .SideBarSection {
   overflow: hidden;
@@ -45,6 +50,7 @@
   display: grid;
   grid-template-rows: 80px auto;
   overflow: auto;
+  width: 100%;
 }
 
 
@@ -89,6 +95,17 @@
   padding-left: 4rem;
   padding-right: 2rem;
   padding-bottom: 5rem;
+}
+
+.CustomOverViewSmallContainer {
+  /* padding: 2rem; */
+  background: var(--gray-bg-light-color);
+  max-width: 50rem;
+  padding-left: 4rem;
+  padding-right: 2rem;
+  padding-bottom: 5rem;
+  display: flex;
+  justify-self: center;
 }
 
 .field {

--- a/src/components/AdminProjectDetails/index.js
+++ b/src/components/AdminProjectDetails/index.js
@@ -17,10 +17,13 @@ import Modal from "../Modal";
 import { ReactComponent as BackButton } from "../../assets/images/arrow-left.svg";
 import Feedback from "../Feedback";
 import NewResourceCard from "../NewResourceCard";
+import { useLocation } from 'react-router-dom';
 
 const AdminProjectDetails = () => {
   const clusterID = localStorage.getItem("clusterID");
   const clusterName = localStorage.getItem("clusterName");
+  const location = useLocation();
+  const isOverviewProject = location.pathname.includes('/projects-overview');
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
@@ -40,16 +43,16 @@ const AdminProjectDetails = () => {
   };
 
   const fetchProjectDetails = useCallback(() => {
-    setLoading(true);
     handleGetRequest(`/projects/${projectID}`)
       .then((response) => {
         setDetails(response.data.data.project);
-        setLoading(false);
       })
       .catch((error) => {
         setError("Failed to fetch project detail please refresh");
+      })
+      .finally(()=>{
         setLoading(false);
-      });
+      })
   }, [projectID]);
 
   useEffect(() => {
@@ -81,10 +84,11 @@ const AdminProjectDetails = () => {
       <div className={styles.TopBarSection}>
         <Header />
       </div>
-      <div className={styles.MainSection}>
-        <div className={styles.SideBarSection}>
+      <div className={isOverviewProject? styles.CenterSection : styles.MainSection}>
+       {!isOverviewProject && <div className={styles.SideBarSection}>
           <SideNav clusterName={clusterName} clusterId={clusterID} />
         </div>
+        }
         <div className={styles.MainContentSection}>
           <div className={styles.InformationBarSection}>
             <InformationBar
@@ -92,7 +96,7 @@ const AdminProjectDetails = () => {
                 <span className={styles.InformationBarTitle}>
                   <Link
                     className={ `${styles.breadcrumb} ${styles.flex_back_link}`}
-                    to={`/clusters/${clusterID}/projects-listing`}
+                    to={isOverviewProject? `/projects-overview` : `/clusters/${clusterID}/projects-listing`}
                   >
                     <BackButton />
                     <div className={styles.back_link}>Project Details</div>
@@ -102,7 +106,7 @@ const AdminProjectDetails = () => {
               showBtn={false}
             />
           </div>
-          <div className={styles.CustomSmallContainer}>
+          <div className={isOverviewProject ?  styles.CustomOverViewSmallContainer : styles.CustomSmallContainer}>
             {loading ? (
               <div className={styles.CentralSpinner}>
                 <Spinner />

--- a/src/components/AppListing/index.js
+++ b/src/components/AppListing/index.js
@@ -15,7 +15,7 @@ const AppListing = (props) => {
   }, [gettingApps, currentPage]);
   
   return (
-    <div className="APage">
+    <div className="SubTableContainer">
       <div className="AMainSection">
         <div className="ContentSection">
           <div

--- a/src/components/ProjectListing/ProjectList.js
+++ b/src/components/ProjectListing/ProjectList.js
@@ -18,6 +18,9 @@ import { filterGraphData } from "../../helpers/filterGraphData.js";
 import { retrieveMonthNames } from "../../helpers/monthNames.js";
 import NewResourceCard from "../../components/NewResourceCard";
 import Select from "../../components/Select";
+import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
+import { Link } from "react-router-dom/cjs/react-router-dom.min";
+import { ReactComponent as BackButton } from "../../assets/images/arrow-left.svg";
 import {
   projectPieCategories,
   projectGraphCategories,
@@ -58,6 +61,7 @@ const AdminProjectsOverview = () => {
   let createNewPieChartData = [];
   let filteredGraphData = [];
   let newFilteredGraphData = [];
+  const history = useHistory();
 
   const COLORS = [
     "#0088FE",
@@ -435,7 +439,18 @@ const AdminProjectsOverview = () => {
       <div className="AMainSection">
         <div className="ContentSection">
           <div className="InformationBarSection">
-            <InformationBar header={<>Projects Listing</>} showBackBtn={true} />
+            <InformationBar  header={
+                <span className="ProjectsInformationBarTitle">
+                  <Link
+                    className={ `breadcrumb flex_back_link`}
+                    to={`/clusters`}
+                  >
+                    <BackButton />
+                    <div className="back_link">Project Listing</div>
+                  </Link>
+                </span>
+              }
+              showBtn={false} />
           </div>
 
           <div className="TitleArea">
@@ -905,7 +920,11 @@ const AdminProjectsOverview = () => {
                               isRetrieved &&
                               projects !== undefined &&
                               projects.map((project) => (
-                                <tr key={projects.indexOf(project)}>
+                                <tr 
+                                onClick={() => {
+                                  history.push(`/projects-overview/${project.id}/details`);
+                                }}
+                                key={projects.indexOf(project)}>
                                   <td>{project?.name}</td>
                                   <td>{getUserName(project?.owner_id)}</td>
                                   <td>{project?.description}</td>

--- a/src/components/UserListing/index.jsx
+++ b/src/components/UserListing/index.jsx
@@ -25,7 +25,7 @@ const UserListing = (props) => {
   // };
 
   return (
-    <div className="APage">
+    <div className="SubTableContainer">
       <div className="AMainSection">
         <div className="ContentSection">
           <div

--- a/src/index.css
+++ b/src/index.css
@@ -548,6 +548,17 @@ tr.TableLoading td {
 
 }
 
+.InformationBarTitle{
+  display: flex;
+  flex-direction: row;
+}
+.flex_back_link {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  color: #000 !important
+}
+
 
 
 /* //////////////////////////////////////////// */

--- a/src/index.css
+++ b/src/index.css
@@ -606,3 +606,7 @@ tr.TableLoading td {
   align-items: center;
   justify-content: center;
 }
+
+.SubTableContainer{
+  padding-bottom: 5rem;
+}

--- a/src/pages/AdminProjectsPage/index.js
+++ b/src/pages/AdminProjectsPage/index.js
@@ -14,6 +14,7 @@ import usePaginator from "../../hooks/usePaginator";
 import Pagination from "../../components/Pagination";
 import { handleGetRequest } from "../../apis/apis.js";
 import { ReactComponent as SearchButton } from "../../assets/images/search.svg";
+import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
 
 
 const AdminProjectsPage = () => {
@@ -21,7 +22,7 @@ const AdminProjectsPage = () => {
   const clusterID = localStorage.getItem("clusterID");
   const dispatch = useDispatch();
   const [word, setWord] = useState("");
-  // const [searchProjectList, setSearchProjectList] = useState([]);
+  const history = useHistory();
 
   const { isRetrieved , isRetrieving, projects, pagination} = useSelector(
     (state) => state.adminProjectsReducer
@@ -196,7 +197,11 @@ const AdminProjectsPage = () => {
                     {isRetrieved &&
                       projects !== undefined &&
                        projects.map((project) =>(
-                        <tr key={projects.indexOf(project)}>
+                        <tr 
+                        onClick={() => {
+                          history.push(`/projects/${project.id}/details`);
+                        }}
+                        key={projects.indexOf(project)}>
                            <td>{project?.name}</td>
                             <td>{getUserName(project?.owner_id)}</td>
                             <td >{project?.description}</td>

--- a/src/redux/actions/adminProjectsList.js
+++ b/src/redux/actions/adminProjectsList.js
@@ -22,11 +22,18 @@ export const getAdminProjectsFailed = (error) => ({
   },
 });
 
-const getAdminProjectsList = (page , keyword) => async (dispatch) => {
+const getAdminProjectsList = (page , keyword, state='') => async (dispatch) => {
   dispatch(startTheFetch());
+  let url
+  if(state){
+   url = `/projects?keywords=${keyword}&page=${page}&disabled=${state}`
+  }else{
+   url =  `/projects?page=${page}&keywords=${keyword}`
+  }
+
   try {
     const response = await axios.get(
-     `/projects?keywords=${keyword}&page=${page}`
+    url
     );
     return dispatch(getAdminProjectsSuccess(response));
   } catch (error) {

--- a/src/router.js
+++ b/src/router.js
@@ -94,7 +94,6 @@ const Routes = () => (
       <Route path="/terms-of-service" component={Terms} />
       <Route path="/privacy-policy" component={Privacy} />
       <Route path="/status" component={MonitoringPage} />
-      <Route path="/projects-overview" component={AdminProjectsOverview} />
       {/* projects */}
       <ProtectedRoute
         isAllowed={hasToken}
@@ -228,6 +227,18 @@ const Routes = () => (
         exact
         path="/projects/:projectID/details"
         component={AdminProjectDetails}
+      />
+      <ProtectedRoute
+        isAllowed={hasToken}
+        exact
+        path="/projects-overview/:projectID/details"
+        component={AdminProjectDetails}
+      />
+      <Route
+      isAllowed={hasToken}
+      exact 
+      path="/projects-overview" 
+      component={AdminProjectsOverview} 
       />
       <ProtectedRoute
         isAllowed={hasToken}


### PR DESCRIPTION
# Description

Make a project on overview listing clickable to route to its details page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/xYPdCMqE

## How Can This Been Tested?

Checkout the projects overview page and scroll down to the listing.
When you click on a project, you should be able to see its details.
The active filter on the listing should also be operational

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="1421" alt="Screenshot 2023-09-05 at 13 50 25" src="https://github.com/crane-cloud/frontend/assets/69305400/2650d10c-3d7d-43bb-a76a-04bdeb929e68">
