### PR TITLE
chore: add realtime project name validation for user input guidance

### DIFF
--- a/src/components/Forms/CreateProjectForm.tsx
+++ b/src/components/Forms/CreateProjectForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import TitleText from "../TitleText";
 import {
   Button,
@@ -13,7 +13,7 @@ import {
   Text,
   Alert,
 } from "@mantine/core";
-import { useSetContainerSize } from "@/utils/helpers";
+import { useSetContainerSize, validateProjectName } from "@/utils/helpers";
 import useGet from "@/utils/useGet";
 import { API_CLUSTERS, API_PROJECTS, API_TAGS } from "@/utils/apis";
 import { NO, ORGANISATIONS, PROJECT_TYPES, YES } from "@/utils/constants";
@@ -21,6 +21,7 @@ import usePost from "@/utils/usePost";
 import { useAuth } from "@/utils/AuthContext";
 import { useNavigate } from "react-router-dom";
 import useForm from "@/hooks/generic/useForm";
+import { FaCheckCircle, FaTimesCircle } from "react-icons/fa";
 
 type TCreateProjectForm = {
   project?: any;
@@ -55,6 +56,14 @@ const CreateProjectForm = (props: TCreateProjectForm) => {
     success,
     data: project_data,
   } = usePost();
+
+  const [nameValid, setNameValid] = useState<boolean | null>(null);
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e);
+    const value = e.target.value.trimStart();
+    setNameValid(value.length > 0 ? validateProjectName(value) : null);
+  };
 
   useEffect(() => {
     getClusters({
@@ -132,11 +141,22 @@ const CreateProjectForm = (props: TCreateProjectForm) => {
               label="Project Name"
               description="Helps you identify your application."
               name="name"
-              placeholder="My Project"
+              placeholder="My-Project"
               required
               value={form.name as string}
-              onChange={onChange}
-              error={error?.name}
+              onChange={handleNameChange}
+              error={
+                nameValid === false
+                  ? "Max 30 characters. Only letters, numbers, and hyphens allowed (no spaces, symbols, or leading/trailing/consecutive hyphens)."
+                  : error?.name
+              }
+              rightSection={
+                nameValid === null ? null : nameValid ? (
+                  <FaCheckCircle color="green" />
+                ) : (
+                  <FaTimesCircle color="red" />
+                )
+              }
             />
             <Textarea
               label="Project Description"

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -329,3 +329,7 @@ export const detailsCardView = (item: any) => {
 export const formatDate = (value: any, format?: string) => {
   return moment(value).format(format || "DD MMM YYYY");
 };
+
+export const validateProjectName = (name: string) => {
+  return name.length <= 30 && /^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/.test(name);
+};


### PR DESCRIPTION
# Description

- This PR addresses the user experience when adding a project name by providing real-time input feedback to the user to know which format is accepted before they proceed to fill in the next fields, and also sanitises the input value incase of any whitespace left by the user during input.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## ClickUp Ticket ID

https://app.clickup.com/t/8699fe8d2

## How Can This Been Tested?

- Try creating a new project with special characters, trailing spaces and a name that exceeds 30 characters to see the real-time feedback

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2025-06-18 at 7 48 33 AM](https://github.com/user-attachments/assets/836d1c05-1e53-490f-ad00-46a5fdef2a2c)

![Screenshot 2025-06-18 at 7 47 33 AM](https://github.com/user-attachments/assets/80e408df-f817-43c6-8136-9c75996104b4)
