### PR TITLE
chore: add loading and error states on admin sections

### DIFF
--- a/src/components/AdminDB/index.jsx
+++ b/src/components/AdminDB/index.jsx
@@ -266,65 +266,73 @@ const AdminDBList = () => {
                       </div>
                     </span>
                   </div>
-                  <AreaChart
-                    width={600}
-                    height={350}
-                    margin={{
-                      top: 20,
-                      right: 30,
-                      left: 0,
-                      bottom: 0,
-                    }}
-                    syncId="anyId"
-                    data={period !== "all" ? filteredGraphData : graphDataArray}
-                  >
-                    <Line type="monotone" dataKey="Value" stroke="#8884d8" />
-                    <CartesianGrid stroke="#ccc" />
-                    <XAxis dataKey="Month" />
-                    <XAxis
-                      xAxisId={1}
-                      dx={10}
-                      label={{
-                        value: "Months",
-                        angle: 0,
-                        position: "outside",
+                  {graphDataArray.length > 0 ? (
+                    <AreaChart
+                      width={600}
+                      height={350}
+                      margin={{
+                        top: 20,
+                        right: 30,
+                        left: 0,
+                        bottom: 0,
                       }}
-                      height={70}
-                      interval={12}
-                      dataKey="Year"
-                      tickLine={false}
-                      tick={{ fontSize: 12, angle: 0 }}
-                    />
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <YAxis
-                      label={{
-                        value: "Number of Databases",
-                        angle: 270,
-                        position: "outside",
-                      }}
-                      width={80}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="Value"
-                      stroke="#82ca9d"
-                      fill="#82ca9d"
-                    />
-                    <Tooltip
-                      labelFormatter={(value) => {
-                        const monthNames = retrieveMonthNames();
-                        const month = parseInt(value) - 1;
-                        return monthNames[month].name;
-                      }}
-                      formatter={(value) => {
-                        if (value === 1) {
-                          return [`${value} database`];
-                        } else {
-                          return [`${value} databases`];
-                        }
-                      }}
-                    />
-                  </AreaChart>
+                      syncId="anyId"
+                      data={
+                        period !== "all" ? filteredGraphData : graphDataArray
+                      }
+                    >
+                      <Line type="monotone" dataKey="Value" stroke="#8884d8" />
+                      <CartesianGrid stroke="#ccc" />
+                      <XAxis dataKey="Month" />
+                      <XAxis
+                        xAxisId={1}
+                        dx={10}
+                        label={{
+                          value: "Months",
+                          angle: 0,
+                          position: "outside",
+                        }}
+                        height={70}
+                        interval={12}
+                        dataKey="Year"
+                        tickLine={false}
+                        tick={{ fontSize: 12, angle: 0 }}
+                      />
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <YAxis
+                        label={{
+                          value: "Number of Databases",
+                          angle: 270,
+                          position: "outside",
+                        }}
+                        width={80}
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey="Value"
+                        stroke="#82ca9d"
+                        fill="#82ca9d"
+                      />
+                      <Tooltip
+                        labelFormatter={(value) => {
+                          const monthNames = retrieveMonthNames();
+                          const month = parseInt(value) - 1;
+                          return monthNames[month].name;
+                        }}
+                        formatter={(value) => {
+                          if (value === 1) {
+                            return [`${value} database`];
+                          } else {
+                            return [`${value} databases`];
+                          }
+                        }}
+                      />
+                    </AreaChart>
+                  ) : (
+                    <div className="ResourceSpinnerWrapper">
+                      <Spinner size="big" />
+                    </div>
+                  )}
                 </div>
 
                 <div className="VisualArea">
@@ -333,57 +341,63 @@ const AdminDBList = () => {
                       Pie Chart for Database Flavors
                     </span>
                   </div>
-                  <div className="PieContainer">
-                    <div className="ChartColumn">
-                      <PieChart width={300} height={300}>
-                        <Pie
-                          data={createDatabasesPieChartData(databaseCounts)}
-                          dataKey="value"
-                          nameKey="category"
-                          cx="50%"
-                          cy="50%"
-                          outerRadius={140}
-                          paddingAngle={3}
-                        >
+                  {Object.keys(metadata).length === 0 ? (
+                    <div className="ResourceSpinnerWrapper">
+                      <Spinner size="big" />
+                    </div>
+                  ) : (
+                    <div className="PieContainer">
+                      <div className="ChartColumn">
+                        <PieChart width={300} height={300}>
+                          <Pie
+                            data={createDatabasesPieChartData(databaseCounts)}
+                            dataKey="value"
+                            nameKey="category"
+                            cx="50%"
+                            cy="50%"
+                            outerRadius={140}
+                            paddingAngle={3}
+                          >
+                            {createDatabasesPieChartData(databaseCounts).map(
+                              (entry, index) => (
+                                <Cell
+                                  key={`cell-${index}`}
+                                  fill={COLORS[index % COLORS.length]}
+                                />
+                              )
+                            )}
+                          </Pie>
+                          <Tooltip />
+                        </PieChart>
+                      </div>
+                      <div className="PercentageColumn">
+                        <ul className="KeyItems">
                           {createDatabasesPieChartData(databaseCounts).map(
                             (entry, index) => (
-                              <Cell
-                                key={`cell-${index}`}
-                                fill={COLORS[index % COLORS.length]}
-                              />
+                              <>
+                                {" "}
+                                <li key={`list-item-${index}`}>
+                                  <span
+                                    style={{
+                                      color: COLORS[index % COLORS.length],
+                                    }}
+                                  >
+                                    {entry.category}:
+                                  </span>{" "}
+                                  {(
+                                    (entry.value / databaseCounts.total) *
+                                    100
+                                  ).toFixed(0)}
+                                  %
+                                </li>
+                                <hr style={{ width: "100%" }} />
+                              </>
                             )
                           )}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
+                        </ul>
+                      </div>
                     </div>
-                    <div className="PercentageColumn">
-                      <ul className="KeyItems">
-                        {createDatabasesPieChartData(databaseCounts).map(
-                          (entry, index) => (
-                            <>
-                              {" "}
-                              <li key={`list-item-${index}`}>
-                                <span
-                                  style={{
-                                    color: COLORS[index % COLORS.length],
-                                  }}
-                                >
-                                  {entry.category}:
-                                </span>{" "}
-                                {(
-                                  (entry.value / databaseCounts.total) *
-                                  100
-                                ).toFixed(0)}
-                                %
-                              </li>
-                              <hr style={{ width: "100%" }} />
-                            </>
-                          )
-                        )}
-                      </ul>
-                    </div>
-                  </div>
+                  )}
                 </div>
               </div>
 

--- a/src/components/AdminProjectDetails/AdminProjectDetails.module.css
+++ b/src/components/AdminProjectDetails/AdminProjectDetails.module.css
@@ -26,7 +26,7 @@
 }
 
 .CenterSection {
-  background-color: var(--gray-bg-light-color);
+  /* background-color: var(--gray-bg-light-color); */
   display: flex;
   width: 100vw;
 }

--- a/src/components/AdminProjectDetails/index.js
+++ b/src/components/AdminProjectDetails/index.js
@@ -86,43 +86,33 @@ const AdminProjectDetails = () => {
 
     try {
       if (details.disabled) {
-        handlePostRequestWithOutDataObject(
-          {},
-          `/projects/${projectID}/enable`
-        )
+        handlePostRequestWithOutDataObject({}, `/projects/${projectID}/enable`)
           .then(() => {
             window.location.reload();
           })
           .catch((error) => {
-            setError(error)
+            setError(error);
           });
       } else {
-        handlePostRequestWithOutDataObject(
-          {},
-          `/projects/${projectID}/disable`
-        )
+        handlePostRequestWithOutDataObject({}, `/projects/${projectID}/disable`)
           .then(() => {
             window.location.reload();
           })
           .catch((error) => {
-            setError(error)
+            setError(error);
           });
       }
     } catch (error) {
       console.error("API call error:", error);
-    } 
+    }
   };
 
   return (
-    <section className={styles.Page}>
+    <div className="MainPage">
       <div className={styles.TopBarSection}>
         <Header />
       </div>
-      <div
-        className={
-          isOverviewProject ? styles.CenterSection : styles.MainSection
-        }
-      >
+      <div className={isOverviewProject ? "Mainsection" : styles.MainSection}>
         {!isOverviewProject && (
           <div className={styles.SideBarSection}>
             <SideNav clusterName={clusterName} clusterId={clusterID} />
@@ -157,201 +147,193 @@ const AdminProjectDetails = () => {
                 : styles.CustomSmallContainer
             }
           >
-            {loading ? (
-              <div className={styles.CentralSpinner}>
-                <Spinner />
+            {loading || Object.keys(details).length === 0 ? (
+              <div className={styles.ResourceSpinnerWrapper}>
+                <Spinner size="big" />
               </div>
-            ) : (
+            ) : Object.keys(details).length > 0 ? (
               <>
-                {!error && (
-                  <div>
-                    {/* Project information */}
-                    <section className={styles.DetailsSection}>
-                      <div className="SectionTitle">Project Information</div>
-                      <div className={styles.ProjectInstructions}>
-                        <div className={styles.ProjectInfo}>
-                          <div className={styles.ProjectInfoHeader}>
-                            <div className={styles.AvatarName}>
-                              <Avatar
-                                name={details?.name}
-                                className={styles.avatar_author}
-                              />
+                <div>
+                  {/* Project information */}
+                  <section className={styles.DetailsSection}>
+                    <div className="SectionTitle">Project Information</div>
+                    <div className={styles.ProjectInstructions}>
+                      <div className={styles.ProjectInfo}>
+                        <div className={styles.ProjectInfoHeader}>
+                          <div className={styles.AvatarName}>
+                            <Avatar
+                              name={details?.name}
+                              className={styles.avatar_author}
+                            />
+                          </div>
+                          <div>
+                            <div className={styles.flex_name_status}>
+                              <div className={styles.ProjectName}>
+                                {details?.name}
+                              </div>
+                              <div className={styles.ProjectStatus}>
+                                {details?.disabled ? (
+                                  <div
+                                    className={`${styles.font_status} ${styles.disabled}`}
+                                  >
+                                    Disabled
+                                  </div>
+                                ) : (
+                                  <div
+                                    className={`${styles.font_status} ${styles.active}`}
+                                  >
+                                    Active
+                                  </div>
+                                )}
+                              </div>
                             </div>
-                            <div>
-                              <div className={styles.flex_name_status}>
-                                <div className={styles.ProjectName}>
-                                  {details?.name}
-                                </div>
-                                <div className={styles.ProjectStatus}>
-                                  {details?.disabled ? (
-                                    <div
-                                      className={`${styles.font_status} ${styles.disabled}`}
-                                    >
-                                      Disabled
-                                    </div>
-                                  ) : (
-                                    <div
-                                      className={`${styles.font_status} ${styles.active}`}
-                                    >
-                                      Active
-                                    </div>
-                                  )}
-                                </div>
-                              </div>
-                              <div className={styles.ProjectDescription}>
-                                {details?.description}
-                              </div>
+                            <div className={styles.ProjectDescription}>
+                              {details?.description}
                             </div>
                           </div>
-                          <div className={styles.ProjectInfoBody}>
-                            <div className={styles.ProjectInfoOwner}>
-                              <div className={styles.project_details_type}>
-                                Project Type:{" "}
-                                <span className={styles.boldStyle}>
-                                  {details?.project_type}
-                                </span>
-                              </div>
-                              <div className={styles.line_between}></div>
-                              <div className={styles.project_details_type}>
-                                Organization:{" "}
-                                <span className={styles.boldStyle}>
-                                  {details?.organisation}
-                                </span>
-                              </div>
-                              <div className={styles.line_between}></div>
-                              <div className={styles.project_details_type}>
-                                Created:{" "}
-                                <span className={styles.boldStyle}>
-                                  {dateInWords(details?.date_created)}
-                                </span>
-                              </div>
+                        </div>
+                        <div className={styles.ProjectInfoBody}>
+                          <div className={styles.ProjectInfoOwner}>
+                            <div className={styles.project_details_type}>
+                              Project Type:{" "}
+                              <span className={styles.boldStyle}>
+                                {details?.project_type}
+                              </span>
+                            </div>
+                            <div className={styles.line_between}></div>
+                            <div className={styles.project_details_type}>
+                              Organization:{" "}
+                              <span className={styles.boldStyle}>
+                                {details?.organisation}
+                              </span>
+                            </div>
+                            <div className={styles.line_between}></div>
+                            <div className={styles.project_details_type}>
+                              Created:{" "}
+                              <span className={styles.boldStyle}>
+                                {dateInWords(details?.date_created)}
+                              </span>
                             </div>
                           </div>
                         </div>
                       </div>
-                    </section>
-                    {/* Project Metrics */}
-                    <section className={styles.DetailsSection}>
-                      <div className="SectionTitle">Project Metrics</div>
-                      <div className={styles.flex_metrics}>
-                        {Object.keys(projectCount).map((key, index) => (
-                          <NewResourceCard
-                            key={index}
-                            title={key}
-                            count={projectCount[key]}
-                          />
-                        ))}
-                      </div>
-                    </section>
-                    {/* Membership */}
-                    <section className={styles.DetailsSection}>
-                      <div className="SectionTitle">Membership</div>
-                      <div className={styles.ProjectInstructions}>
-                        <>
-                          <div className={styles.MembershipHeader}>
-                            <div className={styles.MemberSection}>
-                              <div className={styles.SettingsSectionInfoHeader}>
-                                {details?.users?.length === 1 ? (
-                                  <div className="SectionSubTitle">
-                                    Project has 1 Team Member
-                                  </div>
-                                ) : (
-                                  <div>
-                                    Project has {details?.users?.length} Team
-                                    Members
-                                  </div>
-                                )}
-                              </div>
-                              <div className="SubText">
-                                Members that have accounts on crane cloud can
-                                perform different operations on the project
-                                depending on their permission.
-                              </div>
+                    </div>
+                  </section>
+                  {/* Project Metrics */}
+                  <section className={styles.DetailsSection}>
+                    <div className="SectionTitle">Project Metrics</div>
+                    <div className={styles.flex_metrics}>
+                      {Object.keys(projectCount).map((key, index) => (
+                        <NewResourceCard
+                          key={index}
+                          title={key}
+                          count={projectCount[key]}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                  {/* Membership */}
+                  <section className={styles.DetailsSection}>
+                    <div className="SectionTitle">Membership</div>
+                    <div className={styles.ProjectInstructions}>
+                      <>
+                        <div className={styles.MembershipHeader}>
+                          <div className={styles.MemberSection}>
+                            <div className={styles.SettingsSectionInfoHeader}>
+                              {details?.users?.length === 1 ? (
+                                <div className="SectionSubTitle">
+                                  Project has 1 Team Member
+                                </div>
+                              ) : (
+                                <div>
+                                  Project has {details?.users?.length} Team
+                                  Members
+                                </div>
+                              )}
+                            </div>
+                            <div className="SubText">
+                              Members that have accounts on crane cloud can
+                              perform different operations on the project
+                              depending on their permission.
                             </div>
                           </div>
-                          <div className={styles.MemberTable}>
-                            <div className={styles.MemberBody}>
-                              {details?.users?.map((entry, index) => (
-                                <div
-                                  className={styles.MemberTableRow}
-                                  key={index}
-                                >
-                                  <div className={styles.MemberInfo}>
-                                    <Avatar
-                                      name={entry.user.name}
-                                      className={styles.MemberAvatar}
-                                    />
-                                    <div className={styles.MemberNameEmail}>
-                                      <div className={styles.UserHeader}>
-                                        {entry.user.name}
-                                      </div>
-                                      <div className={styles.Wrap}>
-                                        {entry.user.email}
-                                      </div>
+                        </div>
+                        <div className={styles.MemberTable}>
+                          <div className={styles.MemberBody}>
+                            {details?.users?.map((entry, index) => (
+                              <div
+                                className={styles.MemberTableRow}
+                                key={index}
+                              >
+                                <div className={styles.MemberInfo}>
+                                  <Avatar
+                                    name={entry.user.name}
+                                    className={styles.MemberAvatar}
+                                  />
+                                  <div className={styles.MemberNameEmail}>
+                                    <div className={styles.UserHeader}>
+                                      {entry.user.name}
                                     </div>
-                                  </div>
-                                  {entry.role !== "RolesList.owner" &&
-                                    entry.accepted_collaboration_invite ===
-                                      false && (
-                                      <div className="SubText">
-                                        Invite pending.
-                                      </div>
-                                    )}
-                                  <div className={styles.MemberOptions}>
-                                    <div className={styles.MemberRole}>
-                                      <span>Role:</span>
-                                      {entry.role.split(".").pop()}
+                                    <div className={styles.Wrap}>
+                                      {entry.user.email}
                                     </div>
                                   </div>
                                 </div>
-                              ))}
-                            </div>
-                          </div>
-                        </>
-                      </div>
-                    </section>
-                    <div className="AdminDBSections">
-                      <div className="SectionTitle">Manage Project</div>
-                      <div className="ProjectInstructions">
-                        <div className="MemberBody">
-                          <div className="MemberTableRow">
-                            <div className="SettingsSectionRow">
-                              <div className="SubTitle">
-                                {details?.disabled ? "Enable" : "Disable"}{" "}
-                                project
-                                <br />
-                                <div className="SubTitleContent">
-                                  {details?.disabled
-                                    ? "Enable and make all project resources accessible (apps, and databases) to the user."
-                                    : "Disable and make all project resources inaccessible (apps, and databases) to the user."}
+                                {entry.role !== "RolesList.owner" &&
+                                  entry.accepted_collaboration_invite ===
+                                    false && (
+                                    <div className="SubText">
+                                      Invite pending.
+                                    </div>
+                                  )}
+                                <div className={styles.MemberOptions}>
+                                  <div className={styles.MemberRole}>
+                                    <span>Role:</span>
+                                    {entry.role.split(".").pop()}
+                                  </div>
                                 </div>
                               </div>
-                              <div className="SectionButtons">
-                                <PrimaryButton
-                                  color="red-outline"
-                                  onClick={handleEnableButtonClick}
-                                  className={
-                                    details?.disabled
-                                      ? "enableBtn"
-                                      : "disableBtn"
-                                  }
-                                >
-                                  {details?.disabled
-                                    ? "Enable"
-                                    : "Disable"}
-                                </PrimaryButton>
+                            ))}
+                          </div>
+                        </div>
+                      </>
+                    </div>
+                  </section>
+                  <div className="AdminDBSections">
+                    <div className="SectionTitle">Manage Project</div>
+                    <div className="ProjectInstructions">
+                      <div className="MemberBody">
+                        <div className="MemberTableRow">
+                          <div className="SettingsSectionRow">
+                            <div className="SubTitle">
+                              {details?.disabled ? "Enable" : "Disable"} project
+                              <br />
+                              <div className="SubTitleContent">
+                                {details?.disabled
+                                  ? "Enable and make all project resources accessible (apps, and databases) to the user."
+                                  : "Disable and make all project resources inaccessible (apps, and databases) to the user."}
                               </div>
+                            </div>
+                            <div className="SectionButtons">
+                              <PrimaryButton
+                                color="red-outline"
+                                onClick={handleEnableButtonClick}
+                                className={
+                                  details?.disabled ? "enableBtn" : "disableBtn"
+                                }
+                              >
+                                {details?.disabled ? "Enable" : "Disable"}
+                              </PrimaryButton>
                             </div>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                )}
+                </div>
               </>
-            )}
-            {Object.keys(details).length < 0 && error && (
-              <div className={styles.CentralSpinner}>{error}</div>
+            ) : (
+              <div className="NoResourcesMessage">{error}</div>
             )}
           </div>
           <AppFooter />
@@ -412,7 +394,7 @@ const AdminProjectDetails = () => {
           </Modal>
         </div>
       )}
-    </section>
+    </div>
   );
 };
 

--- a/src/components/AdminUsersProfile/index.js
+++ b/src/components/AdminUsersProfile/index.js
@@ -30,7 +30,7 @@ import AppFooter from "../appFooter";
 import {
   handleGetRequest,
   handlePostRequestWithOutDataObject,
-} from "../../apis/apis"
+} from "../../apis/apis";
 
 class AdminUserPage extends Component {
   constructor() {
@@ -65,7 +65,7 @@ class AdminUserPage extends Component {
     this.handleDisableAlert = this.handleDisableAlert.bind(this);
     this.showDisableAlert = this.showDisableAlert.bind(this);
     this.hideDisableAlert = this.hideDisableAlert.bind(this);
-    this.getUserDetails =  this.getUserDetails.bind(this);
+    this.getUserDetails = this.getUserDetails.bind(this);
   }
   componentDidMount() {
     const {
@@ -241,10 +241,7 @@ class AdminUserPage extends Component {
 
     try {
       if (userDetail.disabled) {
-        handlePostRequestWithOutDataObject(
-          userID,
-          `/users/${userID}/enable`
-        )
+        handlePostRequestWithOutDataObject(userID, `/users/${userID}/enable`)
           .then(() => {
             window.location.reload();
           })
@@ -254,10 +251,7 @@ class AdminUserPage extends Component {
             });
           });
       } else {
-        handlePostRequestWithOutDataObject(
-          userID,
-          `/users/${userID}/disable`
-        )
+        handlePostRequestWithOutDataObject(userID, `/users/${userID}/disable`)
           .then(() => {
             window.location.reload();
           })
@@ -292,8 +286,13 @@ class AdminUserPage extends Component {
     const {
       match: { params },
     } = this.props;
-    const { credits, creditDescription, openDeleteAlert, openDisableAlert, userDetail } =
-      this.state;
+    const {
+      credits,
+      creditDescription,
+      openDeleteAlert,
+      openDisableAlert,
+      userDetail,
+    } = this.state;
     const user = getUser(users, params.userID);
     const { credit_assignment_records } = userCredits;
     return (
@@ -319,382 +318,411 @@ class AdminUserPage extends Component {
               />
             </div>
             <div className="LeftAlignContainer">
-              <div className="ContentSection">
-                <div className="AdminUserPageContainer">
-                  <section>
-                    <div className="SectionTitle">Personal information</div>
-                    <div className="AdminCardArea">
-                      <div className="AdminUserProfileCard">
-                        <div className="AdminUserProfileInfoSect">
-                          <div className="AdminUserProfileInfoHeader">
-                            <Avatar
-                              name={userDetail?.name}
-                              className={userProfleStyles.UserAvatarLarge}
-                            />
-                            <div className={userProfleStyles.Identity}>
-                              <div className={userProfleStyles.IdentityName}>
-                                {userDetail?.name}
-                                {userDetail?.is_beta_user === true && (
-                                  <div className={userProfleStyles.BetaUserDiv}>
-                                    Beta User
+              {userDetail.length === 0 ? (
+                <div className="ResourceSpinnerWrapper">
+                  <Spinner size="big" />
+                </div>
+              ) : (
+                <>
+                  <div className="ContentSection">
+                    <div className="AdminUserPageContainer">
+                      <section>
+                        <div className="SectionTitle">Personal information</div>
+                        <div className="AdminCardArea">
+                          <div className="AdminUserProfileCard">
+                            <div className="AdminUserProfileInfoSect">
+                              <div className="AdminUserProfileInfoHeader">
+                                <Avatar
+                                  name={userDetail?.name}
+                                  className={userProfleStyles.UserAvatarLarge}
+                                />
+                                <div className={userProfleStyles.Identity}>
+                                  <div
+                                    className={userProfleStyles.IdentityName}
+                                  >
+                                    {userDetail?.name}
+                                    {userDetail?.is_beta_user === true && (
+                                      <div
+                                        className={userProfleStyles.BetaUserDiv}
+                                      >
+                                        Beta User
+                                      </div>
+                                    )}
+                                  </div>
+                                  <div
+                                    className={userProfleStyles.IdentityEmail}
+                                  >
+                                    {userDetail?.email}
+                                  </div>
+                                </div>
+                              </div>
+
+                              <div className="AdminProfileRowInfo">
+                                <div className="AdminProfileRowItem">
+                                  Verified:
+                                  <span>
+                                    {userDetail?.verified ? "True" : "False"}
+                                  </span>
+                                </div>
+                                |
+                                <div className="AdminProfileRowItem">
+                                  Role:
+                                  <span>
+                                    {userDetail?.roles?.length > 0
+                                      ? userDetail?.roles[0].name
+                                      : "None"}
+                                  </span>
+                                </div>
+                                |
+                                <div className="AdminProfileRowItem">
+                                  Date Joined:
+                                  <span>
+                                    {moment(userDetail?.date_created)
+                                      .utc()
+                                      .format("ddd, MMMM DD, yyyy")}
+                                  </span>
+                                </div>
+                                |
+                                <div className="AdminProfileRowItem">
+                                  Last Seen:
+                                  <span>
+                                    {userDetail?.last_seen
+                                      ? moment(userDetail?.last_seen)
+                                          .utc()
+                                          .format("ddd, MMMM DD, yyyy")
+                                      : "Not available"}
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </section>
+                      {/* Credential history */}
+                      {credit_assignment_records?.length > 0 && (
+                        <div className="CreditsAlotted">
+                          <div className="CreditsTable">
+                            <div className="CreditsHeader">
+                              Credits Assignment History
+                            </div>
+                            <div className="Credits">
+                              <div className="CreditsHead">
+                                <div className="CreditsHeaderRow">
+                                  <div className="CreditsHeaderAttribute">
+                                    Record ID
+                                  </div>
+                                  <div className="CreditsHeaderAttribute">
+                                    Date & Time
+                                  </div>
+                                  <div className="CreditsHeaderAttribute">
+                                    Amount
+                                  </div>
+                                  <div className="CreditsHeaderAttribute">
+                                    Description
+                                  </div>
+                                </div>
+                              </div>
+                              <div className="CreditsBody">
+                                {credit_assignment_records ? (
+                                  credit_assignment_records.map((credit) => (
+                                    <div className="CreditsHeaderRow">
+                                      <div className="CreditsRowAttribute">
+                                        {credit?.id}
+                                      </div>
+                                      <div className="CreditsRowAttribute">
+                                        {DisplayDateTime(
+                                          new Date(credit?.date_created)
+                                        )}
+                                      </div>
+                                      <div className="CreditsRowAttribute">
+                                        {credit?.amount}
+                                      </div>
+                                      <div className="CreditsRowAttribute">
+                                        {credit?.description}
+                                      </div>
+                                    </div>
+                                  ))
+                                ) : (
+                                  <div className="CreditsError">
+                                    <>No Credits Assigned.</>
                                   </div>
                                 )}
                               </div>
-                              <div className={userProfleStyles.IdentityEmail}>
-                                {userDetail?.email}
-                              </div>
                             </div>
                           </div>
-
-                          <div className="AdminProfileRowInfo">
-                            <div className="AdminProfileRowItem">
-                              Verified:
-                              <span>{userDetail?.verified ? "True" : "False"}</span>
-                            </div>
-                            |
-                            <div className="AdminProfileRowItem">
-                              Role:
-                              <span>
-                                {userDetail?.roles?.length > 0
-                                  ? userDetail?.roles[0].name
-                                  : "None"}
-                              </span>
-                            </div>
-                            |
-                            <div className="AdminProfileRowItem">
-                              Date Joined:
-                              <span>
-                                {moment(userDetail?.date_created)
-                                  .utc()
-                                  .format("ddd, MMMM DD, yyyy")}
-                              </span>
-                            </div>
-                            |
-                            <div className="AdminProfileRowItem">
-                              Last Seen:
-                              <span>
-                                {userDetail?.last_seen
-                                  ? moment(userDetail?.last_seen)
-                                      .utc()
-                                      .format("ddd, MMMM DD, yyyy")
-                                  : "Not available"}
-                              </span>
-                            </div>
-                          </div>
+                        </div>
+                      )}
+                      <div>
+                        <div className="SectionTitle">
+                          User Platform Metrics
+                        </div>
+                        <div className="Cluster1Container">
+                          <NewResourceCard
+                            key={1}
+                            title="Projects Owned"
+                            count={this.state.projectsCount}
+                          />
+                          <NewResourceCard
+                            key={1}
+                            title="Apps Deployed"
+                            count={6}
+                          />
+                          <NewResourceCard
+                            key={1}
+                            title="Databases Created"
+                            count={3}
+                          />
+                          <NewResourceCard
+                            key={1}
+                            title="Credits"
+                            count={
+                              user?.credits.length === 0
+                                ? 0
+                                : user?.credits[0].amount
+                            }
+                          />
                         </div>
                       </div>
-                    </div>
-                  </section>
-                  {/* Credential history */}
-                  {credit_assignment_records?.length > 0 && (
-                    <div className="CreditsAlotted">
-                      <div className="CreditsTable">
-                        <div className="CreditsHeader">
-                          Credits Assignment History
-                        </div>
-                        <div className="Credits">
-                          <div className="CreditsHead">
-                            <div className="CreditsHeaderRow">
-                              <div className="CreditsHeaderAttribute">
-                                Record ID
-                              </div>
-                              <div className="CreditsHeaderAttribute">
-                                Date & Time
-                              </div>
-                              <div className="CreditsHeaderAttribute">
-                                Amount
-                              </div>
-                              <div className="CreditsHeaderAttribute">
-                                Description
-                              </div>
-                            </div>
-                          </div>
-                          <div className="CreditsBody">
-                            {credit_assignment_records ? (
-                              credit_assignment_records.map((credit) => (
-                                <div className="CreditsHeaderRow">
-                                  <div className="CreditsRowAttribute">
-                                    {credit?.id}
-                                  </div>
-                                  <div className="CreditsRowAttribute">
-                                    {DisplayDateTime(
-                                      new Date(credit?.date_created)
-                                    )}
-                                  </div>
-                                  <div className="CreditsRowAttribute">
-                                    {credit?.amount}
-                                  </div>
-                                  <div className="CreditsRowAttribute">
-                                    {credit?.description}
+                      <div className="AdminDBSections">
+                        <div className="SectionTitle">Manage User</div>
+                        <div className="ProjectInstructions">
+                          <div className="MemberBody">
+                            <div className="MemberTableRow">
+                              <div className="SettingsSectionInfo">
+                                <div className="SubTitle">
+                                  Add Credits to User
+                                  <br />
+                                  <div className="SubTitleContent">
+                                    This will add credits to the user.
                                   </div>
                                 </div>
-                              ))
-                            ) : (
-                              <div className="CreditsError">
-                                <>No Credits Assigned.</>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  <div>
-                    <div className="SectionTitle">User Platform Metrics</div>
-                    <div className="Cluster1Container">
-                      <NewResourceCard
-                        key={1}
-                        title="Projects Owned"
-                        count={this.state.projectsCount}
-                      />
-                      <NewResourceCard
-                        key={1}
-                        title="Apps Deployed"
-                        count={6}
-                      />
-                      <NewResourceCard
-                        key={1}
-                        title="Databases Created"
-                        count={3}
-                      />
-                      <NewResourceCard
-                        key={1}
-                        title="Credits"
-                        count={
-                          user?.credits.length === 0
-                            ? 0
-                            : user?.credits[0].amount
-                        }
-                      />
-                    </div>
-                  </div>
-                  <div className="AdminDBSections">
-                    <div className="SectionTitle">Manage User</div>
-                    <div className="ProjectInstructions">
-                      <div className="MemberBody">
-                        <div className="MemberTableRow">
-                          <div className="SettingsSectionInfo">
-                            <div className="SubTitle">
-                              Add Credits to User
-                              <br />
-                              <div className="SubTitleContent">
-                                This will add credits to the user.
+                                <div className="SectionButtons">
+                                  <PrimaryButton
+                                    color="primary-outline"
+                                    onClick={this.showCreditsModal}
+                                  >
+                                    Add Credits
+                                  </PrimaryButton>
+                                </div>
                               </div>
                             </div>
-                            <div className="SectionButtons">
-                              <PrimaryButton
-                                color="primary-outline"
-                                onClick={this.showCreditsModal}
-                              >
-                                Add Credits
-                              </PrimaryButton>
+                            <div className="MemberTableRow">
+                              <div className="SettingsSectionInfo">
+                                <div className="SubTitle">
+                                  {userDetail?.disabled ? "Enable" : "Disable"}{" "}
+                                  User
+                                  <br />
+                                  <div className="SubTitleContent">
+                                    {userDetail?.disabled
+                                      ? "This will enable this user."
+                                      : "This will temporary disable the user."}
+                                  </div>
+                                </div>
+                                <div className="SectionButtons">
+                                  <PrimaryButton
+                                    onClick={this.handleEnableButtonClick}
+                                    color={
+                                      userDetail?.disabled
+                                        ? "primary-outline"
+                                        : "red-outline"
+                                    }
+                                  >
+                                    {userDetail?.disabled
+                                      ? "Enable"
+                                      : "Disable"}
+                                  </PrimaryButton>
+                                </div>
+                              </div>
+                            </div>
+                            <div className="SettingsSectionInfo1">
+                              <div className="SubTitle">
+                                Delete User
+                                <br />
+                                <div className="SubTitleContent">
+                                  This will permanently delete the user-history
+                                  , apps , database and settings.
+                                </div>
+                              </div>
+                              <div className="SectionButtons">
+                                <PrimaryButton
+                                  color="red-outline"
+                                  onClick={this.showDeleteAlert}
+                                >
+                                  Delete
+                                </PrimaryButton>
+                              </div>
                             </div>
                           </div>
                         </div>
-                        <div className="MemberTableRow">
-                          <div className="SettingsSectionInfo">
-                            <div className="SubTitle">
-                              {userDetail?.disabled ? "Enable" : "Disable"} User
-                              <br />
-                              <div className="SubTitleContent">
-                                {userDetail?.disabled
-                                  ? "This will enable this user."
-                                  : "This will temporary disable the user."}
-                              </div>
-                            </div>
-                            <div className="SectionButtons">
-                              <PrimaryButton
-                                onClick={this.handleEnableButtonClick}
-                                color={
-                                  userDetail?.disabled
-                                    ? "primary-outline"
-                                    : "red-outline"
-                                }
-                              >
-                                {userDetail?.disabled ? "Enable" : "Disable"}
-                              </PrimaryButton>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="SettingsSectionInfo1">
-                          <div className="SubTitle">
-                            Delete User
-                            <br />
-                            <div className="SubTitleContent">
-                              This will permanently delete the user-history ,
-                              apps , database and settings.
-                            </div>
-                          </div>
-                          <div className="SectionButtons">
-                            <PrimaryButton
-                              color="red-outline"
-                              onClick={this.showDeleteAlert}
+                        {openDeleteAlert && (
+                          <div className="ProjectDeleteModel">
+                            <Modal
+                              showModal={openDeleteAlert}
+                              onClickAway={this.hideDeleteAlert}
                             >
-                              Delete
-                            </PrimaryButton>
+                              <div className="DeleteDatabaseModel">
+                                <div className="DeleteProjectModalUpperSection">
+                                  <div className="InnerModalDescription">
+                                    Are you sure you want to delete this user
+                                    &nbsp;
+                                    <span className="DatabaseName">
+                                      {userDetail?.name} ?
+                                    </span>
+                                    <DeleteWarning />
+                                  </div>
+                                </div>
+
+                                <div className="DeleteProjectModalLowerSection">
+                                  <div className="DeleteProjectModelButtons">
+                                    <PrimaryButton
+                                      className="CancelBtn"
+                                      onClick={this.hideDeleteAlert}
+                                    >
+                                      Cancel
+                                    </PrimaryButton>
+                                    <PrimaryButton
+                                      color="red"
+                                      onClick={(e) =>
+                                        this.handleDeleteAlert(e, userID)
+                                      }
+                                    >
+                                      {deletingUser ? <Spinner /> : "Delete"}
+                                    </PrimaryButton>
+                                  </div>
+
+                                  {userDeleteFailed && isDeleteUser && (
+                                    <Feedback
+                                      message={isDeleteUser}
+                                      type="error"
+                                    />
+                                  )}
+                                </div>
+                              </div>
+                            </Modal>
                           </div>
+                        )}
+                        {openDisableAlert && (
+                          <div className="ProjectDeleteModel">
+                            <Modal
+                              showModal={openDisableAlert}
+                              onClickAway={this.hideDisableAlert}
+                            >
+                              <div className="DeleteDatabaseModel">
+                                <div className="DeleteProjectModalUpperSection">
+                                  <div className="InnerModalDescription">
+                                    Are you sure you want to disable this user
+                                    &nbsp;
+                                    <span className="DatabaseName">
+                                      {userDetail?.name} ?
+                                    </span>
+                                  </div>
+                                </div>
+
+                                <div className="DeleteProjectModalLowerSection">
+                                  <div className="DeleteProjectModelButtons">
+                                    <PrimaryButton
+                                      className="CancelBtn"
+                                      onClick={this.hideDisableAlert}
+                                    >
+                                      Cancel
+                                    </PrimaryButton>
+                                    <PrimaryButton
+                                      color="red"
+                                      onClick={(e) =>
+                                        this.handleDisableAlert(e, userID)
+                                      }
+                                    >
+                                      {isDisablingUser ? (
+                                        <Spinner />
+                                      ) : (
+                                        "Disable"
+                                      )}
+                                    </PrimaryButton>
+                                  </div>
+
+                                  {userDisableFailed && isDisableUser && (
+                                    <Feedback
+                                      message={isDisableUser}
+                                      type="error"
+                                    />
+                                  )}
+                                </div>
+                              </div>
+                            </Modal>
+                          </div>
+                        )}
+
+                        {!isFetching && !isFetched && (
+                          <div className="NoResourcesMessage">
+                            <p>
+                              Oops! Something went wrong! Failed to retrieve
+                              User Profile.
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    <Modal
+                      showModal={this.state.addCredits}
+                      onClickAway={() => this.hideCreditsModal()}
+                    >
+                      <div className="ModalHeader">
+                        <h5 className="ModalTitle">Add Credits</h5>
+
+                        <div className="">Number of credits</div>
+                        <div className="ModalContent">
+                          <BlackInputText
+                            required
+                            placeholder="Number of credits"
+                            name="credits"
+                            type="number"
+                            value={credits}
+                            onChange={(e) => {
+                              this.handleChange(e);
+                            }}
+                          />
                         </div>
+                        <div className="CreditsTitle">Description</div>
+                        <textarea
+                          className="TextArea"
+                          type="text"
+                          placeholder="Credits description"
+                          rows="4"
+                          cols="50"
+                          name="creditDescription"
+                          value={creditDescription}
+                          onChange={(e) => {
+                            this.handleChange(e);
+                          }}
+                        />
                       </div>
-                    </div>
-                    {openDeleteAlert && (
-                      <div className="ProjectDeleteModel">
-                        <Modal
-                          showModal={openDeleteAlert}
-                          onClickAway={this.hideDeleteAlert}
-                        >
-                          <div className="DeleteDatabaseModel">
-                            <div className="DeleteProjectModalUpperSection">
-                              <div className="InnerModalDescription">
-                                Are you sure you want to delete this user &nbsp;
-                                <span className="DatabaseName">
-                                  {userDetail?.name} ?
-                                </span>
-                                <DeleteWarning />
-                              </div>
-                            </div>
+                      <div className="ModalFooter">
+                        <div className="ModalButtons">
+                          <PrimaryButton
+                            className="CancelBtn"
+                            onClick={() => this.hideCreditsModal()}
+                          >
+                            Cancel
+                          </PrimaryButton>
 
-                            <div className="DeleteProjectModalLowerSection">
-                              <div className="DeleteProjectModelButtons">
-                                <PrimaryButton
-                                  className="CancelBtn"
-                                  onClick={this.hideDeleteAlert}
-                                >
-                                  Cancel
-                                </PrimaryButton>
-                                <PrimaryButton
-                                  color="red"
-                                  onClick={(e) =>
-                                    this.handleDeleteAlert(e, userID)
-                                  }
-                                >
-                                  {deletingUser ? <Spinner /> : "Delete"}
-                                </PrimaryButton>
-                              </div>
-
-                              {userDeleteFailed && isDeleteUser && (
-                                <Feedback message={isDeleteUser} type="error" />
-                              )}
-                            </div>
-                          </div>
-                        </Modal>
+                          <PrimaryButton
+                            type="button"
+                            onClick={() => this.handleCreditSubmittion()}
+                          >
+                            {Adding ? <Spinner /> : "Add"}
+                          </PrimaryButton>
+                        </div>
+                        {Failed && (
+                          <Feedback
+                            message={"failed to add credits"}
+                            type={"error"}
+                          />
+                        )}
                       </div>
-                    )}
-                    {openDisableAlert && (
-                      <div className="ProjectDeleteModel">
-                        <Modal
-                          showModal={openDisableAlert}
-                          onClickAway={this.hideDisableAlert}
-                        >
-                          <div className="DeleteDatabaseModel">
-                            <div className="DeleteProjectModalUpperSection">
-                              <div className="InnerModalDescription">
-                                Are you sure you want to disable this user
-                                &nbsp;
-                                <span className="DatabaseName">
-                                  {userDetail?.name} ?
-                                </span>
-                              </div>
-                            </div>
-
-                            <div className="DeleteProjectModalLowerSection">
-                              <div className="DeleteProjectModelButtons">
-                                <PrimaryButton
-                                  className="CancelBtn"
-                                  onClick={this.hideDisableAlert}
-                                >
-                                  Cancel
-                                </PrimaryButton>
-                                <PrimaryButton
-                                  color="red"
-                                  onClick={(e) =>
-                                    this.handleDisableAlert(e, userID)
-                                  }
-                                >
-                                  {isDisablingUser ? <Spinner /> : "Disable"}
-                                </PrimaryButton>
-                              </div>
-
-                              {userDisableFailed && isDisableUser && (
-                                <Feedback
-                                  message={isDisableUser}
-                                  type="error"
-                                />
-                              )}
-                            </div>
-                          </div>
-                        </Modal>
-                      </div>
-                    )}
-
-                    {!isFetching && !isFetched && (
-                      <div className="NoResourcesMessage">
-                        <p>
-                          Oops! Something went wrong! Failed to retrieve User
-                          Profile.
-                        </p>
-                      </div>
-                    )}
+                    </Modal>
                   </div>
-                </div>
-                <Modal
-                  showModal={this.state.addCredits}
-                  onClickAway={() => this.hideCreditsModal()}
-                >
-                  <div className="ModalHeader">
-                    <h5 className="ModalTitle">Add Credits</h5>
-
-                    <div className="">Number of credits</div>
-                    <div className="ModalContent">
-                      <BlackInputText
-                        required
-                        placeholder="Number of credits"
-                        name="credits"
-                        type="number"
-                        value={credits}
-                        onChange={(e) => {
-                          this.handleChange(e);
-                        }}
-                      />
-                    </div>
-                    <div className="CreditsTitle">Description</div>
-                    <textarea
-                      className="TextArea"
-                      type="text"
-                      placeholder="Credits description"
-                      rows="4"
-                      cols="50"
-                      name="creditDescription"
-                      value={creditDescription}
-                      onChange={(e) => {
-                        this.handleChange(e);
-                      }}
-                    />
-                  </div>
-                  <div className="ModalFooter">
-                    <div className="ModalButtons">
-                      <PrimaryButton
-                        className="CancelBtn"
-                        onClick={() => this.hideCreditsModal()}
-                      >
-                        Cancel
-                      </PrimaryButton>
-
-                      <PrimaryButton
-                        type="button"
-                        onClick={() => this.handleCreditSubmittion()}
-                      >
-                        {Adding ? <Spinner /> : "Add"}
-                      </PrimaryButton>
-                    </div>
-                    {Failed && (
-                      <Feedback
-                        message={"failed to add credits"}
-                        type={"error"}
-                      />
-                    )}
-                  </div>
-                </Modal>
-              </div>
+                </>
+              )}
             </div>
             <AppFooter />
           </div>

--- a/src/components/ProjectListing/ProjectList.js
+++ b/src/components/ProjectListing/ProjectList.js
@@ -590,147 +590,168 @@ const AdminProjectsOverview = () => {
               <div className="ChartsArea">
                 {sectionValue1 === "Projects" ? (
                   <div>
-                    <AreaChart
-                      width={550}
-                      height={380}
-                      syncId="anyId"
-                      data={
-                        period !== "all" ? filteredGraphData : graphDataArray
-                      }
-                    >
-                      <Line type="monotone" dataKey="Value" stroke="#8884d8" />
-                      <CartesianGrid stroke="#ccc" />
-                      <XAxis dataKey="Month" />
-                      <XAxis
-                        xAxisId={1}
-                        dx={10}
-                        label={{
-                          value: "Time",
-                          angle: 0,
-                          position: "bottom",
-                        }}
-                        interval={12}
-                        dataKey="Year"
-                        tickLine={false}
-                        tick={{ fontSize: 12, angle: 0 }}
-                      />
-                      <CartesianGrid strokeDasharray="3 3" />
-                      <YAxis
-                        label={{
-                          value: "Number of Projects",
-                          angle: 270,
-                          position: "outside",
-                        }}
-                        width={100}
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="Value"
-                        stroke="#82ca9d"
-                        fill="#82ca9d"
-                      />
-                      <Tooltip
-                        labelFormatter={(value) => {
-                          const monthNames = retrieveMonthNames();
-                          const month = parseInt(value) - 1;
-                          return monthNames[month].name;
-                        }}
-                        formatter={(value) => {
-                          return [`${value} projects`];
-                        }}
-                      />
-                    </AreaChart>
+                    {graphDataArray.length > 0 ? (
+                      <AreaChart
+                        width={550}
+                        height={380}
+                        syncId="anyId"
+                        data={
+                          period !== "all" ? filteredGraphData : graphDataArray
+                        }
+                      >
+                        <Line
+                          type="monotone"
+                          dataKey="Value"
+                          stroke="#8884d8"
+                        />
+                        <CartesianGrid stroke="#ccc" />
+                        <XAxis dataKey="Month" />
+                        <XAxis
+                          xAxisId={1}
+                          dx={10}
+                          label={{
+                            value: "Time",
+                            angle: 0,
+                            position: "bottom",
+                          }}
+                          interval={12}
+                          dataKey="Year"
+                          tickLine={false}
+                          tick={{ fontSize: 12, angle: 0 }}
+                        />
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <YAxis
+                          label={{
+                            value: "Number of Projects",
+                            angle: 270,
+                            position: "outside",
+                          }}
+                          width={100}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="Value"
+                          stroke="#82ca9d"
+                          fill="#82ca9d"
+                        />
+                        <Tooltip
+                          labelFormatter={(value) => {
+                            const monthNames = retrieveMonthNames();
+                            const month = parseInt(value) - 1;
+                            return monthNames[month].name;
+                          }}
+                          formatter={(value) => {
+                            return [`${value} projects`];
+                          }}
+                        />
+                      </AreaChart>
+                    ) : (
+                      <div className="ResourceSpinnerWrapper">
+                        <Spinner size="big" />
+                      </div>
+                    )}
                   </div>
                 ) : (
                   <div className="ChartsArea">
-                    <AreaChart
-                      width={550}
-                      height={380}
-                      data={
-                        period !== "all"
-                          ? newFilteredGraphData
-                          : newGraphDataArray
-                      }
-                      margin={{
-                        top: 10,
-                        right: 30,
-                        left: 0,
-                        bottom: 0,
-                      }}
-                    >
-                      <CartesianGrid stroke="#ccc" />
-                      <XAxis dataKey="Month" />
-                      <XAxis
-                        xAxisId={1}
-                        dx={10}
-                        label={{
-                          value: "Time",
-                          angle: 0,
-                          position: "bottom",
+                    {newGraphDataArray.length > 0 ? (
+                      <AreaChart
+                        width={550}
+                        height={380}
+                        data={
+                          period !== "all"
+                            ? newFilteredGraphData
+                            : newGraphDataArray
+                        }
+                        margin={{
+                          top: 10,
+                          right: 30,
+                          left: 0,
+                          bottom: 0,
                         }}
-                        interval={12}
-                        dataKey="Year"
-                        tickLine={false}
-                        tick={{ fontSize: 12, angle: 0 }}
-                      />
-                      <YAxis
-                        label={{
-                          value: "Numbers per Project Type",
-                          angle: 270,
-                          position: "outside",
-                        }}
-                        width={100}
-                      />
-                      <Tooltip
-                        labelFormatter={(value) => {
-                          const monthNames = retrieveMonthNames();
-                          const month = parseInt(value) - 1;
-                          return monthNames[month].name;
-                        }}
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="Personal"
-                        stackId="1"
-                        stroke="#8884d8"
-                        fill="#8884d8"
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="Research"
-                        stackId="1"
-                        stroke="#82ca9d"
-                        fill="#82ca9d"
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="Student"
-                        stackId="1"
-                        stroke="#ffc658"
-                        fill="#ffc658"
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="Commercial"
-                        stackId="1"
-                        stroke="#ffc999"
-                        fill="#ffc999"
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="Charity"
-                        stackId="1"
-                        stroke="#ffc302"
-                        fill="#ffc302"
-                      />
-                    </AreaChart>
+                      >
+                        <CartesianGrid stroke="#ccc" />
+                        <XAxis dataKey="Month" />
+                        <XAxis
+                          xAxisId={1}
+                          dx={10}
+                          label={{
+                            value: "Time",
+                            angle: 0,
+                            position: "bottom",
+                          }}
+                          interval={12}
+                          dataKey="Year"
+                          tickLine={false}
+                          tick={{ fontSize: 12, angle: 0 }}
+                        />
+                        <YAxis
+                          label={{
+                            value: "Numbers per Project Type",
+                            angle: 270,
+                            position: "outside",
+                          }}
+                          width={100}
+                        />
+                        <Tooltip
+                          labelFormatter={(value) => {
+                            const monthNames = retrieveMonthNames();
+                            const month = parseInt(value) - 1;
+                            return monthNames[month].name;
+                          }}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="Personal"
+                          stackId="1"
+                          stroke="#8884d8"
+                          fill="#8884d8"
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="Research"
+                          stackId="1"
+                          stroke="#82ca9d"
+                          fill="#82ca9d"
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="Student"
+                          stackId="1"
+                          stroke="#ffc658"
+                          fill="#ffc658"
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="Commercial"
+                          stackId="1"
+                          stroke="#ffc999"
+                          fill="#ffc999"
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="Charity"
+                          stackId="1"
+                          stroke="#ffc302"
+                          fill="#ffc302"
+                        />
+                      </AreaChart>
+                    ) : (
+                      <div className="ResourceSpinnerWrapper">
+                        <Spinner size="big" />
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
             </div>
 
             <div className="VisualArea">
-              {sectionValue === "Projects" ? (
+              {sectionValue === "Projects" &&
+              Object.keys(projectTypeCounts).length === 0 ? (
+                <div className="ResourceSpinnerWrapper">
+                  <Spinner size="big" />
+                </div>
+              ) : Object.keys(projectTypeCounts).length !== 0 ? (
                 <>
                   <div className="PieContainer">
                     <div className="ChartColumn">
@@ -774,7 +795,9 @@ const AdminProjectsOverview = () => {
                     </div>
                   </div>
                 </>
-              ) : (
+              ) : null}
+
+              {sectionValue === "Organisations" ? (
                 <>
                   <div className="PieContainer">
                     <div className="ChartColumn">
@@ -820,7 +843,7 @@ const AdminProjectsOverview = () => {
                     </div>
                   </div>
                 </>
-              )}
+              ) : null}
             </div>
           </div>
 

--- a/src/pages/AdminAppsPage/index.js
+++ b/src/pages/AdminAppsPage/index.js
@@ -227,51 +227,57 @@ const AdminAppsPage = () => {
                   </div>
                 </span>
               </div>
-              <AreaChart
-                width={840}
-                height={350}
-                margin={{
-                  top: 20,
-                  right: 30,
-                  left: 0,
-                  bottom: 0,
-                }}
-                syncId="anyId"
-                data={pagination}
-              >
-                <Line type="monotone" dataKey="Value" stroke="#8884d8" />
-                <CartesianGrid stroke="#ccc" />
-                <XAxis dataKey="month" />
-                <XAxis
-                  xAxisId={1}
-                  dx={10}
-                  label={{
-                    value: "Months",
-                    angle: 0,
-                    position: "outside",
+              {pagination.length !== 0 ? (
+                <AreaChart
+                  width={840}
+                  height={350}
+                  margin={{
+                    top: 20,
+                    right: 30,
+                    left: 0,
+                    bottom: 0,
                   }}
-                  height={70}
-                  interval={12}
-                  dataKey="year"
-                  tickLine={false}
-                  tick={{ fontSize: 12, angle: 0 }}
-                />
-                <CartesianGrid strokeDasharray="3 3" />
-                <YAxis
-                  label={{
-                    value: "Number of Apps",
-                    angle: 270,
-                    position: "outside",
-                  }}
-                  width={80}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="value"
-                  stroke="#82ca9d"
-                  fill="#82ca9d"
-                />
-              </AreaChart>
+                  syncId="anyId"
+                  data={pagination}
+                >
+                  <Line type="monotone" dataKey="Value" stroke="#8884d8" />
+                  <CartesianGrid stroke="#ccc" />
+                  <XAxis dataKey="month" />
+                  <XAxis
+                    xAxisId={1}
+                    dx={10}
+                    label={{
+                      value: "Months",
+                      angle: 0,
+                      position: "outside",
+                    }}
+                    height={70}
+                    interval={12}
+                    dataKey="year"
+                    tickLine={false}
+                    tick={{ fontSize: 12, angle: 0 }}
+                  />
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <YAxis
+                    label={{
+                      value: "Number of Apps",
+                      angle: 270,
+                      position: "outside",
+                    }}
+                    width={80}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="value"
+                    stroke="#82ca9d"
+                    fill="#82ca9d"
+                  />
+                </AreaChart>
+              ) : (
+                <div className="ResourceSpinnerWrapper">
+                  <Spinner size="big" />
+                </div>
+              )}
             </div>
 
             <div className="VisualArea">

--- a/src/pages/AdminUserOverviewPage/index.jsx
+++ b/src/pages/AdminUserOverviewPage/index.jsx
@@ -98,7 +98,7 @@ const AdminUserOverviewPage = () => {
     verified: usersSummary.filter((user) => user.verified === true).length,
     unverified: usersSummary.filter((user) => user.verified === false).length,
     beta: usersSummary.filter((user) => user.is_beta_user === true).length,
-    disabled: 0
+    disabled: 0,
   };
 
   const handleChange = ({ target }) => {
@@ -131,7 +131,7 @@ const AdminUserOverviewPage = () => {
   const handleDateRangeChange = (range) => {
     setDateRange(range);
   };
-  
+
   return (
     <div className="APage">
       <div className="TopRow">
@@ -253,65 +253,72 @@ const AdminUserOverviewPage = () => {
                   </div>
                 </span>
               </div>
-              <AreaChart
-                width={600}
-                height={350}
-                margin={{
-                  top: 20,
-                  right: 30,
-                  left: 0,
-                  bottom: 0,
-                }}
-                syncId="anyId"
-                data={period !== "all" ? filteredGraphData : graphDataArray}
-              >
-                <Line type="monotone" dataKey="Value" stroke="#8884d8" />
-                <CartesianGrid stroke="#ccc" />
-                <XAxis dataKey="Month" />
-                <XAxis
-                  xAxisId={1}
-                  dx={10}
-                  label={{
-                    value: "Months",
-                    angle: 0,
-                    position: "outside",
+
+              {graphDataArray.length > 0 ? (
+                <AreaChart
+                  width={600}
+                  height={350}
+                  margin={{
+                    top: 20,
+                    right: 30,
+                    left: 0,
+                    bottom: 0,
                   }}
-                  height={70}
-                  interval={12}
-                  dataKey="Year"
-                  tickLine={false}
-                  tick={{ fontSize: 12, angle: 0 }}
-                />
-                <CartesianGrid strokeDasharray="3 3" />
-                <YAxis
-                  label={{
-                    value: "Number of Users",
-                    angle: 270,
-                    position: "outside",
-                  }}
-                  width={80}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="Value"
-                  stroke="#82ca9d"
-                  fill="#82ca9d"
-                />
-                <Tooltip
-                  labelFormatter={(value) => {
-                    const monthNames = retrieveMonthNames();
-                    const month = parseInt(value) - 1;
-                    return monthNames[month].name;
-                  }}
-                  formatter={(value) => {
-                    if (value === 1) {
-                      return [`${value} user`];
-                    } else {
-                      return [`${value} users`];
-                    }
-                  }}
-                />
-              </AreaChart>
+                  syncId="anyId"
+                  data={period !== "all" ? filteredGraphData : graphDataArray}
+                >
+                  <Line type="monotone" dataKey="Value" stroke="#8884d8" />
+                  <CartesianGrid stroke="#ccc" />
+                  <XAxis dataKey="Month" />
+                  <XAxis
+                    xAxisId={1}
+                    dx={10}
+                    label={{
+                      value: "Months",
+                      angle: 0,
+                      position: "outside",
+                    }}
+                    height={70}
+                    interval={12}
+                    dataKey="Year"
+                    tickLine={false}
+                    tick={{ fontSize: 12, angle: 0 }}
+                  />
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <YAxis
+                    label={{
+                      value: "Number of Users",
+                      angle: 270,
+                      position: "outside",
+                    }}
+                    width={80}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="Value"
+                    stroke="#82ca9d"
+                    fill="#82ca9d"
+                  />
+                  <Tooltip
+                    labelFormatter={(value) => {
+                      const monthNames = retrieveMonthNames();
+                      const month = parseInt(value) - 1;
+                      return monthNames[month].name;
+                    }}
+                    formatter={(value) => {
+                      if (value === 1) {
+                        return [`${value} user`];
+                      } else {
+                        return [`${value} users`];
+                      }
+                    }}
+                  />
+                </AreaChart>
+              ) : (
+                <div className="ResourceSpinnerWrapper">
+                  <Spinner size="big" />
+                </div>
+              )}
             </div>
 
             <div className="VisualArea">
@@ -320,50 +327,62 @@ const AdminUserOverviewPage = () => {
                   Pie Chart for Users Categories
                 </span>
               </div>
-              <div className="PieContainer">
-                <div className="ChartColumn">
-                  <PieChart width={300} height={300}>
-                    <Pie
-                      data={createUsersPieChartData(userCounts)}
-                      dataKey="value"
-                      nameKey="category"
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={140}
-                      paddingAngle={3}
-                      label={true}
-                    >
+
+              {Object.keys(usersSummary).length === 0 ? (
+                <div className="ResourceSpinnerWrapper">
+                  <Spinner size="big" />
+                </div>
+              ) : (
+                <div className="PieContainer">
+                  <div className="ChartColumn">
+                    <PieChart width={300} height={300}>
+                      <Pie
+                        data={createUsersPieChartData(userCounts)}
+                        dataKey="value"
+                        nameKey="category"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={140}
+                        paddingAngle={3}
+                        label={true}
+                      >
+                        {createUsersPieChartData(userCounts).map(
+                          (entry, index) => (
+                            <Cell
+                              key={`cell-${index}`}
+                              fill={COLORS[index % COLORS.length]}
+                            />
+                          )
+                        )}
+                      </Pie>
+                      <Tooltip />
+                    </PieChart>
+                  </div>
+                  <div className="PercentageColumn">
+                    <ul className="KeyItems">
                       {createUsersPieChartData(userCounts).map(
                         (entry, index) => (
-                          <Cell
-                            key={`cell-${index}`}
-                            fill={COLORS[index % COLORS.length]}
-                          />
+                          <>
+                            {" "}
+                            <li key={`list-item-${index}`}>
+                              <span
+                                style={{ color: COLORS[index % COLORS.length] }}
+                              >
+                                {entry.category}:
+                              </span>{" "}
+                              {((entry.value / userCounts.total) * 100).toFixed(
+                                0
+                              )}
+                              %
+                            </li>
+                            <hr style={{ width: "100%" }} />
+                          </>
                         )
                       )}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
+                    </ul>
+                  </div>
                 </div>
-                <div className="PercentageColumn">
-                  <ul className="KeyItems">
-                    {createUsersPieChartData(userCounts).map((entry, index) => (
-                      <>
-                        {" "}
-                        <li key={`list-item-${index}`}>
-                          <span
-                            style={{ color: COLORS[index % COLORS.length] }}
-                          >
-                            {entry.category}:
-                          </span>{" "}
-                          {((entry.value / userCounts.total) * 100).toFixed(0)}%
-                        </li>
-                        <hr style={{ width: "100%" }} />
-                      </>
-                    ))}
-                  </ul>
-                </div>
-              </div>
+              )}
             </div>
           </div>
 

--- a/src/pages/ClusterPage/ClusterPage.module.css
+++ b/src/pages/ClusterPage/ClusterPage.module.css
@@ -7,6 +7,10 @@
   padding-left: 1rem;
 }
 
+.LoadingArea {
+  padding: 3rem;
+}
+
 .ViewAccountsBtn {
   text-transform: capitalize !important;
   color: var(--primary-color);

--- a/src/pages/ClusterPage/index.jsx
+++ b/src/pages/ClusterPage/index.jsx
@@ -33,6 +33,7 @@ const ClusterPage = ({
   const [description, setDescription] = useState("");
   const [prometheus_url, setPrometheus_url] = useState("");
   const [summary, setSummary] = useState({});
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     getClustersList();
@@ -40,13 +41,17 @@ const ClusterPage = ({
   }, []);
 
   const getAllMetrics = async () => {
+    setLoading(true);
     try {
       const response = await handleGetRequest("/system_summary");
       if (response.data.status === "success") {
         setSummary(response.data.data);
+        setLoading(false);
       }
     } catch (error) {
-      throw new Error("Failed to fetch summary metrics, please try again");
+      setError("Failed to fetch summary metrics, please try again");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -96,107 +101,115 @@ const ClusterPage = ({
         </div>
       </div>
 
-      <div className={styles.OtherCards}>
-        <Link to="/accounts" className={styles.ResourceCard}>
-          <div className={styles.columnCardSection}>
-            <div className={styles.CardHeader}>Users</div>
-            <div className={styles.ResourceDigit}>
-              {summary?.Users?.total_count}
-            </div>
-          </div>
-          <div className={styles.rowCardSection}>
+      {summary && Object.keys(summary).length > 0 ? (
+        <div className={styles.OtherCards}>
+          <Link to="/accounts" className={styles.ResourceCard}>
             <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>Verified</div>
-              <div className={styles.rowResourceDigit}>
-                {summary?.Users?.verified}
+              <div className={styles.CardHeader}>Users</div>
+              <div className={styles.ResourceDigit}>
+                {summary?.Users?.total_count}
               </div>
             </div>
-            <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>Unverified</div>
-              <div
-                className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
-              >
-                {parseInt(
-                  parseInt(summary?.Users?.total_count) -
-                    parseInt(summary?.Users?.verified)
-                )}
+            <div className={styles.rowCardSection}>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>Verified</div>
+                <div className={styles.rowResourceDigit}>
+                  {summary?.Users?.verified}
+                </div>
+              </div>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>Unverified</div>
+                <div
+                  className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
+                >
+                  {parseInt(
+                    parseInt(summary?.Users?.total_count) -
+                      parseInt(summary?.Users?.verified)
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        </Link>
-        <Link to="/projects-overview" className={styles.ResourceCard}>
-          <div className={styles.columnCardSection}>
-            <div className={styles.CardHeader}>Projects</div>
-            <div className={styles.ResourceDigit}>
-              {summary?.Projects?.total_count}
-            </div>
-          </div>
-          <div className={styles.rowCardSection}>
+          </Link>
+          <Link to="/projects-overview" className={styles.ResourceCard}>
             <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>Active</div>
-              <div className={styles.rowResourceDigit}>
-                {summary?.Projects?.total_count - summary?.Projects?.disabled}
+              <div className={styles.CardHeader}>Projects</div>
+              <div className={styles.ResourceDigit}>
+                {summary?.Projects?.total_count}
               </div>
             </div>
-            <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>Disabled</div>
-              <div
-                className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
-              >
-                {summary?.Projects?.disabled}
+            <div className={styles.rowCardSection}>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>Active</div>
+                <div className={styles.rowResourceDigit}>
+                  {summary?.Projects?.total_count - summary?.Projects?.disabled}
+                </div>
+              </div>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>Disabled</div>
+                <div
+                  className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
+                >
+                  {summary?.Projects?.disabled}
+                </div>
               </div>
             </div>
-          </div>
-        </Link>
-        <Link to="/databases" className={styles.ResourceCard}>
-          <div className={styles.columnCardSection}>
-            <div className={styles.CardHeader}>Databases</div>
-            <div className={styles.ResourceDigit}>
-              {summary?.Databases?.total_count}
-            </div>
-          </div>
-          <div className={styles.rowCardSection}>
+          </Link>
+          <Link to="/databases" className={styles.ResourceCard}>
             <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>MySql</div>
-              <div className={styles.rowResourceDigit}>
-                {summary?.Databases?.mysql}
+              <div className={styles.CardHeader}>Databases</div>
+              <div className={styles.ResourceDigit}>
+                {summary?.Databases?.total_count}
               </div>
             </div>
-            <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>Postgresql</div>
-              <div
-                className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
-              >
-                {summary?.Databases?.postgres}
+            <div className={styles.rowCardSection}>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>MySql</div>
+                <div className={styles.rowResourceDigit}>
+                  {summary?.Databases?.mysql}
+                </div>
+              </div>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>Postgresql</div>
+                <div
+                  className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
+                >
+                  {summary?.Databases?.postgres}
+                </div>
               </div>
             </div>
-          </div>
-        </Link>
-        <Link to="/apps" className={styles.ResourceCard}>
-          <div className={styles.columnCardSection}>
-            <div className={styles.CardHeader}>Apps</div>
-            <div className={styles.ResourceDigit}>
-              {summary ? summary?.Apps?.total_count : 0}
-            </div>
-          </div>
-          <div className={styles.rowCardSection}>
+          </Link>
+          <Link to="/apps" className={styles.ResourceCard}>
             <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>Up</div>
-              <div className={styles.rowResourceDigit}>
-                {summary?.Apps?.total_count}
+              <div className={styles.CardHeader}>Apps</div>
+              <div className={styles.ResourceDigit}>
+                {summary ? summary?.Apps?.total_count : 0}
               </div>
             </div>
-            <div className={styles.columnCardSection}>
-              <div className={styles.innerCardHeader}>Down</div>
-              <div
-                className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
-              >
-                {0}
+            <div className={styles.rowCardSection}>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>Up</div>
+                <div className={styles.rowResourceDigit}>
+                  {summary?.Apps?.total_count}
+                </div>
+              </div>
+              <div className={styles.columnCardSection}>
+                <div className={styles.innerCardHeader}>Down</div>
+                <div
+                  className={`${styles.rowResourceDigit} ${styles.rightTextAlign}`}
+                >
+                  {0}
+                </div>
               </div>
             </div>
-          </div>
-        </Link>
-      </div>
+          </Link>
+        </div>
+      ) : loading ? (
+        <div className={styles.LoadingArea}>
+          <Spinner size="big" />
+        </div>
+      ) : (
+        <div className="NoResourcesMessage">{error}</div>
+      )}
 
       <div>
         <div className="TitleArea">


### PR DESCRIPTION
# Description

- Add loading states for most admin sections that were showing before data is returned, and error states otherwise!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/QkOfT6mY

## How Can This Been Tested?

- Run this branch locally and check out most of the admin side sections paying attention to the overview and detail pages

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![chrome-capture-2023-10-1 (1)](https://github.com/crane-cloud/frontend/assets/63339234/b77415c3-99e1-4970-995b-af16d6e2f7d4)
