### PR TITLE
chore:enable update of empty entry command at the frontend

### DIFF
--- a/src/pages/AppSettingsPage/index.jsx
+++ b/src/pages/AppSettingsPage/index.jsx
@@ -141,6 +141,15 @@ const AppSettingsPage = () => {
     };
   }, [appID, currentPage, dispatch]);
 
+  useEffect(() => {
+    if (app.command) {
+      setEntryCommand(app.command);
+    }
+    if (app.port) {
+      setPort(app.port);
+    }
+  }, [app?.command, app?.port]);
+
   const fetchProjectDetails = useCallback(() => {
     handleGetRequest(`/projects/${app?.project_id}`)
       .then((response) => {
@@ -272,13 +281,8 @@ const AppSettingsPage = () => {
   const handleEnvSubmit = () => {
     const projectID = app?.project_id;
     let updatePayload = {};
-
     if (port !== "" && port.toString() !== app.port.toString()) {
       updatePayload = { ...updatePayload, port: parseInt(port, 10) };
-    }
-
-    if (entryCommand !== app.command) {
-      updatePayload = { ...updatePayload, command: entryCommand };
     }
 
     if (haveEnvVarsChanged(envVars, app?.env_vars)) {
@@ -295,6 +299,11 @@ const AppSettingsPage = () => {
       },
       {}
     );
+    //since command can be empty
+
+    if (entryCommand !== app.command) {
+      updatePayload = { ...updatePayload, command: entryCommand };
+    }
 
     // Check if the payload is empty (no changes)
     if (Object.keys(updatePayload).length === 0) {
@@ -338,6 +347,7 @@ const AppSettingsPage = () => {
     const projectID = app?.project_id;
     setLoadingIndex(index);
     const keyToRemove = Object.keys(envVars)[index];
+    console.log(keyToRemove)
 
     if (keyToRemove !== null) {
       const updatePayload = { delete_env_vars: [keyToRemove] };


### PR DESCRIPTION
# Description

This PR allows a user to send an empty field to the backend in order to update the entry command.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/BWRn2yjD

## How Can This Been Tested?

Run this branch and make sure that on updating an app with an entry command, you can submit.
Be aware that on refreshing, your app will still have the old command because currently the backend doesn't allow this update and that is the next PR after this.
The goal of this is to ensure you can submit an empty string

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="881" alt="Screenshot 2024-02-01 at 16 04 54" src="https://github.com/crane-cloud/frontend/assets/69305400/68f167cf-cf81-4f80-9e70-6f11d848bc7d">
