### PR TITLE
feat: show when a database is being enabled or disabled

### DIFF
--- a/src/components/DisableModalContent/index.jsx
+++ b/src/components/DisableModalContent/index.jsx
@@ -11,9 +11,14 @@ const DisableModalContent = ({
   isFailed,
 }) => {
   const isProject = item && item.type === "project";
+  const isDatabase = item && item.type === "database";
 
   return (
-    <div className={`DisableContentAlert ${isProject ? 'Project' : 'App'}`}>
+    <div
+      className={`DisableContentAlert ${
+        isProject ? "Project" : isDatabase ? "Database" : "App"
+      }`}
+    >
       <div className="AlertUpperSection">
         <div className="WarningContainer">
           <div className="AlertDescription">
@@ -22,18 +27,19 @@ const DisableModalContent = ({
           </div>
           <div className="AlertSubDescription">
             {item?.disabled
-              ? `Allow access to ${isProject ? 'Project' : 'App'} resources and enable billing`
-              : `This will prevent your ${isProject ? 'project' : 'app'} from being billed by blocking access to its resources.`}
+              ? `Allow access to ${
+                  isProject ? "project" : isDatabase ? "database" : "app"
+                } resources and enable billing`
+              : `This will prevent your ${
+                  isProject ? "project" : isDatabase ? "database" : "app"
+                } from being billed by blocking access to its resources.`}
           </div>
         </div>
       </div>
 
       <div className="AlertLowerSection">
         <div className="AlertButtons">
-          <PrimaryButton
-            className="CancelBtn"
-            onClick={hideDisableAlert}
-          >
+          <PrimaryButton className="CancelBtn" onClick={hideDisableAlert}>
             Cancel
           </PrimaryButton>
           <PrimaryButton

--- a/src/pages/DBSettingsPage/index.jsx
+++ b/src/pages/DBSettingsPage/index.jsx
@@ -20,6 +20,8 @@ import "./DBSettingsPage.css";
 import { getProjectName } from "../../helpers/projectName";
 import DashboardLayout from "../../components/Layouts/DashboardLayout";
 import SettingsActionRow from "../../components/SettingsActionRow/index.jsx";
+import SettingsModal from "../../components/SettingsModal/index.jsx";
+import DisableModalContent from "../../components/DisableModalContent/index.jsx";
 
 class DBSettingsPage extends React.Component {
   constructor(props) {
@@ -40,6 +42,9 @@ class DBSettingsPage extends React.Component {
       openUpdateModal: false,
       newDatabasePassword: "",
       confirmNewDatabasePassword: "",
+      disableDatabaseError: "",
+      disableDatabaseAlert: false,
+      disableDisableDatabaseProgress: false,
       // api states
       gettingDatabases: false,
       fetchingDatabaseErrors: "",
@@ -81,6 +86,8 @@ class DBSettingsPage extends React.Component {
     this.hideUpdateModal = this.hideUpdateModal.bind(this);
     this.handleSubmitUpdate = this.handleSubmitUpdate.bind(this);
     this.fetchPassword = this.fetchPassword.bind(this);
+    this.showDisableAlert = this.showDisableAlert.bind(this);
+    this.hideDisableAlert = this.hideDisableAlert.bind(this);
 
     // api functions
     this.fetchSelectedDb = this.fetchSelectedDb.bind(this);
@@ -143,6 +150,14 @@ class DBSettingsPage extends React.Component {
   // show update modal
   showUpdateModal() {
     this.setState({ openUpdateModal: true });
+  }
+
+  showDisableAlert() {
+    this.setState({ disableDatabaseAlert: true });
+  }
+
+  hideDisableAlert() {
+    this.setState({ disableDatabaseAlert: false });
   }
 
   // hide update modal
@@ -340,6 +355,7 @@ class DBSettingsPage extends React.Component {
   handleEnableButtonClick = () => {
     let { currentDB } = this.state;
     const { databaseID } = this.props.match.params;
+    this.setState({ disableDisableDatabaseProgress: true });
 
     try {
       if (currentDB.disabled) {
@@ -352,7 +368,8 @@ class DBSettingsPage extends React.Component {
           })
           .catch((error) => {
             this.setState({
-              error: error,
+              disableDatabaseError: error,
+              disableDisableDatabaseProgress: false,
             });
           });
       } else {
@@ -365,7 +382,8 @@ class DBSettingsPage extends React.Component {
           })
           .catch((error) => {
             this.setState({
-              error: error,
+              disableDatabaseError: error,
+              disableDisableDatabaseProgress: false,
             });
           });
       }
@@ -402,6 +420,9 @@ class DBSettingsPage extends React.Component {
       resettingResponseCode,
       deletingDB,
       deleteDBError,
+      disableDatabaseError,
+      disableDatabaseAlert,
+      disableDisableDatabaseProgress,
     } = this.state;
     return (
       <DashboardLayout
@@ -550,6 +571,20 @@ class DBSettingsPage extends React.Component {
                   </div>
                 </div>
               </div>
+              <div>
+                <div className="SectionSubTitle">Database Status</div>
+                <div className="DetailRow">
+                  <div className="SettingsSectionInfo">
+                    <div>
+                      {currentDB?.disabled === true ? (
+                        <span style={{ color: "red" }}>Disabled</span>
+                      ) : (
+                        "Enabled"
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <div className="DBSections">
@@ -686,7 +721,7 @@ class DBSettingsPage extends React.Component {
                   }
                   buttonLabel={currentDB?.disabled ? "Enable" : "Disable"}
                   buttonColor={currentDB?.disabled ? "primary" : "red"}
-                  onButtonClick={this.handleEnableButtonClick}
+                  onButtonClick={this.showDisableAlert}
                 />
 
                 <SettingsActionRow
@@ -835,6 +870,28 @@ class DBSettingsPage extends React.Component {
               </div>
             )}
           </div>
+        )}
+
+        {disableDatabaseAlert && (
+          <SettingsModal
+            showModal={disableDatabaseAlert}
+            onClickAway={this.hideDisableAlert}
+          >
+            <DisableModalContent
+              item={{
+                name: currentDB?.name,
+                type: "database",
+                disabled: currentDB?.disabled,
+              }}
+              disableProgress={disableDisableDatabaseProgress}
+              handleDisableButtonClick={() => {
+                this.handleEnableButtonClick();
+              }}
+              hideDisableAlert={this.hideDisableAlert}
+              message={disableDatabaseError}
+              isFailed={disableDatabaseError ? true : false}
+            />
+          </SettingsModal>
         )}
       </DashboardLayout>
     );


### PR DESCRIPTION
# Description

- Use the reusable disable modal for the database settings page for the scenario where a user wants to enable or disable their database.
- Note that you can't disable or enable a database when the parent project has been disabled! 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

https://trello.com/c/x4eLKxWI

## How Can This Been Tested?

- Run this branch locally and checkout the database settings page and attempt to disable or enable that database.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="1041" alt="image" src="https://github.com/crane-cloud/frontend/assets/63339234/f9e0bc42-d631-44ad-964e-3670fa3112a8">
