### PR TITLE
Fixed admin app category count and  filtering

### DIFF
--- a/src/components/AppListing/index.js
+++ b/src/components/AppListing/index.js
@@ -1,27 +1,35 @@
-import React, { useEffect } from "react";
-import { useSelector } from "react-redux";
+import React from "react";
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min";
 import Pagination from "../../components/Pagination";
 import Spinner from "../Spinner";
+import { useAppList } from "../../hooks/useApps";
 
 const AppListing = (props) => {
-  const { currentPage, gettingApps, handlePageChange } = props;
+  const {
+    sectionValue,
+    currentPage,
+    currentPaginationPage,
+    handleChangePage,
+    setCurrentPaginationPage,
+  } = props;
 
-  const { isFetching, apps, isFetched, pagination } = useSelector(
-    (state) => state.appsAdminListReducer
+  const { data: response, isLoading } = useAppList(
+    sectionValue,
+    currentPaginationPage
   );
 
-  useEffect(() => {
-    gettingApps(currentPage);
-  }, [gettingApps, currentPage]);
-
   const history = useHistory();
+
+  const handlePageChange = (currentPage) => {
+    handleChangePage(currentPage);
+    setCurrentPaginationPage(currentPage);
+  };
 
   return (
     <div className="ContentSection">
       <div
         className={
-          isFetching ? "ResourcesTable LoadingResourcesTable" : "ResourcesTable"
+          isLoading ? "ResourcesTable LoadingResourcesTable" : "ResourcesTable"
         }
       >
         <table className="UsersTable">
@@ -33,7 +41,7 @@ const AppListing = (props) => {
               <th>Age</th>
             </tr>
           </thead>
-          {isFetching ? (
+          {isLoading ? (
             <tbody>
               <tr className="TableLoading">
                 <td className="TableTdSpinner">
@@ -45,11 +53,11 @@ const AppListing = (props) => {
             </tbody>
           ) : (
             <tbody>
-              {isFetched &&
-                apps !== undefined &&
-                apps?.map((app) => (
+              {!isLoading &&
+                response?.data?.data?.apps !== undefined &&
+                response?.data?.data?.apps?.map((app) => (
                   <tr
-                    key={apps.indexOf(app)}
+                    key={response?.data?.data?.apps.indexOf(app)}
                     onClick={() => {
                       history.push(`/apps/${app?.id}`);
                     }}
@@ -64,12 +72,12 @@ const AppListing = (props) => {
           )}
         </table>
 
-        {isFetched && apps.length === 0 && (
+        {response?.data?.data?.apps.length === 0 && (
           <div className="AdminNoResourcesMessage">
             <p>No apps Available</p>
           </div>
         )}
-        {!isFetching && !isFetched && (
+        {!isLoading && response?.data?.data?.apps?.length === 0 && (
           <div className="AdminNoResourcesMessage">
             <p>
               Oops! Something went wrong! Failed to retrieve Available apps.
@@ -77,10 +85,10 @@ const AppListing = (props) => {
           </div>
         )}
       </div>
-      {pagination?.pages > 1 && (
+      {response?.data?.data?.pagination?.pages > 1 && (
         <div className="AdminPaginationSection">
           <Pagination
-            total={pagination.pages}
+            total={response?.data?.data?.pagination?.pages}
             current={currentPage}
             onPageChange={handlePageChange}
           />

--- a/src/helpers/getAppCategories.js
+++ b/src/helpers/getAppCategories.js
@@ -2,6 +2,7 @@ export const getAppCategories = () => {
   const appCategories = [
     { id: 1, name: "All Apps", value: "all" },
     { id: 2, name: "Active Apps", value: "active" },
+    { id: 4, name: "Notebooks", value: "is_notebook" },
     { id: 3, name: "Disabled Apps", value: "disabled" },
   ];
   return appCategories;

--- a/src/hooks/useApps.js
+++ b/src/hooks/useApps.js
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import api from './../axios';
+
+export const useAppList = (category = "", page) => {
+  let link = `/apps?page=${page}`;
+
+  if (category && category !== "all") {
+    link += `&${category}=true`;
+  }
+
+  return useQuery({
+    queryFn: () => api.get(link),
+    queryKey: ["adminAppsList", category, page],
+    meta: {
+      errorMessage: "Failed to fetch all apps",
+    },
+  });
+};

--- a/src/pages/AdminAppsPage/index.js
+++ b/src/pages/AdminAppsPage/index.js
@@ -1,6 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
-import { useDispatch } from "react-redux";
-import getAppsList from "../../redux/actions/adminApps";
+import React, { useState, useEffect } from "react";
 import { getAppCategories } from "../../helpers/getAppCategories";
 import Header from "../../components/Header";
 import InformationBar from "../../components/InformationBar";
@@ -28,17 +26,17 @@ import { filterGraphData } from "../../helpers/filterGraphData.js";
 import { retrieveMonthNames } from "../../helpers/monthNames.js";
 
 const AdminAppsPage = () => {
-  // const [apps, setApps] = useState([]);
   const [appTotal, setAppTotal] = useState([]);
   const [appGraphData, setAppGraphData] = useState([]);
   const [feedback, setFeedback] = useState("");
   const [loading, setLoading] = useState(false);
   const [period, setPeriod] = useState("all");
-  //sectionValue will be set when being used
-  const [, setSectionValue] = useState("all");
+  const [sectionValue, setSectionValue] = useState("all");
   const [word, setWord] = useState("");
+  const [is_notebook, setIsNotebook] = useState();
+  const [disabledApps, setDisabledApps] = useState();
   const [currentPage, handleChangePage] = usePaginator();
-  const dispatch = useDispatch();
+  const [currentPaginationPage, setCurrentPaginationPage] = useState(1);
 
   let filteredGraphData = [];
 
@@ -53,6 +51,8 @@ const AdminAppsPage = () => {
       const response = await handleGetRequest("/apps?series=true");
       setAppGraphData(response.data.data.graph_data);
       setAppTotal(response.data.data.metadata.total_apps);
+      setIsNotebook(response.data.data.metadata.is_notebook);
+      setDisabledApps(response.data.data.metadata.disabled);
     } catch (error) {
       setFeedback("Failed to fetch Apps metrics");
     } finally {
@@ -67,21 +67,12 @@ const AdminAppsPage = () => {
   const availableAppCategories = getAppCategories();
 
   const handleSectionChange = (selectedOption) => {
+   
     const selectedValue = selectedOption.value;
     setSectionValue(selectedValue);
   };
 
-  const gettingApps = useCallback(
-    () => dispatch(getAppsList(currentPage, word)),
-    [currentPage, dispatch, word]
-  );
-  
   const handleCallbackSearchword = ({ target: { value } }) => setWord(value);
-
-  const handlePageChange = (currentPage) => {
-    handleChangePage(currentPage);
-    gettingApps();
-  };
 
   filteredGraphData = filterGraphData(appGraphData, period);
 
@@ -121,6 +112,14 @@ const AdminAppsPage = () => {
               <NewResourceCard
                 title="Down Apps"
                 count={Math.floor(appTotal * 0.1)}
+              />
+              <NewResourceCard
+                title="Notebooks"
+                count={is_notebook}
+              />
+              <NewResourceCard
+                title="Disabled Apps"
+                count={disabledApps}
               />
             </div>
           )}
@@ -365,11 +364,14 @@ const AdminAppsPage = () => {
               </span>
             </div>
           </div>
-          {/* {sectionValue === "active" ? } */}
+
           <AppListing
-            gettingApps={gettingApps}
-            handlePageChange={handlePageChange}
+            handleChangePage={handleChangePage}
+            word={word}
             currentPage={currentPage}
+            sectionValue={sectionValue}
+            currentPaginationPage={currentPaginationPage}
+            setCurrentPaginationPage={setCurrentPaginationPage}
           />
         </div>
       </div>


### PR DESCRIPTION
# Description

This PR aims to display disabled apps and notebooks count on the admin apps overview page and enable filtering of app categories on the app listing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Click up Ticket ID
https://app.clickup.com/t/8696k7bkw
https://app.clickup.com/t/869801gx0


## How Can This Been Tested?
Go to Admin apps overview page, filter app listing according to the available categories. Observe changes in the app listing 
table.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots
![Screenshot from 2025-02-26 22-40-10](https://github.com/user-attachments/assets/6e20a04d-ce5c-4be3-86ef-5e2bc9526e7a)
![Screenshot from 2025-02-26 22-40-23](https://github.com/user-attachments/assets/eab0c9cb-52e3-4150-9cde-040bbc6fc06a)