### PR TITLE
feat: retrieve relevant project and cluster details for app details on admin side

### DIFF
--- a/src/hooks/useProject.js
+++ b/src/hooks/useProject.js
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "../axios";
+
+export const useProject = (id) => {
+  return useQuery({
+    queryFn: () => api.get(`/projects/${id}`),
+    queryKey: ["project", id],
+    meta: {
+      errorMessage: "Failed to fetch project details",
+    },
+  });
+};

--- a/src/pages/AdminAppDetail/AdminAppDetail.module.css
+++ b/src/pages/AdminAppDetail/AdminAppDetail.module.css
@@ -1,6 +1,5 @@
 .DetailContainer {
   display: flex;
-  gap: 5%;
   padding: 2rem;
   flex-wrap: wrap;
   justify-content: space-between;
@@ -24,11 +23,27 @@
 
 .DetailFirst {
   width: 55%;
+  max-height: fit-content;
 }
 
 .DetailSecond {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.DetailSecondColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
   width: 40%;
-  height: fit-content;
+}
+
+.RevisionCard,
+.SecondaryCard {
+  border-radius: 5px;
+  border: 1px solid #ddd;
+  padding: 1rem;
 }
 
 .Revision {
@@ -37,16 +52,7 @@
   padding: 0.5rem 1rem;
 }
 
-.DetailSecondColumn {
-  margin: 1rem;
-  border-radius: 4px;
-  border: 1px solid var(--primary-color);
-
-}
-
 .listItem {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
   position: relative;
   display: block;
   padding: 10px 15px;
@@ -63,6 +69,6 @@
 }
 
 .SpinnerArea {
-  padding: 2rem 0 2rem 0;
+  padding: 2rem 0;
   height: 5vh;
 }

--- a/src/pages/AdminAppDetail/index.js
+++ b/src/pages/AdminAppDetail/index.js
@@ -12,15 +12,19 @@ import getAppRevisions, {
   clearFetchAppRevisionsState,
 } from "../../redux/actions/getRevisions.js";
 import Spinner from "../../components/Spinner/index.js";
+import { useProject } from "../../hooks/useProject.js";
 
 const AdminAppDetail = () => {
   const dispatch = useDispatch();
   const { appID } = useParams();
+  const [projectID, setProjectID] = useState("");
   const [appDetail, setAppDetail] = useState({});
 
   const { revisions, isFetching } = useSelector(
     (state) => state.appRevisionsReducer
   );
+
+  const { data: projectDetails, isLoading } = useProject(projectID);
 
   useEffect(() => {
     getAppDetails(appID);
@@ -50,6 +54,7 @@ const AdminAppDetail = () => {
       const response = await handleGetRequest(`/apps/${appID}`);
       if (response.data.status === "success") {
         setAppDetail(response.data.data);
+        setProjectID(response.data.data?.apps?.project_id);
       } else {
         throw new Error("No App detail found");
       }
@@ -180,10 +185,95 @@ const AdminAppDetail = () => {
             )}
           </div>
         </div>
-        <div className={styles.DetailSecond}>
-          <div className={styles.DetailFirstTitle}>Revision History</div>
-          <div className={styles.DetailSecondColumn}>
-            <div className={styles.Revision}>Current Revision</div>
+
+        <div className={styles.DetailSecondColumn}>
+          <div>
+            <div className={styles.DetailFirstTitle}>Cluster Information</div>
+            {isLoading ? (
+              <div className={styles.SpinnerArea}>
+                <Spinner size={"small"} />
+              </div>
+            ) : (
+              <>
+                <div class="list-group">
+                  <div className={styles.listItem}>
+                    <strong>Name:</strong>{" "}
+                    {projectDetails
+                      ? projectDetails?.data?.data?.project?.cluster?.name
+                      : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>ID:</strong>{" "}
+                    {projectDetails
+                      ? projectDetails?.data?.data?.project?.cluster?.id
+                      : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Description:</strong>{" "}
+                    {projectDetails
+                      ? projectDetails?.data?.data?.project?.cluster
+                          ?.description
+                      : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Created:</strong>{" "}
+                    {projectDetails
+                      ? DisplayDateTime(
+                          new Date(
+                            projectDetails?.data?.data?.project?.cluster?.date_created
+                          )
+                        )
+                      : "N/A"}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div>
+            <div className={styles.DetailFirstTitle}>Project Information</div>
+            {isLoading ? (
+              <div className={styles.SpinnerArea}>
+                <Spinner size={"small"} />
+              </div>
+            ) : (
+              <>
+                <div class="list-group">
+                  <div className={styles.listItem}>
+                    <strong>Name:</strong>{" "}
+                    {projectDetails
+                      ? projectDetails?.data?.data?.project?.name
+                      : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Description:</strong>{" "}
+                    {projectDetails
+                      ? projectDetails?.data?.data?.project?.description
+                      : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Owner ID:</strong>{" "}
+                    {projectDetails
+                      ? projectDetails?.data?.data?.project?.owner_id
+                      : "N/A"}
+                  </div>
+                  <div className={styles.listItem}>
+                    <strong>Created:</strong>{" "}
+                    {projectDetails
+                      ? DisplayDateTime(
+                          new Date(
+                            projectDetails?.data?.data?.project?.date_created
+                          )
+                        )
+                      : "N/A"}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div>
+            <div className={styles.DetailFirstTitle}>Current Revision</div>
             {isFetching ? (
               <div className={styles.SpinnerArea}>
                 <Spinner size={"small"} />


### PR DESCRIPTION
# Description

This PR retrieves relevant project and cluster details when viewing app details on admin side

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Clickup Ticket ID

https://app.clickup.com/t/8696k7nhn

## How Can This Been Tested?

Run this branch locally and checkout the apps on the admin side, proceed to view details of a single deployment inorder to view all the relevant information.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2024-11-11 at 1 34 12 PM](https://github.com/user-attachments/assets/20f19df4-ca86-4d9d-90d4-896b8fe02063)
