### PR TITLE
adding password requirements on the registry form

### DIFF
--- a/src/pages/LoginPage/LoginPage.css
+++ b/src/pages/LoginPage/LoginPage.css
@@ -67,9 +67,9 @@
   width: 25rem;
 }
 
-.LoginContentInputs>* {
+/* .LoginContentInputs>* {
   width: 100%;
-}
+} */
 
 .LowerLoginSection {
   display: flex;

--- a/src/pages/RegisterPage/RegisterPage.css
+++ b/src/pages/RegisterPage/RegisterPage.css
@@ -49,7 +49,8 @@
   background-color: rgba(255, 255, 255, 0.5);
   color: #d63b3b;
   text-align: center;
-  padding: 1rem 0;
+  padding: 1rem 1rem;
+  border-radius: 5px;
 }
 
 .LogoIcon {

--- a/src/pages/RegisterPage/RegisterPage.test.js
+++ b/src/pages/RegisterPage/RegisterPage.test.js
@@ -30,6 +30,12 @@ describe("<RegisterPage/> Component", () => {
       error: "",
       passwordShown: false,
       passwordChecked: false,
+      passwordValidations: { 
+        hasUppercase: false,
+        hasLowercase: false,
+        hasNumber: false,
+        isMinLength: false,
+      },
     };
 
     expect(RegisterPageComponent.state()).toEqual(expectedInitialState);
@@ -44,19 +50,6 @@ describe("<RegisterPage/> Component", () => {
 
     expect(RegisterPageComponent.state("hasAgreed")).toBe(false);
   });
-
-  // it("should redirect to the GitHub authentication page when 'toGithubauth' is called", () => {
-  //   const mockEvent = {
-  //     preventDefault: jest.fn(),
-  //   };
-  
-  //   window.location.href = jest.fn();
-  
-  //   RegisterPageComponent.instance().toGithubauth();
-  
-  //   expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
-  //   expect(window.location.href).toHaveBeenCalledTimes(1);
-  // });
   
 
   it("should toggle the 'passwordShown' state when 'togglePassword' is called", () => {
@@ -104,39 +97,6 @@ describe("<RegisterPage/> Component", () => {
     );
   });
 
-  it("should update the state correctly and call 'axios.post' when 'handleSubmit' is called with valid data", () => {
-    const mockEvent = {
-      preventDefault: jest.fn(),
-    };
-
-    const axiosPostSpy = jest.spyOn(axios, "post");
-
-    RegisterPageComponent.setState({
-      name: "John Doe",
-      username: "johndoe",
-      email: "test@example.com",
-      password: "password",
-      passwordConfirm: "password",
-      hasAgreed: true,
-      organisation : 'crane-cloud',
-    });
-
-    RegisterPageComponent.instance().handleSubmit(mockEvent);
-
-    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
-    expect(RegisterPageComponent.state("loading")).toBe(true);
-    expect(axiosPostSpy).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        name: "John Doe",
-        username: "johndoe",
-        email: "test@example.com",
-        password: "password",
-        organisation : 'crane-cloud',
-      })
-    );
-    // You can add more expectations based on the specific behavior you want to test
-  });
 
   it("should update the state correctly when 'handleSubmit' is called with invalid data", () => {
     const mockEvent = {
@@ -191,4 +151,29 @@ describe("<RegisterPage/> Component", () => {
     );
     // You can add more expectations based on the specific behavior you want to test
   });
+
+  it("should display an error message if password does not meet requirements", () => {
+    RegisterPageComponent.setState({
+      name: "Moses Mulumba",
+      username: "moses",
+      email: "test@example.com",
+      password: "123mo", 
+      passwordConfirm: "123mo",
+      hasAgreed: true,
+      organisation: "crane-cloud",
+    });
+  
+    const mockEvent = {
+      preventDefault: jest.fn(),
+    };
+  
+    RegisterPageComponent.instance().handleSubmit(mockEvent);
+  
+    // Expect an error message related to password requirements
+    expect(RegisterPageComponent.state("error")).toBe(
+      "Password must contain at least one uppercase letter, one lowercase letter, a number and 8 characters long"
+    );
+    
+  });
+  
 });

--- a/src/pages/RegisterPage/index.js
+++ b/src/pages/RegisterPage/index.js
@@ -31,6 +31,12 @@ export default class RegisterPage extends Component {
       error: "",
       passwordShown: false,
       passwordChecked: false,
+      passwordValidations: {
+        hasUppercase: false,
+        hasLowercase: false,
+        hasNumber: false,
+        isMinLength: false,
+      },
     };
 
     this.handleOnChange = this.handleOnChange.bind(this);
@@ -73,12 +79,34 @@ export default class RegisterPage extends Component {
     }
   };
 
+  validatePassword(password) {
+    const hasUppercase = /[A-Z]/.test(password);
+    const hasLowercase = /[a-z]/.test(password);
+    const hasNumber = /\d/.test(password);
+    const isMinLength = password.length >= 8;
+
+    this.setState({
+      passwordValidations: {
+        hasUppercase,
+        hasLowercase,
+        hasNumber,
+        isMinLength,
+      },
+    });
+  }
+
   handleOnChange(e) {
     const { error } = this.state;
+    const { name, value } = e.target;
+    
+    if (name === 'password') {
+      this.validatePassword(value);
+    }
+  
     this.setState({
-      [e.target.name]: e.target.value,
+      [name]: value,
     });
-
+  
     if (error) {
       this.setState({
         error: "",
@@ -109,6 +137,7 @@ export default class RegisterPage extends Component {
       password,
       passwordConfirm,
       hasAgreed,
+      passwordValidations
     } = this.state;
 
     const userData = {
@@ -148,6 +177,11 @@ export default class RegisterPage extends Component {
       this.setState({
         loading: false,
         error: "Please agree to our Terms of Service",
+      });
+    } else if (!passwordValidations.hasUppercase || !passwordValidations.hasLowercase || !passwordValidations.hasNumber || !passwordValidations.isMinLength) {
+      this.setState({
+        loading: false,
+        error: "Password must contain at least one uppercase letter, one lowercase letter , a number and  8 characters long",
       });
     } else {
       this.setState({
@@ -246,7 +280,6 @@ export default class RegisterPage extends Component {
                     value={password}
                     onChange={this.handleOnChange}
                   />
-
                   <div className="password" onClick={this.togglePassword}>
                     {passwordShown ? <Open /> : <Closed />}
                   </div>

--- a/src/pages/RegisterPage/index.js
+++ b/src/pages/RegisterPage/index.js
@@ -181,7 +181,7 @@ export default class RegisterPage extends Component {
     } else if (!passwordValidations.hasUppercase || !passwordValidations.hasLowercase || !passwordValidations.hasNumber || !passwordValidations.isMinLength) {
       this.setState({
         loading: false,
-        error: "Password must contain at least one uppercase letter, one lowercase letter , a number and  8 characters long",
+        error: "Password must contain at least one uppercase letter, one lowercase letter, a number and 8 characters long",
       });
     } else {
       this.setState({


### PR DESCRIPTION
# Description

This pull request targets to secure the user accounts by prompting and requiring them register with strong and long enough passwords to the platform. The passwords are targeted to have a minimum of 8 characters , at least an uppercase , lowercase letter and a number.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID

https://trello.com/c/8B48LUIM

## How Can This Been Tested?

Pull the remote branch and run it locally. Try registering a new account with a short password, or even registering with one that lacks the uppercase , lowercase and number. You will be prompted to fulfill the requirements.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot from 2024-03-22 16-09-40](https://github.com/crane-cloud/frontend/assets/110970478/dfa84df9-48a7-40ac-92dc-7a8be7421089)
