### PR TITLE
feat: show user following card under recent activity

### DIFF
--- a/src/components/FeaturedUsersSection/FeaturedUsersSection.module.css
+++ b/src/components/FeaturedUsersSection/FeaturedUsersSection.module.css
@@ -17,3 +17,20 @@
     height: 40vh;
     text-align: center;
 }
+
+.titleRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.followButton {
+    background-color: var(--secondary-color);
+    color: #ffffff;
+    border: none;
+    border-radius: 5px;
+    padding: 5px 10px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: background-color 0.3s ease;
+}

--- a/src/components/FeaturedUsersSection/index.jsx
+++ b/src/components/FeaturedUsersSection/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./FeaturedUsersSection.module.css";
 import NewUserCard from "../NewUserCard";
 import { useDispatch, useSelector } from "react-redux";
@@ -8,17 +8,33 @@ import Spinner from "../Spinner";
 const FeaturedUsersSection = () => {
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    dispatch(getUsersList(null, null, 1, null));
-  }, [dispatch]);
-
-  const { isFetching, users, isFetched } = useSelector(
+  const { isFetching, users, isFetched, pagination } = useSelector(
     (state) => state.usersListReducer
   );
 
+  const [currentPage, setCurrentPage] = useState(
+    Math.floor(Math.random() * pagination?.pages) + 1
+  );
+
+  useEffect(() => {
+    dispatch(getUsersList(null, null, currentPage, null));
+  }, [dispatch, currentPage]);
+
+  const handleRefresh = () => {
+    setCurrentPage((prevPage) => {
+      const totalPages = pagination?.pages;
+      return prevPage < totalPages ? prevPage + 1 : 1;
+    });
+  };
+
   return (
     <div className={styles.featuredUsers}>
-      <h2>Suggested Users</h2>
+      <div className={styles.titleRow}>
+        <h2>Suggested Users</h2>
+        <button className={styles.followButton} onClick={handleRefresh}>
+          Refresh
+        </button>
+      </div>
 
       {isFetching && !isFetched ? (
         <div className={styles.noActivity}>
@@ -30,7 +46,7 @@ const FeaturedUsersSection = () => {
         </div>
       ) : (
         <>
-          {users?.slice(0, 7).map((user, index) => (
+          {users?.map((user, index) => (
             <NewUserCard key={index} userID={user?.id} />
           ))}
         </>

--- a/src/components/NewUserCard/index.jsx
+++ b/src/components/NewUserCard/index.jsx
@@ -4,11 +4,11 @@ import { Link } from "react-router-dom/cjs/react-router-dom.min";
 import {
   handleDeleteRequest,
   handleGetRequest,
-  handlePostRequestWithOutDataObject,
 } from "../../apis/apis";
 import Spinner from "../Spinner";
+import axios from "../../axios";
 
-const NewUserCard = ({ userID }) => {
+const NewUserCard = ({ userID, showFollowBtn = true }) => {
   const [userDetails, setUserDetails] = useState({});
   const [sectionLoad, setSectionLoad] = useState(false);
   const [userFollowLoading, setUserFollowLoading] = useState(false);
@@ -29,7 +29,7 @@ const NewUserCard = ({ userID }) => {
     getUserDetails();
   }, [getUserDetails, userFollowLoading]);
 
-  const onFollowClick = () => {
+  const onFollowClick = async () => {
     setUserFollowLoading(true);
     if (userDetails?.requesting_user_follows) {
       handleDeleteRequest(`users/${userDetails?.id}/following`, {})
@@ -41,17 +41,16 @@ const NewUserCard = ({ userID }) => {
           setUserFollowLoading(false);
         });
     } else {
-      handlePostRequestWithOutDataObject(
-        {},
-        `users/${userDetails?.id}/following`
-      )
-        .then(() => {
+      try {
+        const response = await axios.post(`users/${userDetails?.id}/following`);
+        if (response.status === 201) {
           setSectionLoad(true);
           setUserFollowLoading(false);
-        })
-        .catch((error) => {
-          setUserFollowLoading(false);
-        });
+        }
+      } catch (error) {
+        console.error("Error following user:", error);
+        setUserFollowLoading(false);
+      }
     }
   };
 
@@ -80,17 +79,19 @@ const NewUserCard = ({ userID }) => {
                 </Link>
               </h3>
             </div>
-            <div className={styles.followButtonArea}>
-              <button className={styles.followButton} onClick={onFollowClick}>
-                {userFollowLoading ? (
-                  <Spinner />
-                ) : userDetails?.requesting_user_follows ? (
-                  "Unfollow"
-                ) : (
-                  "+ Follow"
-                )}
-              </button>
-            </div>
+            {showFollowBtn && (
+              <div className={styles.followButtonArea}>
+                <button className={styles.followButton} onClick={onFollowClick}>
+                  {userFollowLoading ? (
+                    <Spinner />
+                  ) : userDetails?.requesting_user_follows ? (
+                    "Unfollow"
+                  ) : (
+                    "+ Follow"
+                  )}
+                </button>
+              </div>
+            )}
           </div>
           <div className={styles.cardContent}>
             <div className={styles.cardExtras}>

--- a/src/components/RecentActivityItem/index.jsx
+++ b/src/components/RecentActivityItem/index.jsx
@@ -3,6 +3,7 @@ import styles from "./RecentActivityItem.module.css";
 import NewProjectCard from "../NewProjectCard";
 import tellAge from "../../helpers/ageUtility";
 import NewAppCard from "../NewAppCard";
+import NewUserCard from "../NewUserCard";
 
 const RecentActivityItem = ({ item }) => {
   return (
@@ -15,7 +16,14 @@ const RecentActivityItem = ({ item }) => {
         </div>
         <div className={styles.time}>{tellAge(item?.creation_date)}</div>
         <div className={styles.projectCard}>
-          {item?.a_app_id == null ? (
+          {item?.a_app_id != null ? (
+            <NewAppCard
+              name={item?.app?.name}
+              url={item?.app?.url}
+              image={item?.app?.image}
+              port={item?.app?.port}
+            />
+          ) : item?.a_project_id != null ? (
             <NewProjectCard
               projectID={item?.project?.id}
               name={item?.project?.name}
@@ -24,14 +32,9 @@ const RecentActivityItem = ({ item }) => {
               type={item?.project?.project_type}
               showFollowers={false}
             />
-          ) : (
-            <NewAppCard
-              name={item?.app?.name}
-              url={item?.app?.url}
-              image={item?.app?.image}
-              port={item?.app?.port}
-            />
-          )}
+          ) : item?.a_user_id != null ? (
+            <NewUserCard userID={item?.a_user_id} showFollowBtn={false} />
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/pages/UsersDashboard/UsersDashboard.module.css
+++ b/src/pages/UsersDashboard/UsersDashboard.module.css
@@ -27,10 +27,6 @@
     overflow-y: auto;
 }
 
-.rightSection>div {
-    flex: 1;
-}
-
 .sticky {
     position: sticky;
     top: 0;


### PR DESCRIPTION
# Description

- This PR adds missing User following card to visualise followed users.
- Also resolves the bug on the user follow-event not being reflected on the users dashboard recent activity; the issue was from the way the request was being sent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## ClickUp Ticket ID

https://app.clickup.com/t/86953rz2p

## How Can This Been Tested?

- Run this branch locally and from the dashboard try following users and try shuffling the list as well with the newly introduced refresh button!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

Before 
![Screenshot 2024-07-15 at 10 26 56 PM](https://github.com/user-attachments/assets/d9b92cc8-2ee8-4428-844a-7d7e601e1037)

After
![Screenshot 2024-07-15 at 10 17 08 PM](https://github.com/user-attachments/assets/1f1e94d7-5042-493a-94dc-de0dfe279748)
