### PR TITLE
feat: user experience to migrate projects from disabled clusters

### DIFF
--- a/src/components/Forms/CreateProjectForm.tsx
+++ b/src/components/Forms/CreateProjectForm.tsx
@@ -25,6 +25,7 @@ import { useNavigate } from "react-router-dom";
 type TCreateProjectForm = {
   project?: any;
   showTitle?: boolean;
+  isUpdatingProject?: boolean;
   onCancel?: () => void;
   refresh?: () => void;
 };
@@ -32,6 +33,7 @@ type TCreateProjectForm = {
 const CreateProjectForm = (props: TCreateProjectForm) => {
   const {
     project,
+    isUpdatingProject = false,
     showTitle = true,
     onCancel = false,
     refresh = () => {},
@@ -168,41 +170,45 @@ const CreateProjectForm = (props: TCreateProjectForm) => {
               onChange={(value) => updateFormValue("organisation", value)}
               error={error?.organisation}
             />
-            <Select
-              label="Is it an Machine Learning Project?"
-              description="Tick if it is a machine learning project"
-              placeholder="Enter project location"
-              data={[YES, NO]}
-              name="supports_ml"
-              defaultValue={NO}
-              value={form?.supports_ml as string}
-              onChange={(value) => updateFormValue("supports_ml", value)}
-              required
-              error={error?.supports_ml}
-              disabled={project?.id}
-            />
-            <Select
-              label={
-                form.supports_ml === YES
-                  ? "Machine Learning Project Location"
-                  : "Project Location"
-              }
-              description={
-                form.supports_ml === YES
-                  ? "Select where your machine learning project will be deployed"
-                  : "Select where your project will be deployed"
-              }
-              placeholder="Enter project location"
-              data={form.supports_ml === YES ? ml_clusters : clusters}
-              name="cluster_id"
-              rightSection={clustersLoading ? <Loader size="xs" /> : null}
-              searchable
-              value={form.cluster_id as string}
-              onChange={(value) => updateFormValue("cluster_id", value)}
-              required
-              error={error?.cluster_id}
-              disabled={project?.id}
-            />
+            {!isUpdatingProject && (
+              <>
+                <Select
+                  label="Is it an Machine Learning Project?"
+                  description="Tick if it is a machine learning project"
+                  placeholder="Enter project location"
+                  data={[YES, NO]}
+                  name="supports_ml"
+                  defaultValue={NO}
+                  value={form?.supports_ml as string}
+                  onChange={(value) => updateFormValue("supports_ml", value)}
+                  required
+                  error={error?.supports_ml}
+                  disabled={project?.id}
+                />
+                <Select
+                  label={
+                    project?.supports_ml === true
+                      ? "Machine Learning Project Location"
+                      : "Project Location"
+                  }
+                  description={
+                    project?.supports_ml === true
+                      ? "Select where your machine learning project will be deployed"
+                      : "Select where your project will be deployed"
+                  }
+                  placeholder="Enter project location"
+                  data={form.supports_ml === YES ? ml_clusters : clusters}
+                  name="cluster_id"
+                  rightSection={clustersLoading ? <Loader size="xs" /> : null}
+                  searchable
+                  value={form.cluster_id as string}
+                  onChange={(value) => updateFormValue("cluster_id", value)}
+                  required
+                  error={error?.cluster_id}
+                  disabled={project?.id}
+                />
+              </>
+            )}
             <TagsInput
               label="Tags"
               description="Add tags to help identify your project"
@@ -292,6 +298,9 @@ export const MigrateProjectForm = (props: {
       value: cluster.id,
     }));
 
+  const availableClusters =
+    project?.supports_ml === true ? ml_clusters : clusters;
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     uploadData({
@@ -338,7 +347,7 @@ export const MigrateProjectForm = (props: {
           <Select
             label="Is it an Machine Learning Project?"
             description="Tick if it is a machine learning project"
-            placeholder="Enter project location"
+            placeholder="Does this project use machine learning?"
             data={[YES, NO]}
             name="supports_ml"
             defaultValue={NO}
@@ -346,20 +355,21 @@ export const MigrateProjectForm = (props: {
             onChange={(value) => updateFormValue("supports_ml", value)}
             required
             error={error?.supports_ml}
+            disabled={project?.id}
           />
           <Select
             label={
-              form.supports_ml === YES
+              project?.supports_ml === true
                 ? "Machine Learning Project Location"
                 : "Project Location"
             }
             description={
-              form.supports_ml === YES
+              project?.supports_ml === true
                 ? "Select where your machine learning project will be deployed"
                 : "Select where your project will be deployed"
             }
             placeholder="Enter project location"
-            data={form.supports_ml === YES ? ml_clusters : clusters}
+            data={availableClusters}
             name="cluster_id"
             rightSection={clustersLoading ? <Loader size="xs" /> : null}
             searchable

--- a/src/pages/Projects/ProjectDetailsPage.tsx
+++ b/src/pages/Projects/ProjectDetailsPage.tsx
@@ -3,17 +3,58 @@ import TitleText from "@/components/TitleText";
 import { useGetProject } from "@/utils/helpers";
 import AppsList from "@/components/Lists/AppsList";
 import { AddServiceButton } from "@/components/Elements/Elements";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import useGet from "@/utils/useGet";
+import { API_CLUSTERS } from "@/utils/apis";
+import { MigrateProjectForm } from "@/components/Forms/CreateProjectForm";
+import { ModalConfirm } from "@/components/Elements/Modals";
+import { BiTransferAlt } from "react-icons/bi";
 
 const ProjectDetailsPage = () => {
   const { project_id } = useParams();
   const { project, loading, success } = useGetProject(project_id || "");
+  const {
+    data: clustersData,
+    getData: getClusters,
+    loading: clustersLoading,
+    success: getDisabledClustersSuccess,
+  } = useGet();
+
+  const [showProjectMigrateModal, setShowProjectMigrateModal] = useState(false);
 
   const [refresh, setRefresh] = useState(false);
 
+  useEffect(() => {
+    getClusters({
+      api: `${API_CLUSTERS}`,
+      params: { disabled: true },
+    });
+  }, []);
+
+  useEffect(() => {
+    if (success && project && getDisabledClustersSuccess) {
+      // check if clustersData is not empty
+      if (clustersData?.data?.clusters?.length < 1) {
+        setShowProjectMigrateModal(false);
+      } else {
+        // check if disabled cluster matches the one for the opened project
+        const foundDisabledCluster = clustersData?.data?.clusters?.some(
+          (cluster: any) => cluster.id === project.cluster_id,
+        );
+
+        // show modal to migrate the project if match is found
+        if (foundDisabledCluster) {
+          setShowProjectMigrateModal(true);
+        } else {
+          setShowProjectMigrateModal(false);
+        }
+      }
+    }
+  }, [getDisabledClustersSuccess, success, project]);
+
   return (
-    <div>
-      {success && (
+    <>
+      {!clustersLoading && success && (
         <TitleText
           loading={loading}
           rightSection={
@@ -26,7 +67,28 @@ const ProjectDetailsPage = () => {
 
       <AppsList project_id={project_id} refresh={refresh} />
       {/* <DatabaseList project_id={id} /> */}
-    </div>
+
+      {showProjectMigrateModal && (
+        <ModalConfirm
+          opened={showProjectMigrateModal}
+          onClose={() => setShowProjectMigrateModal(false)}
+          title="Server Cluster Unavailable - Migrate Project Now"
+          buttonText="Migrate"
+          // buttonColor="red"
+          onConfirm={() => {}}
+          size="xl"
+          showFooterActions={false}
+          leftSection={<BiTransferAlt />}
+        >
+          <MigrateProjectForm
+            project={project}
+            showTitle={false}
+            onCancel={() => setShowProjectMigrateModal(false)}
+            refresh={() => setRefresh(true)}
+          />
+        </ModalConfirm>
+      )}
+    </>
   );
 };
 

--- a/src/pages/Projects/ProjectSettingsPage.tsx
+++ b/src/pages/Projects/ProjectSettingsPage.tsx
@@ -339,6 +339,7 @@ const GeneralTab = ({
             <CreateProjectForm
               project={project}
               showTitle={false}
+              isUpdatingProject
               onCancel={() => setUpdateConfirmOpened(false)}
               refresh={() => setRefresh(true)}
             />


### PR DESCRIPTION
# Description

- This PR will let users who have a project on a disabled cluster to be able to migrate it to a different location/cluster.
- Ensure project migration happens for project that support machine learning on clusters that support it, otherwise migration for projects that don't support machine learning shouldn't proceed to machine learning clusters.
- Conditionally showing the machine learning selection and project selection in the `CreateProjectForm` and not showing it in the `Edit Project View` since we now have a separate section to handle project/cluster migration

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## ClickUp Ticket ID

https://app.clickup.com/t/8699151pk

## How Can This Been Tested?

- Run this branch locally and checkout a project(from the projects dashboard) that is associated to a disabled cluster to be able to see the migration instructions modal.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2025-05-19 at 2 43 45 PM](https://github.com/user-attachments/assets/03941c5d-6230-49fa-a072-ac2e91926ecc)
