### PR TITLE
fix: align project left menu selection with project dashboard page content

### DIFF
--- a/src/pages/Projects/ProjectDetailsPage.tsx
+++ b/src/pages/Projects/ProjectDetailsPage.tsx
@@ -3,13 +3,22 @@ import TitleText from "@/components/TitleText";
 import { useGetProject } from "@/utils/helpers";
 import AppsList from "@/components/Lists/AppsList";
 import { AddServiceButton } from "@/components/Elements/Elements";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const ProjectDetailsPage = () => {
   const { project_id } = useParams();
-  const { project, loading, success } = useGetProject(project_id || "");
+  const { project, loading, success, getData } = useGetProject(
+    project_id || "",
+  );
 
   const [refresh, setRefresh] = useState(false);
+
+  useEffect(() => {
+    getData({
+      id: project_id,
+      api: `/projects`,
+    });
+  }, [project_id]);
 
   return (
     <div>

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -56,7 +56,7 @@ export const useGetProject = (project_id: string) => {
     }
   }, [setMenuType, project_id, project]);
 
-  return { project, cluster, loading, success, refresh, setRefresh };
+  return { project, cluster, loading, success, refresh, setRefresh, getData };
 };
 
 export const useGetApp = (app_id: string) => {


### PR DESCRIPTION
# Description

- The goal of this PR is to resolve the context issue that happens when a project is selected from the sidebar, but the current view of the project dashboard page maintains some parts of the previous project such as the name, and select options for making deployments and creating databases etc. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## ClickUp Ticket ID

https://app.clickup.com/t/86998y52f

## How Can This Been Tested?

- Run this branch locally and checkout any project, and attempt to switch projects from the Left menu sidebar.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2025-06-02 at 8 58 12 AM](https://github.com/user-attachments/assets/2317c49e-fbb7-4a36-b987-cf350487df63)
