### PR TITLE
Fix the over-flowing image names in the app-revisions and the timed-out fetching for the status page.

### DIFF
--- a/src/components/DateInput/DateInput.css
+++ b/src/components/DateInput/DateInput.css
@@ -42,10 +42,13 @@
   position: absolute; /*relative */
   top: 3rem;
   z-index: 1;
-  /* left: 1rem; */
+  left: 1px;
   width: 20rem;
   border-radius: 10px;
   /* margin-top: 0.8rem; */
+}
+.DateInputsSection>.DateInputCalendar {
+  padding-right: 2rem;
 }
 
 .CalendarModalButtons {

--- a/src/pages/AppSettingsPage/AppSettingsPage.css
+++ b/src/pages/AppSettingsPage/AppSettingsPage.css
@@ -819,7 +819,15 @@ ul li {
 
 .version-name {
   font-size: 1.1rem;
-
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 12rem;
+}
+.version-name:hover{
+  white-space: normal;
+  word-wrap: break-word;
+  overflow: visible;
 }
 
 .version-id {

--- a/src/pages/MonitoringPage/index.jsx
+++ b/src/pages/MonitoringPage/index.jsx
@@ -37,10 +37,20 @@ const MonitoringPage = () => {
   }, [currentUser]);
 
   useEffect(() => {
-    getStatusData();
-    getStatusGraphData();
-  }, []);
+    setLoading(true);
+    const fetchData = async () => {
+      await getStatusData();
+      await getStatusGraphData();
+    };
 
+    const timeoutId = setTimeout(fetchData, 4000);
+
+    return () => {
+      setLoading(false);
+      clearTimeout(timeoutId); // Clear the timeout if the component unmounts before 4 seconds
+    };
+  }, []);
+  
   const getStatusData = async () => {
     setLoading(true);
     try {

--- a/src/pages/UserActivity/UserActivity.module.css
+++ b/src/pages/UserActivity/UserActivity.module.css
@@ -48,7 +48,13 @@
 
 .ActivityStatus {
   display: flex;
-  gap: 0.5rem;
+  gap: 3.5rem;
+  padding-left: 3.5rem;
+}
+
+.ActivityDescription{
+  padding-right: 1rem;
+  min-width: 4rem;
 }
 
 .FilterItemLabel {
@@ -104,16 +110,26 @@
 
 .Success {
   color: green;
+  padding-left: 1rem;
 }
 
 .Danger {
   color: red;
+  padding-left: 1rem;
 }
 
 .Entity {
   color: var(--primary-color);
+  overflow: hidden;
+  max-width: 17rem;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
-
+.Entity:hover{
+  overflow: visible;
+  white-space: normal;
+  word-wrap: break-word;
+}
 .hr {
   margin: .5rem 0;
 }
@@ -121,12 +137,13 @@
 .Row {
   display: flex;
   justify-content: space-between;
-  width: -webkit-fill-available;
+  gap: 3.5rem;
+  /* width: -webkit-fill-available; */
 }
 
 .RowCell {
   display: flex;
-  gap: 1rem;
+  gap: 2rem;
 }
 
 .LastCell {

--- a/src/pages/UserActivity/index.js
+++ b/src/pages/UserActivity/index.js
@@ -287,18 +287,18 @@ const UserActivity = () => {
                   <span className={styles.FilterItemLabel}>Date</span>
                   <div className={styles.DateBtn}>
                     <div className="DateInputsSection">
-                      <DateInput
-                        label="From"
-                        position="from"
-                        hideTime={true}
-                        handleChange={handleFromDate}
-                        showCalendar={showFromCalendar}
-                        dateValue={fromTS}
-                        onClick={switchCalendars}
-                        onCancel={closeCalendar}
-                        onSubmit={handleCalenderSubmission}
-                        value="from"
-                      />
+                        <DateInput
+                          label="From"
+                          position="from"
+                          hideTime={true}
+                          handleChange={handleFromDate}
+                          showCalendar={showFromCalendar}
+                          dateValue={fromTS}
+                          onClick={switchCalendars}
+                          onCancel={closeCalendar}
+                          onSubmit={handleCalenderSubmission}
+                          value="from"
+                        />
                       <DateInput
                         label="To"
                         position="to"
@@ -391,6 +391,9 @@ const UserActivity = () => {
                             <span className={styles.EntityOperation}>
                               {item.operation} -
                             </span>
+                            <span className={styles.ActivityDescription}>
+                              <div>{item.model}</div>
+                            </span>
                             <span className={styles.Entity}>
                               {item.a_project_id}
                             </span>{" "}
@@ -406,9 +409,6 @@ const UserActivity = () => {
                                 : item.status}
                             </span>
                           </div>
-                        </div>
-                        <div className={styles.ActivityDescription}>
-                          <div>{item.description}</div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION

# Description

This pull request is to help fix the over-flowing image names in the app revisions, the time-out for fetching the status page, and some calendar alignment for the custom metrics.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/5Hy054G0

https://trello.com/c/ZqjDis4a

## How Can This Been Tested?

Pull the remote branch and run it locally, make sure you visit the app setting's page checkout the long names of the images, the activity page to checkout the cleaned activity table as well as the status page to see if the page loads without the data dislaying.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot from 2024-01-11 21-26-47](https://github.com/crane-cloud/frontend/assets/110970478/d0564d0a-ffe8-47d1-8fd9-ff1c3bf5d1f7)
![Screenshot from 2024-01-11 21-27-30](https://github.com/crane-cloud/frontend/assets/110970478/13bf6be9-e149-406e-bbd9-ef66b26182e6)


