### PR TITLE
feat(metrics): display and allow filtering on metrics for projects and apps with standard units

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -4,6 +4,7 @@ import CreateNewPassword from "./pages/Auth/passwordResetPage";
 import ExperiementsDetailsPage from "./pages/Experirments/ExperiementsDetailsPage";
 import RunsDetailsPage from "./pages/Experirments/RunsDetailsPage";
 import UserProfilePage from "./pages/Users/UserProfilePage";
+import AppMetrics from "./pages/Apps/AppMetrics";
 // import { HomePage } from "./pages/Home.page";
 const AppsListPage = React.lazy(() => import("./pages/Apps/AppsListPage"));
 const ProjectSettingsPage = React.lazy(
@@ -36,11 +37,12 @@ const ProjectDetailsPage = React.lazy(
   () => import("./pages/Projects/ProjectDetailsPage"),
 );
 export const guestRoutes = [
-  // { path: "/", element: <HomePage /> },
+  // { path: "/", element: <></> },
   { path: "/login", element: <LoginPage /> },
   { path: "/reset_password/:token", element: <CreateNewPassword /> },
 ];
 export const DashboardRoutes = [
+  // { path: "/login", element: <LoginPage /> },
   // Users
   { path: "/", element: <LandingPage /> },
   { path: "/profile/:user_id", element: <UserProfilePage /> },
@@ -55,6 +57,10 @@ export const DashboardRoutes = [
   { path: "/projects/:project_id/apps/create", element: <CreateAppForm /> },
   { path: "/projects/:project_id/apps/:app_id", element: <AppDetailPage /> },
   { path: "/projects/:project_id/apps/:app_id/logs", element: <AppLogsPage /> },
+  {
+    path: "/projects/:project_id/apps/:app_id/metrics",
+    element: <AppMetrics />,
+  },
   {
     path: "/projects/:project_id/apps/:app_id/settings",
     element: <AppSettingsPage />,

--- a/src/components/Elements/ChartTooltip.tsx
+++ b/src/components/Elements/ChartTooltip.tsx
@@ -1,0 +1,31 @@
+import { formatMetricValue, formatTimestamp } from "@/utils/helpers";
+import { Paper, Text } from "@mantine/core";
+
+interface ChartTooltipProps {
+  label: string;
+  payload: Record<string, any>[] | undefined;
+  chartType: string;
+}
+
+export default function ChartTooltip({
+  label,
+  payload,
+  chartType,
+}: ChartTooltipProps) {
+  if (!payload || payload.length === 0) {
+    return null;
+  }
+
+  return (
+    <Paper px="md" py="sm" withBorder shadow="md" radius="md">
+      <Text fw={500} mb={5}>
+        {formatTimestamp(Number(label))}
+      </Text>
+      {payload.map((item: any) => (
+        <Text key={item.name} c={item.color} fz="sm">
+          Usage: {formatMetricValue(chartType, item.value)}
+        </Text>
+      ))}
+    </Paper>
+  );
+}

--- a/src/components/Elements/Charts.tsx
+++ b/src/components/Elements/Charts.tsx
@@ -8,10 +8,13 @@ import {
   Group,
   Flex,
   ActionIcon,
+  Loader,
+  Center,
 } from "@mantine/core";
 import { DatePickerInput } from "@mantine/dates";
 import { useState, useEffect } from "react";
 import { FaChartLine, FaEye, FaEyeSlash } from "react-icons/fa";
+import ChartTooltip from "./ChartTooltip";
 
 type TLineMetricChart = {
   title: string;
@@ -22,22 +25,79 @@ type TLineMetricChart = {
   setBigChart?: (chartType: "cpu" | "memory" | "network") => void;
   chartType?: "cpu" | "memory" | "network";
   currentChart?: "cpu" | "memory" | "network";
+  isLoading?: boolean;
 };
 
 export const LineMetricChart = ({
   title,
   data,
   valueFormatter,
-  showAllXValues = false,
+  showAllXValues = true,
   height = 250,
   setBigChart,
   chartType,
   currentChart,
+  isLoading = false,
 }: TLineMetricChart) => {
   const xAxisTicks =
     data?.length > 0
       ? [data[0].timestamp, data[data.length - 1].timestamp]
       : [];
+
+  const renderChartContent = () => {
+    if (isLoading) {
+      return (
+        <Center h={height}>
+          <Loader />
+        </Center>
+      );
+    }
+
+    if (!data || data.length === 0) {
+      return (
+        <Center h={height}>
+          <Text c="dimmed">No data available</Text>
+        </Center>
+      );
+    }
+
+    return (
+      <LineChart
+        h={height}
+        w="100%"
+        data={data}
+        series={[{ name: "value", label: "Usage" }]}
+        dataKey="timestamp"
+        dotProps={{ r: 2 }}
+        type="gradient"
+        gradientStops={[
+          { offset: 0, color: "red.6" },
+          { offset: 20, color: "orange.6" },
+          { offset: 40, color: "yellow.5" },
+          { offset: 70, color: "lime.5" },
+          { offset: 80, color: "cyan.5" },
+          { offset: 100, color: "blue.5" },
+        ]}
+        strokeWidth={2}
+        curveType="natural"
+        valueFormatter={valueFormatter}
+        tooltipProps={{
+          content: ({ label, payload }) => (
+            <ChartTooltip
+              label={label}
+              payload={payload}
+              chartType={chartType!}
+            />
+          ),
+        }}
+        xAxisProps={{
+          tickFormatter: formatTimestamp,
+          ...returnObject(showAllXValues, { ticks: xAxisTicks }),
+        }}
+      />
+    );
+  };
+
   return (
     <Card withBorder p="md" radius="md" w="100%">
       <Stack gap="lg">
@@ -59,37 +119,7 @@ export const LineMetricChart = ({
             </ActionIcon>
           )}
         </Group>
-        <LineChart
-          h={height}
-          w="100%"
-          data={data}
-          series={[{ name: "value", label: "Usage" }]}
-          dataKey="timestamp"
-          dotProps={{
-            r: 2,
-          }}
-          type="gradient"
-          gradientStops={[
-            { offset: 0, color: "red.6" },
-            { offset: 20, color: "orange.6" },
-            { offset: 40, color: "yellow.5" },
-            { offset: 70, color: "lime.5" },
-            { offset: 80, color: "cyan.5" },
-            { offset: 100, color: "blue.5" },
-          ]}
-          strokeWidth={2}
-          curveType="natural"
-          valueFormatter={valueFormatter}
-          tooltipProps={{
-            labelFormatter: (value) => formatTimestamp(value),
-          }}
-          xAxisProps={{
-            tickFormatter: formatTimestamp,
-            ...returnObject(showAllXValues, {
-              ticks: xAxisTicks,
-            }),
-          }}
-        />
+        {renderChartContent()}
       </Stack>
     </Card>
   );
@@ -101,6 +131,7 @@ type TLineLargeMetricChart = TLineMetricChart & {
     endDate: Date | null;
   };
   setFilters: (filter: any) => void;
+  currentChart?: "cpu" | "memory" | "network";
 };
 
 export const LineLargeMetricChart = ({
@@ -111,45 +142,115 @@ export const LineLargeMetricChart = ({
   height = 250,
   filters,
   setFilters,
+  currentChart,
+  isLoading = false,
 }: TLineLargeMetricChart) => {
   const { startDate, endDate } = filters;
   const [filteredData, setFilteredData] = useState(data);
   const [activePreset, setActivePreset] = useState<
-    "1D" | "7D" | "30D" | "90D" | "all" | null
-  >("7D");
+    "1D" | "7D" | "30D" | "90D" | "Today" | null
+  >("Today");
 
   const xAxisTicks =
     data?.length > 0
       ? [data[0].timestamp, data[data.length - 1].timestamp]
       : [];
 
-  const setLast7Days = () => {
-    setFilters({
-      startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
-      endDate: new Date(),
-    });
-    setActivePreset("7D");
+  const handlePresetClick = (range: "1D" | "7D" | "30D" | "90D" | "Today") => {
+    const now = new Date();
+
+    if (range === "Today") {
+      setFilters({
+        startDate: null,
+        endDate: null,
+      });
+    } else {
+      const daysMap = {
+        "1D": 1,
+        "7D": 7,
+        "30D": 30,
+        "90D": 90,
+      };
+
+      const daysToGoBack = daysMap[range];
+      const startDate = new Date(
+        now.getTime() - daysToGoBack * 24 * 60 * 60 * 1000,
+      );
+
+      setFilters({
+        startDate,
+        endDate: now,
+      });
+    }
+
+    setActivePreset(range);
   };
 
-  const setLast30Days = () => {
-    setFilters({
-      startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
-      endDate: new Date(),
-    });
-    setActivePreset("30D");
-  };
+  const renderChartContent = () => {
+    if (isLoading) {
+      return (
+        <Center h={height}>
+          <Loader />
+        </Center>
+      );
+    }
 
-  const setLast1Day = () => {
-    setFilters({
-      startDate: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
-      endDate: new Date(),
-    });
-    setActivePreset("1D");
+    if (!filteredData || filteredData.length === 0) {
+      return (
+        <Center h={height}>
+          <Text c="dimmed">No data available</Text>
+        </Center>
+      );
+    }
+
+    return (
+      <LineChart
+        h={height}
+        w="100%"
+        data={filteredData}
+        series={[{ name: "value", label: "Usage" }]}
+        dataKey="timestamp"
+        dotProps={{ r: 2 }}
+        type="gradient"
+        gradientStops={[
+          { offset: 0, color: "red.6" },
+          { offset: 20, color: "orange.6" },
+          { offset: 40, color: "yellow.5" },
+          { offset: 70, color: "lime.5" },
+          { offset: 80, color: "cyan.5" },
+          { offset: 100, color: "blue.5" },
+        ]}
+        strokeWidth={2}
+        curveType="natural"
+        valueFormatter={valueFormatter}
+        tooltipProps={{
+          content: ({ label, payload }) => (
+            <ChartTooltip
+              label={label}
+              payload={payload}
+              chartType={currentChart!}
+            />
+          ),
+        }}
+        xAxisProps={{
+          tickFormatter: formatTimestamp,
+          ...returnObject(showAllXValues, { ticks: xAxisTicks }),
+        }}
+      />
+    );
   };
 
   useEffect(() => {
-    const filtered = data?.filter((item: any) => {
-      const itemDate = new Date(item.timestamp);
+    if (!data) {
+      return;
+    }
+
+    const filtered = data.filter((item: any) => {
+      if (!startDate && !endDate) {
+        return true;
+      }
+
+      const itemDate = new Date(item.timestamp * 1000);
       return (
         (!startDate || itemDate >= startDate) &&
         (!endDate || itemDate <= endDate)
@@ -167,63 +268,23 @@ export const LineLargeMetricChart = ({
           </Group>
           <Flex justify="space-between" gap="xs" wrap="wrap">
             <Group gap="xs">
-              <Button
-                variant={activePreset === "1D" ? "solid" : "outline"}
-                size="xs"
-                onClick={setLast1Day}
-              >
-                1D
-              </Button>
-              <Button
-                variant={activePreset === "7D" ? "solid" : "outline"}
-                size="xs"
-                onClick={setLast7Days}
-              >
-                7D
-              </Button>
-              <Button
-                variant={activePreset === "30D" ? "solid" : "outline"}
-                size="xs"
-                onClick={setLast30Days}
-              >
-                30D
-              </Button>
-              <Button
-                variant={activePreset === "90D" ? "solid" : "outline"}
-                size="xs"
-                onClick={() => {
-                  setFilters({
-                    startDate: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000),
-                    endDate: new Date(),
-                  });
-                  setActivePreset("90D");
-                }}
-              >
-                90D
-              </Button>
-              <Button
-                variant={activePreset === "all" ? "solid" : "outline"}
-                size="xs"
-                onClick={() => {
-                  setFilters({
-                    startDate: null,
-                    endDate: null,
-                  });
-                  setActivePreset("all");
-                }}
-              >
-                All Time
-              </Button>
+              {(["1D", "7D", "30D", "90D", "Today"] as const).map((range) => (
+                <Button
+                  key={range}
+                  variant={activePreset === range ? "solid" : "outline"}
+                  size="xs"
+                  onClick={() => handlePresetClick(range)}
+                >
+                  {range}
+                </Button>
+              ))}
             </Group>
             <Group>
               <DatePickerInput
                 placeholder="Start date"
                 value={startDate}
                 onChange={(date) => {
-                  setFilters({
-                    ...filters,
-                    startDate: date,
-                  });
+                  setFilters({ ...filters, startDate: date });
                   setActivePreset(null);
                 }}
                 mx="auto"
@@ -233,10 +294,7 @@ export const LineLargeMetricChart = ({
                 placeholder="End date"
                 value={endDate}
                 onChange={(date) => {
-                  setFilters({
-                    ...filters,
-                    endDate: date,
-                  });
+                  setFilters({ ...filters, endDate: date });
                   setActivePreset(null);
                 }}
                 mx="auto"
@@ -245,37 +303,7 @@ export const LineLargeMetricChart = ({
             </Group>
           </Flex>
         </Stack>
-        <LineChart
-          h={height}
-          w="100%"
-          data={filteredData}
-          series={[{ name: "value", label: "Usage" }]}
-          dataKey="timestamp"
-          dotProps={{
-            r: 2,
-          }}
-          type="gradient"
-          gradientStops={[
-            { offset: 0, color: "red.6" },
-            { offset: 20, color: "orange.6" },
-            { offset: 40, color: "yellow.5" },
-            { offset: 70, color: "lime.5" },
-            { offset: 80, color: "cyan.5" },
-            { offset: 100, color: "blue.5" },
-          ]}
-          strokeWidth={2}
-          curveType="natural"
-          valueFormatter={valueFormatter}
-          tooltipProps={{
-            labelFormatter: (value) => formatTimestamp(value),
-          }}
-          xAxisProps={{
-            tickFormatter: formatTimestamp,
-            ...returnObject(showAllXValues, {
-              ticks: xAxisTicks,
-            }),
-          }}
-        />
+        {renderChartContent()}
       </Stack>
     </Card>
   );

--- a/src/pages/Apps/AppMetrics.tsx
+++ b/src/pages/Apps/AppMetrics.tsx
@@ -2,17 +2,16 @@ import {
   LineLargeMetricChart,
   LineMetricChart,
 } from "@/components/Elements/Charts";
+import { MenuContext } from "@/components/Layouts/DashboardLayout";
 import TitleText from "@/components/TitleText";
 import { MONITORING_API_URL } from "@/config";
-import { useGetProject } from "@/utils/helpers";
 import usePost from "@/utils/usePost";
 import { Grid } from "@mantine/core";
-import { useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
-const ProjectMetrics = () => {
-  const { project_id } = useParams();
-  useGetProject(project_id || "");
+const AppMetrics = () => {
+  const { app_id, project_id } = useParams();
   const {
     uploadData: getCPUMetrics,
     data: cpuMetricsData,
@@ -30,6 +29,13 @@ const ProjectMetrics = () => {
   } = usePost();
   const [bigChart, setBigChart] = useState<"cpu" | "memory" | "network">("cpu");
 
+  const { setMenuType, setContainerSize } = useContext(MenuContext);
+
+  useEffect(() => {
+    setContainerSize("xl");
+    setMenuType("app");
+  }, [setContainerSize]);
+
   const [filters, setFilters] = useState<{
     startDate: Date | null;
     endDate: Date | null;
@@ -41,6 +47,7 @@ const ProjectMetrics = () => {
   useEffect(() => {
     const fetchMetrics = () => {
       const baseBody = {
+        app_id,
         project_id,
       };
 
@@ -54,19 +61,21 @@ const ProjectMetrics = () => {
           : baseBody;
 
       getCPUMetrics({
-        api: `${MONITORING_API_URL}/projects/cpu/metrics`,
+        api: `${MONITORING_API_URL}/apps/cpu/metrics`,
         params: requestBody,
         isExternal: true,
         showNotifications: false,
       });
+
       getMemoryMetrics({
-        api: `${MONITORING_API_URL}/projects/memory/metrics`,
+        api: `${MONITORING_API_URL}/apps/memory/metrics`,
         params: requestBody,
         isExternal: true,
         showNotifications: false,
       });
+
       getNetworkMetrics({
-        api: `${MONITORING_API_URL}/projects/network/metrics`,
+        api: `${MONITORING_API_URL}/apps/network/metrics`,
         params: requestBody,
         isExternal: true,
         showNotifications: false,
@@ -74,7 +83,7 @@ const ProjectMetrics = () => {
     };
 
     fetchMetrics();
-  }, [filters, project_id]);
+  }, [filters, app_id, project_id]);
 
   const bigChartData = useMemo(() => {
     if (bigChart === "cpu") {
@@ -103,7 +112,7 @@ const ProjectMetrics = () => {
 
   return (
     <div>
-      <TitleText>Project Metrics</TitleText>
+      <TitleText>App Metrics</TitleText>
       <Grid>
         <Grid.Col span={12}>
           <LineLargeMetricChart
@@ -164,4 +173,4 @@ const ProjectMetrics = () => {
   );
 };
 
-export default ProjectMetrics;
+export default AppMetrics;

--- a/src/pages/Apps/AppMetrics.tsx
+++ b/src/pages/Apps/AppMetrics.tsx
@@ -49,6 +49,7 @@ const AppMetrics = () => {
       const baseBody = {
         app_id,
         project_id,
+        step: "5h",
       };
 
       const requestBody =

--- a/src/pages/Projects/ProjectMetrics.tsx
+++ b/src/pages/Projects/ProjectMetrics.tsx
@@ -42,6 +42,7 @@ const ProjectMetrics = () => {
     const fetchMetrics = () => {
       const baseBody = {
         project_id,
+        step: "5h",
       };
 
       const requestBody =

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -90,7 +90,7 @@ export const useGetApp = (app_id: string) => {
     if (setAppId) {
       setAppId(app_id || "");
     }
-    if (appData?.data?.apps?.is_notebook) {
+    if (appData?.data?.apps?.is_ai) {
       setMenuType("mlops");
     } else {
       setMenuType("app");
@@ -159,7 +159,7 @@ export const dateFormat = (date: string, format = "DD/MMM/YYYY") =>
   moment(date).format(format);
 
 export const formatTimestamp = (timestamp: number) => {
-  return format(new Date(timestamp * 1000), "MMM dd HH:mm:ss");
+  return format(new Date(timestamp * 1000), "MMM dd HH:mm");
 };
 
 export const getConnectionString = (database: any) => {
@@ -262,4 +262,16 @@ export const getPasswordStrength = (password: string): PasswordStrength => {
     return "medium";
   }
   return "weak";
+};
+
+export const formatMetricValue = (chartType: string, value: number) => {
+  if (chartType === "cpu") {
+    return `${value.toFixed(4)} cores`;
+  } else if (chartType === "memory") {
+    return `${Math.round(value).toLocaleString()} MiB`;
+  } else if (chartType === "network") {
+    return `${Math.round(value).toLocaleString()} KB/s`;
+  }
+
+  return null;
 };


### PR DESCRIPTION
# Description

- This PR handles the displaying of metrics [CPU, Memory, Network] for both projects and apps introducing various enhancements on their presentation as mentioned below:
- Introduce a clear loading state to indicate the process of retrieving or filtering through the metrics, and an appropriate fallback message when no metrics are found.
- Ensure correct and standard units are shown for individual metrics
- Ensure filters are working on the metric graphs for each metric.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Clickup Ticket ID

https://app.clickup.com/t/869969xcf

## How Can This Been Tested?

- Run this branch locally and checkout metrics for either a project or an application

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2025-05-26 at 1 08 43 AM](https://github.com/user-attachments/assets/6d0e25dc-5009-4bd3-8dd4-7f182359709c)

![Screenshot 2025-05-26 at 1 09 04 AM](https://github.com/user-attachments/assets/e069ce6f-622a-4655-91fe-2a4892a40316)
