### PR TITLE
Add new provision to re-generate link on new input field

### DIFF
--- a/src/components/DockerWebHook/index.js
+++ b/src/components/DockerWebHook/index.js
@@ -38,6 +38,7 @@ const DockerWebHook = () => {
 
   const handleInputChange = (e) => {
     setImageTag(e.target.value);
+    setShowUrl(false);
   };
 
   const updateUrl = () => {


### PR DESCRIPTION
# Description

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/P2GGA7LW
## How Can This Been Tested?

Try typing in the input field for image tag attribute on the Webhook page
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots
