### PR TITLE
feat: add cluster services list to admin side

### DIFF
--- a/src/hooks/cluster/useServices.ts
+++ b/src/hooks/cluster/useServices.ts
@@ -1,0 +1,43 @@
+import {
+  formatClusterServicePorts,
+  useSetAdminClusterSidebar,
+} from "@/utils/helpers";
+import moment from "moment";
+
+const useServices = ({ cluster_id }: any) => {
+  useSetAdminClusterSidebar();
+
+  const tableColumns = () => [
+    { id: "name", header: "Name" },
+    { id: "type", header: "Type" },
+    { id: "clusterIP", header: "Cluster IP" },
+    { id: "ports", header: "Ports" },
+    { id: "age", header: "Age" },
+  ];
+
+  const tableData = (data: any) => {
+    if (!data) {
+      return [];
+    }
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data.map((item: any) => {
+      const row = {
+        // ...item,
+        name: item?.metadata?.name,
+        type: item?.spec?.type,
+        clusterIP: item?.spec?.clusterIP,
+        ports: formatClusterServicePorts(item?.spec?.ports),
+        age: moment(item?.metadata?.creationTimestamp).fromNow(),
+      };
+      return row;
+    });
+  };
+  const dataParent = "services";
+  const apiRoute = `/clusters/${cluster_id}/services`;
+
+  return { tableColumns, tableData, apiRoute, dataParent };
+};
+
+export default useServices;

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -3,6 +3,7 @@ import useVolumes from "../cluster/useVolumes";
 import { useDatabases } from "../useDatabases";
 import { useProjects } from "../useProjects";
 import { useUsers } from "../useUsers";
+import useServices from "../cluster/useServices";
 
 // handle register creation
 export const registerHooks: Record<string, any> = {
@@ -11,6 +12,7 @@ export const registerHooks: Record<string, any> = {
   projects: useProjects,
   // cluster
   volumes: useVolumes,
+  services: useServices,
 };
 
 export const sourceApis: Record<string, string> = {

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -333,3 +333,19 @@ export const formatDate = (value: any, format?: string) => {
 export const validateProjectName = (name: string) => {
   return name.length <= 30 && /^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/.test(name);
 };
+
+export const formatClusterServicePorts = (ports: any) => {
+  let portValue = "";
+  ports.map((port: any) => {
+    if (portValue !== "") {
+      portValue += ", ";
+    }
+    portValue += `${port.port}`;
+    if (port.nodePort !== undefined) {
+      portValue += `:${port.nodePort}`;
+    }
+    portValue += `/${port.protocol}`;
+    return portValue;
+  });
+  return portValue;
+};


### PR DESCRIPTION
# Description

- This PR registers the `useServices` hook for retrieving and displaying services for a selected cluster on the new admin dashboard.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Clickup Ticket ID

https://app.clickup.com/t/8699fyxnu

## How Can This Been Tested?

- Access the admin dashboard and under a given cluster, select the `Services` left menu item to view the services listing for that cluster.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2025-06-19 at 12 07 05 PM](https://github.com/user-attachments/assets/becdc848-bd25-4a4d-b0c1-3ccc94684cdd)
