### PR TITLE
feat: retrieve single app revisions for admin app details page and add loading states

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -392,7 +392,7 @@ tr.TableLoading td {
 }
 
 .TitleContainer .TitleArea {
-  padding: 1rem 2.5rem 0 2.5rem;
+  padding: 1rem 2rem 0 2rem;
 }
 
 /* //// ADMIN DASHBOARD PAGE STYLING  //// */
@@ -450,6 +450,10 @@ tr.TableLoading td {
   flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
+}
+
+.ContentSection .TitleArea {
+  padding: 0 0 1rem 0;
 }
 
 /*- /////////--- STYLING FOR FEEDBACK ---//////////// */

--- a/src/index.css
+++ b/src/index.css
@@ -222,7 +222,8 @@ input[type="password"] {
 div.ResourcesTable {
   padding: 1rem 0.5rem 0 0.5rem;
 }
-div.ResourcesTable div.nologs{
+
+div.ResourcesTable div.nologs {
   position: relative;
   table-layout: fixed;
   text-align: center;
@@ -235,6 +236,7 @@ div.ResourcesTable div.nologs{
   padding: 1rem 1rem 1rem 2rem;
   right: 1.6rem;
 }
+
 div.ResourcesTable.LoadingResourcesTable {
   flex-grow: 1;
 }
@@ -387,6 +389,10 @@ tr.TableLoading td {
   text-align: center;
   justify-content: center;
   align-items: center;
+}
+
+.TitleContainer .TitleArea {
+  padding: 1rem 2.5rem 0 2.5rem;
 }
 
 /* //// ADMIN DASHBOARD PAGE STYLING  //// */
@@ -679,8 +685,9 @@ tr.TableLoading td {
 .footerPositionAbsolute {
   position: absolute;
 }
+
 /* Modal buttons */
-.AlertButtons{
+.AlertButtons {
   width: 90%;
   display: flex;
   justify-content: space-between;

--- a/src/pages/AdminAppDetail/AdminAppDetail.module.css
+++ b/src/pages/AdminAppDetail/AdminAppDetail.module.css
@@ -1,7 +1,7 @@
 .DetailContainer {
   display: flex;
   gap: 5%;
-  padding: 1% 4%;
+  padding: 2rem;
   flex-wrap: wrap;
   justify-content: space-between;
 }
@@ -28,6 +28,7 @@
 
 .DetailSecond {
   width: 40%;
+  height: fit-content;
 }
 
 .Revision {
@@ -53,10 +54,15 @@
   border: 1px solid #ddd;
 }
 
-.DetailFirstDetail{
+.DetailFirstDetail {
   margin: 2rem;
 }
 
-.listItem strong{
+.listItem strong {
   color: var(--primary-color);
+}
+
+.SpinnerArea {
+  padding: 2rem 0 2rem 0;
+  height: 5vh;
 }

--- a/src/pages/AdminAppDetail/index.js
+++ b/src/pages/AdminAppDetail/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import { handleGetRequest } from "../../apis/apis.js";
 import InformationBar from "../../components/InformationBar";
@@ -7,18 +7,47 @@ import { DisplayDateTime } from "../../helpers/dateConstants";
 import Header from "../../components/Header";
 import styles from "./AdminAppDetail.module.css";
 import { handlePostRequestWithOutDataObject } from "../../apis/apis.js";
+import { useDispatch, useSelector } from "react-redux";
+import getAppRevisions, {
+  clearFetchAppRevisionsState,
+} from "../../redux/actions/getRevisions.js";
+import Spinner from "../../components/Spinner/index.js";
 
 const AdminAppDetail = () => {
+  const dispatch = useDispatch();
   const { appID } = useParams();
   const [appDetail, setAppDetail] = useState({});
+
+  const { revisions, isFetching } = useSelector(
+    (state) => state.appRevisionsReducer
+  );
 
   useEffect(() => {
     getAppDetails(appID);
   }, [appID]);
 
-  const getAppDetails = (appID) => {
+  const applicationRevisions = useCallback(
+    () => dispatch(getAppRevisions(appID)),
+    [dispatch, appID]
+  );
+
+  useEffect(() => {
+    applicationRevisions();
+    return () => {
+      dispatch(clearFetchAppRevisionsState());
+    };
+  }, [applicationRevisions, dispatch]);
+
+  useEffect(() => {
+    dispatch(getAppRevisions(appID));
+    return () => {
+      dispatch(clearFetchAppRevisionsState());
+    };
+  }, [appID, dispatch]);
+
+  const getAppDetails = async (appID) => {
     try {
-      const response = handleGetRequest(`/apps/${appID}`);
+      const response = await handleGetRequest(`/apps/${appID}`);
       if (response.data.status === "success") {
         setAppDetail(response.data.data);
       } else {
@@ -28,13 +57,11 @@ const AdminAppDetail = () => {
       throw new Error("Failed to fetch app detail, please try again");
     }
   };
+
   const handleEnableButtonClick = () => {
     try {
       if (appDetail?.apps?.disabled) {
-        handlePostRequestWithOutDataObject(
-          appID,
-          `/apps/${appID}/enable`
-        )
+        handlePostRequestWithOutDataObject(appID, `/apps/${appID}/enable`)
           .then(() => {
             window.location.reload();
           })
@@ -44,10 +71,7 @@ const AdminAppDetail = () => {
             window.location.reload();
           });
       } else {
-        handlePostRequestWithOutDataObject(
-          appID,
-          `/apps/${appID}/disable`
-        )
+        handlePostRequestWithOutDataObject(appID, `/apps/${appID}/disable`)
           .then(() => {
             window.location.reload();
           })
@@ -61,7 +85,7 @@ const AdminAppDetail = () => {
       console.error("API call error:", error);
     }
   };
-  console.log(appDetail);
+
   return (
     <div className={styles.Page}>
       <div className="TopRow">
@@ -69,13 +93,15 @@ const AdminAppDetail = () => {
         <InformationBar header="App Detail" showBackBtn />
       </div>
 
-      <div>
+      <div className="TitleContainer">
         <div className="TitleArea">
           <div className="SectionTitle" style={{ paddingTop: "1rem" }}>
             <b>Application Detail</b>{" "}
             <PrimaryButton
               onClick={handleEnableButtonClick}
-              color={appDetail?.apps?.disabled ? "primary-outline" : "red-outline"}
+              color={
+                appDetail?.apps?.disabled ? "primary-outline" : "red-outline"
+              }
             >
               {appDetail?.apps?.disabled ? "Enable" : "Disable"}
             </PrimaryButton>
@@ -87,84 +113,101 @@ const AdminAppDetail = () => {
         <div className={styles.DetailFirst}>
           <div className={styles.DetailFirstTitle}>App Information</div>
           <div className={styles.DetailFirstDetail}>
-            <div class="list-group">
-              <div className={styles.listItem}>
-                <strong>Name:</strong> {appDetail?.apps?.name}
+            {isFetching ? (
+              <div className={styles.SpinnerArea}>
+                <Spinner size={"big"} />
               </div>
-              <div className={styles.listItem}>
-                <strong>ID:</strong> {appDetail?.apps?.id}
-              </div>
-              <div className={styles.listItem}>
-                <strong>URL:</strong>{" "}
-                <a href={appDetail?.apps?.url} target="_blank" rel="noreferrer">
-                  {appDetail?.apps?.url}
-                </a>
-              </div>
-              <div className={styles.listItem}>
-                <strong>Port:</strong> {appDetail?.apps?.port}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Custom Domain:</strong>{" "}
-                {appDetail?.apps?.has_custom_domain === "true" ? "Yes" : "No"}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Date Created:</strong>{" "}
-                {DisplayDateTime(new Date(appDetail?.apps?.date_created))}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Command:</strong> {appDetail?.apps?.command ? appDetail?.apps?.command : "None"}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Private Image:</strong>{" "}
-                {appDetail?.apps?.private_image === "true" ? "Yes" : "No"}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Age:</strong> {appDetail?.apps?.age}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Alias:</strong> {appDetail?.apps?.alias}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Image:</strong> {appDetail?.apps?.image}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Replicas:</strong> {appDetail?.apps?.replicas}
-              </div>
-              <div className={styles.listItem}>
-                <strong>Running Status:</strong>{" "}
-                {appDetail?.apps?.app_running_status}
-              </div>
-            </div>
+            ) : (
+              <>
+                <div class="list-group">
+                  <div className={styles.listItem}>
+                    <strong>Name:</strong> {appDetail?.apps?.name}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>ID:</strong> {appDetail?.apps?.id}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>URL:</strong>{" "}
+                    <a
+                      href={appDetail?.apps?.url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {appDetail?.apps?.url}
+                    </a>
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Port:</strong> {appDetail?.apps?.port}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Custom Domain:</strong>{" "}
+                    {appDetail?.apps?.has_custom_domain === "true"
+                      ? "Yes"
+                      : "No"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Date Created:</strong>{" "}
+                    {DisplayDateTime(new Date(appDetail?.apps?.date_created))}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Command:</strong>{" "}
+                    {appDetail?.apps?.command
+                      ? appDetail?.apps?.command
+                      : "None"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Private Image:</strong>{" "}
+                    {appDetail?.apps?.private_image === "true" ? "Yes" : "No"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Age:</strong> {appDetail?.apps?.age}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Alias:</strong> {appDetail?.apps?.alias}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Image:</strong> {appDetail?.apps?.image}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Replicas:</strong> {appDetail?.apps?.replicas}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Running Status:</strong>{" "}
+                    {appDetail?.apps?.app_running_status}
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </div>
         <div className={styles.DetailSecond}>
-          <div className={styles.DetailFirstTitle}>Revisions</div>
+          <div className={styles.DetailFirstTitle}>Revision History</div>
           <div className={styles.DetailSecondColumn}>
             <div className={styles.Revision}>Current Revision</div>
-            <div class="list-group">
-              <div></div>
-              <div className={styles.listItem}>
-                {/* <strong>Revision:</strong> {appDetail?.revisions[0]?.revision} */}
-                <strong>Revision:</strong>{" "}
-                {appDetail?.revisions?.length > 0
-                  ? appDetail.revisions[0].revision
-                  : "N/A"}
+            {isFetching ? (
+              <div className={styles.SpinnerArea}>
+                <Spinner size={"small"} />
               </div>
-              <div className={styles.listItem}>
-                {/* <strong>Revision ID:</strong> {appDetail?.revisions[0]?.revision_id} */}
-                <strong>Revision:</strong>{" "}
-                {appDetail?.revisions?.length > 0
-                  ? appDetail.revisions[0].revision_id
-                  : "N/A"}
-              </div>
-              <div className={styles.listItem}>
-                {/* <strong>Revision ID:</strong> {appDetail?.revisions[0]?.revision_id} */}
-                <strong>Created:</strong>{" "}
-                {appDetail?.revisions?.length > 0
-                  ? DisplayDateTime(new Date(appDetail.revisions[0].created_at))
-                  : "N/A"}
-              </div>
-            </div>
+            ) : (
+              <>
+                <div class="list-group">
+                  <div className={styles.listItem}>
+                    <strong>Revision No:</strong>{" "}
+                    {revisions?.length > 0 ? revisions[0].revision : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Revision ID:</strong>{" "}
+                    {revisions?.length > 0 ? revisions[0].revision_id : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Created:</strong>{" "}
+                    {revisions?.length > 0
+                      ? DisplayDateTime(new Date(revisions[0].created_at))
+                      : "N/A"}
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/AdminUserOverviewPage/index.jsx
+++ b/src/pages/AdminUserOverviewPage/index.jsx
@@ -152,6 +152,7 @@ const AdminUserOverviewPage = () => {
           <div className="TitleArea">
             <div className="SectionTitle">Users Category Summary</div>
           </div>
+
           {loading && sectionValue !== "active" ? (
             <div className="ResourceSpinnerWrapper">
               <Spinner size="big" />

--- a/src/pages/ClusterPage/index.jsx
+++ b/src/pages/ClusterPage/index.jsx
@@ -93,7 +93,7 @@ const ClusterPage = ({
         />
       </div>
 
-      <div>
+      <div className="TitleContainer">
         <div className="TitleArea">
           <div className="SectionTitle" style={{ paddingTop: "1rem" }}>
             <b>Summary</b>
@@ -211,7 +211,7 @@ const ClusterPage = ({
         <div className="NoResourcesMessage">{error}</div>
       )}
 
-      <div>
+      <div className="TitleContainer">
         <div className="TitleArea">
           <div className="SectionTitle" style={{ paddingTop: "2rem" }}>
             <b>Select Infrastructure ({clusters?.metadata?.cluster_count})</b>


### PR DESCRIPTION
# Description

This PR addresses the following issues  
1. Admin app details not being displayed, this was because the API call made returns a promise that needs to resolve asynchronously which wasn't the case.
2. Added loading states still on the app detail page, since the page was showing even before the app data is completely fetched.
3. Fix broken css on the admin cluster page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/1RiEvlGi

## How Can This Been Tested?

- Run this branch locally and checkout the admin side - app details section i.e. `http://localhost:3000/apps/1cbe403a-a6a8-40bc-a208-3f4a734a5963`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

https://github.com/crane-cloud/frontend/assets/63339234/abd20a70-5f7b-4c26-9972-d65f46962702

