### PR TITLE
Fix app spacing

### DIFF
--- a/src/components/AppsList/AppsList.module.css
+++ b/src/components/AppsList/AppsList.module.css
@@ -1,5 +1,5 @@
-.AppList {
-  display: grid;
+ .AppList { 
+  display: flex;
   grid-template-columns: repeat(4, 1fr);
   grid-gap: 1rem;
   min-height: 40vh;

--- a/src/components/attentionComponent/attentionComponent.css
+++ b/src/components/attentionComponent/attentionComponent.css
@@ -7,6 +7,7 @@
    font-weight: 400;
    font-size: 0.9rem;
    padding: 1rem 1.4rem 0.6rem 2rem;
+   margin-bottom: 20px;
 }
 .attentionNoticeHeading{
     font-weight: 700;

--- a/src/pages/AppSettingsPage/index.jsx
+++ b/src/pages/AppSettingsPage/index.jsx
@@ -741,7 +741,7 @@ class AppSettingsPage extends React.Component {
     //console.log(this.props.app);
 
     return (
-      <DashboardLayout name={appDetail?.name} header="App Settings"  appsWarning= {true} short>
+      <DashboardLayout name={appDetail?.name} header="App Settings" short>
         {isDeleted || isReverted ? this.renderRedirect() : null}
 
         {fetchingAppDetails ? (


### PR DESCRIPTION
# Description

- Fix app spacing
- Removed the banner from the app settings page
- Added some spacing  below between the banner and the apps on the apps page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID
https://trello.com/c/Mcl5bNyk

## How Can This Been Tested?

Run this branch locally then check the apps settings page and the project apps for the changes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Screenshots
App spacing
![Screenshot from 2023-11-15 15-34-22](https://github.com/crane-cloud/frontend/assets/108899937/5bba04ba-a5f3-450e-9266-bbdccfc0c77c)

App settings
![Screenshot from 2023-11-15 15-35-27](https://github.com/crane-cloud/frontend/assets/108899937/b44885f4-4723-4cb0-bfee-39abdea3c24a)

Spacing below the banner on apps page 
![Screenshot from 2023-11-15 15-36-55](https://github.com/crane-cloud/frontend/assets/108899937/b8319c45-6f3e-4723-8f07-ca3b27485072)

