### PR TITLE
chore: use standard unit for memory usage rate for app and project metric graphs

### DIFF
--- a/src/components/Lists/AppsList.tsx
+++ b/src/components/Lists/AppsList.tsx
@@ -25,7 +25,7 @@ const AppsList = (props: any) => {
         params: { page, per_page: 6 },
       });
     },
-    resetTrigger: refresh,
+    resetTrigger: `${project_id}-${refresh}`,
   });
 
   // Initial data fetch

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -135,8 +135,10 @@ export const useInfiniteScrollWithPagination = <T = any>({
   useEffect(() => {
     if (resetTrigger !== undefined) {
       resetList();
+      setCurrentPage(1);
+      onLoadMore(1);
     }
-  }, [resetTrigger, resetList]);
+  }, [resetTrigger]);
 
   // Cleanup
   useEffect(() => {

--- a/src/pages/Apps/AppMetrics.tsx
+++ b/src/pages/Apps/AppMetrics.tsx
@@ -5,6 +5,7 @@ import {
 import { MenuContext } from "@/components/Layouts/DashboardLayout";
 import TitleText from "@/components/TitleText";
 import { MONITORING_API_URL } from "@/config";
+import { bytesToMB } from "@/utils/helpers";
 import usePost from "@/utils/usePost";
 import { Grid } from "@mantine/core";
 import { useContext, useEffect, useMemo, useState } from "react";
@@ -99,7 +100,7 @@ const AppMetrics = () => {
       return {
         data: memoryMetricsData?.data?.values,
         title: "Memory Usage",
-        unit: "MiB",
+        unit: "MB/s",
         numberOfDecimals: 0,
       };
     }
@@ -120,7 +121,7 @@ const AppMetrics = () => {
             title={bigChartData.title}
             data={bigChartData.data}
             valueFormatter={(value) =>
-              `${value.toFixed(bigChartData.numberOfDecimals)} ${bigChartData.unit}`
+              `${bigChartData.title === "Memory Usage" ? bytesToMB(value).toFixed(2) : value.toFixed(bigChartData.numberOfDecimals)} ${bigChartData.unit}`
             }
             showAllXValues
             filters={filters}
@@ -149,7 +150,7 @@ const AppMetrics = () => {
           <LineMetricChart
             title="Memory Usage"
             data={memoryMetricsData?.data?.values}
-            valueFormatter={(value) => `${value.toFixed(0)} MiB`}
+            valueFormatter={(value) => `${bytesToMB(value).toFixed(2)} MB/s`}
             height={180}
             setBigChart={setBigChart}
             chartType="memory"

--- a/src/pages/Projects/ProjectDetailsPage.tsx
+++ b/src/pages/Projects/ProjectDetailsPage.tsx
@@ -3,22 +3,13 @@ import TitleText from "@/components/TitleText";
 import { useGetProject } from "@/utils/helpers";
 import AppsList from "@/components/Lists/AppsList";
 import { AddServiceButton } from "@/components/Elements/Elements";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 const ProjectDetailsPage = () => {
   const { project_id } = useParams();
-  const { project, loading, success, getData } = useGetProject(
-    project_id || "",
-  );
+  const { project, loading, success } = useGetProject(project_id || "");
 
   const [refresh, setRefresh] = useState(false);
-
-  useEffect(() => {
-    getData({
-      id: project_id,
-      api: `/projects`,
-    });
-  }, [project_id]);
 
   return (
     <div>

--- a/src/pages/Projects/ProjectMetrics.tsx
+++ b/src/pages/Projects/ProjectMetrics.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/components/Elements/Charts";
 import TitleText from "@/components/TitleText";
 import { MONITORING_API_URL } from "@/config";
-import { useGetProject } from "@/utils/helpers";
+import { bytesToMB, useGetProject } from "@/utils/helpers";
 import usePost from "@/utils/usePost";
 import { Grid } from "@mantine/core";
 import { useEffect, useMemo, useState } from "react";
@@ -90,7 +90,7 @@ const ProjectMetrics = () => {
       return {
         data: memoryMetricsData?.data?.values,
         title: "Memory Usage",
-        unit: "MiB",
+        unit: "MB/s",
         numberOfDecimals: 0,
       };
     }
@@ -111,7 +111,7 @@ const ProjectMetrics = () => {
             title={bigChartData.title}
             data={bigChartData.data}
             valueFormatter={(value) =>
-              `${value.toFixed(bigChartData.numberOfDecimals)} ${bigChartData.unit}`
+              `${bigChartData.title === "Memory Usage" ? bytesToMB(value).toFixed(2) : value.toFixed(bigChartData.numberOfDecimals)} ${bigChartData.unit}`
             }
             showAllXValues
             filters={filters}
@@ -140,7 +140,7 @@ const ProjectMetrics = () => {
           <LineMetricChart
             title="Memory Usage"
             data={memoryMetricsData?.data?.values}
-            valueFormatter={(value) => `${value.toFixed(0)} MiB`}
+            valueFormatter={(value) => `${bytesToMB(value).toFixed(2)} MB/s`}
             height={180}
             setBigChart={setBigChart}
             chartType="memory"

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -264,11 +264,13 @@ export const getPasswordStrength = (password: string): PasswordStrength => {
   return "weak";
 };
 
+export const bytesToMB = (bytesPerSecond: number) => bytesPerSecond / 1_000_000;
+
 export const formatMetricValue = (chartType: string, value: number) => {
   if (chartType === "cpu") {
     return `${value.toFixed(4)} cores`;
   } else if (chartType === "memory") {
-    return `${Math.round(value).toLocaleString()} MiB`;
+    return `${bytesToMB(value).toFixed(2)} MB/s`;
   } else if (chartType === "network") {
     return `${Math.round(value).toLocaleString()} KB/s`;
   }

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -30,7 +30,7 @@ export const useGetProject = (project_id: string) => {
       id: project_id,
       api: `/projects`,
     });
-  }, [refresh]);
+  }, [project_id, refresh]);
 
   useEffect(() => {
     if (success) {
@@ -56,7 +56,7 @@ export const useGetProject = (project_id: string) => {
     }
   }, [setMenuType, project_id, project]);
 
-  return { project, cluster, loading, success, refresh, setRefresh, getData };
+  return { project, cluster, loading, success, refresh, setRefresh };
 };
 
 export const useGetApp = (app_id: string) => {


### PR DESCRIPTION
# Description

- This PR addresses the feedback to the project and app metric graphs for memory usage that required to eliminate ambiguous values that were in `MiB` and align the values with the ideal standard unit for memory usage rate which is `MB/s`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## ClickUp Ticket ID

https://app.clickup.com/t/8699dvzen

## How Can This Been Tested?

- Run this branch locally and check out memory usage graphs for your existing projects and apps. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2025-06-13 at 8 08 38 AM](https://github.com/user-attachments/assets/3a4be30e-d5d5-46f7-976a-d41ae049f374)
