### PR TITLE
ft: implement cluster nodes list in admin ui

### DIFF
--- a/src/hooks/cluster/useNodes.ts
+++ b/src/hooks/cluster/useNodes.ts
@@ -1,0 +1,51 @@
+import { useSetAdminClusterSidebar } from "@/utils/helpers";
+import moment from "moment";
+
+const useNodeList = ({ cluster_id }: any) => {
+  useSetAdminClusterSidebar();
+
+  const tableColumns = () => [
+    { id: "name", header: "Name" },
+    { id: "taints", header: "Taints" },
+    { id: "roles", header: "Roles" },
+    { id: "version", header: "Version" },
+    { id: "age", header: "Age" },
+    { id: "conditions", header: "Conditions" },
+  ];
+
+  const tableData = (data: any) => {
+    if (!data) {
+      return [];
+    }
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data.map((item: any) => {
+      const row = {
+        // ...item,
+        name: item?.metadata?.name,
+        taints: item?.spec?.taints?.length,
+        roles: Object.keys(item?.metadata?.labels).find((key) => {
+          return key === "node-role.kubernetes.io/control-plane";
+        })
+          ? "Control Plane"
+          : "Worker",
+
+        version: item?.status?.nodeInfo?.kubeletVersion,
+        age: moment(item?.metadata?.creationTimestamp).fromNow(),
+        conditions: item?.status?.conditions.find((condition: any) => {
+          return condition.type === "Ready";
+        })
+          ? "Ready"
+          : "Not Ready",
+      };
+      return row;
+    });
+  };
+  const dataParent = "nodes";
+  const apiRoute = `/clusters/${cluster_id}/nodes`;
+
+  return { tableColumns, tableData, apiRoute, dataParent };
+};
+
+export default useNodeList;

--- a/src/hooks/cluster/useNodes.ts
+++ b/src/hooks/cluster/useNodes.ts
@@ -13,6 +13,32 @@ const useNodeList = ({ cluster_id }: any) => {
     { id: "conditions", header: "Conditions" },
   ];
 
+  const getRole = (labels: any) => {
+    if (!labels) {
+      return "Unknown";
+    }
+    const keys = Object.keys(labels);
+    if (keys.includes("node-role.kubernetes.io/control-plane")) {
+      return "Control Plane";
+    }
+    return "Worker";
+  };
+
+  const isNodeReady = (conditions: any[]) => {
+    return conditions?.find((condition) => condition.type === "Ready")
+      ? "Ready"
+      : "Not Ready";
+  };
+
+  const parseNode = (item: any) => ({
+    name: item?.metadata?.name,
+    taints: item?.spec?.taints?.length,
+    roles: getRole(item?.metadata?.labels),
+    version: item?.status?.nodeInfo?.kubeletVersion,
+    age: moment(item?.metadata?.creationTimestamp).fromNow(),
+    conditions: isNodeReady(item?.status?.conditions),
+  });
+
   const tableData = (data: any) => {
     if (!data) {
       return [];
@@ -20,27 +46,7 @@ const useNodeList = ({ cluster_id }: any) => {
     if (!Array.isArray(data)) {
       return [];
     }
-    return data.map((item: any) => {
-      const row = {
-        // ...item,
-        name: item?.metadata?.name,
-        taints: item?.spec?.taints?.length,
-        roles: Object.keys(item?.metadata?.labels).find((key) => {
-          return key === "node-role.kubernetes.io/control-plane";
-        })
-          ? "Control Plane"
-          : "Worker",
-
-        version: item?.status?.nodeInfo?.kubeletVersion,
-        age: moment(item?.metadata?.creationTimestamp).fromNow(),
-        conditions: item?.status?.conditions.find((condition: any) => {
-          return condition.type === "Ready";
-        })
-          ? "Ready"
-          : "Not Ready",
-      };
-      return row;
-    });
+    return data.map((item: any) => parseNode(item));
   };
   const dataParent = "nodes";
   const apiRoute = `/clusters/${cluster_id}/nodes`;

--- a/src/hooks/cluster/useNodes.ts
+++ b/src/hooks/cluster/useNodes.ts
@@ -1,6 +1,32 @@
 import { useSetAdminClusterSidebar } from "@/utils/helpers";
 import moment from "moment";
 
+const getRole = (labels: any) => {
+  if (!labels) {
+    return "Unknown";
+  }
+  const keys = Object.keys(labels);
+  if (keys.includes("node-role.kubernetes.io/control-plane")) {
+    return "Control Plane";
+  }
+  return "Worker";
+};
+
+const isNodeReady = (conditions: any[]) => {
+  return conditions?.find((condition) => condition.type === "Ready")
+    ? "Ready"
+    : "Not Ready";
+};
+
+const parseNode = (item: any) => ({
+  name: item?.metadata?.name,
+  taints: item?.spec?.taints?.length,
+  roles: getRole(item?.metadata?.labels),
+  version: item?.status?.nodeInfo?.kubeletVersion,
+  age: moment(item?.metadata?.creationTimestamp).fromNow(),
+  conditions: isNodeReady(item?.status?.conditions),
+});
+
 const useNodeList = ({ cluster_id }: any) => {
   useSetAdminClusterSidebar();
 
@@ -12,32 +38,6 @@ const useNodeList = ({ cluster_id }: any) => {
     { id: "age", header: "Age" },
     { id: "conditions", header: "Conditions" },
   ];
-
-  const getRole = (labels: any) => {
-    if (!labels) {
-      return "Unknown";
-    }
-    const keys = Object.keys(labels);
-    if (keys.includes("node-role.kubernetes.io/control-plane")) {
-      return "Control Plane";
-    }
-    return "Worker";
-  };
-
-  const isNodeReady = (conditions: any[]) => {
-    return conditions?.find((condition) => condition.type === "Ready")
-      ? "Ready"
-      : "Not Ready";
-  };
-
-  const parseNode = (item: any) => ({
-    name: item?.metadata?.name,
-    taints: item?.spec?.taints?.length,
-    roles: getRole(item?.metadata?.labels),
-    version: item?.status?.nodeInfo?.kubeletVersion,
-    age: moment(item?.metadata?.creationTimestamp).fromNow(),
-    conditions: isNodeReady(item?.status?.conditions),
-  });
 
   const tableData = (data: any) => {
     if (!data) {

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -4,6 +4,7 @@ import { useDatabases } from "../useDatabases";
 import { useProjects } from "../useProjects";
 import { useUsers } from "../useUsers";
 import useServices from "../cluster/useServices";
+import useNodeList from "../cluster/useNodes";
 
 // handle register creation
 export const registerHooks: Record<string, any> = {
@@ -13,6 +14,7 @@ export const registerHooks: Record<string, any> = {
   // cluster
   volumes: useVolumes,
   services: useServices,
+  nodes: useNodeList,
 };
 
 export const sourceApis: Record<string, string> = {

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -7,7 +7,6 @@ import useServices from "../cluster/useServices";
 import useNodeList from "../cluster/useNodes";
 import { useApps } from "../useApps";
 
-
 // handle register creation
 export const registerHooks: Record<string, any> = {
   users: useUsers,


### PR DESCRIPTION
# Description

This PR includes the `useNodes` hook for retrieving and displaying nodes for a selected cluster on the new admin dashboard.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

[https://app.clickup.com/t/8699g1h2e](https://app.clickup.com/t/8699g1h2e)

## How Can This Been Tested?

Access the admin dashboard and under a given cluster, select the **Nodes** left menu item to view the nodes listing for that cluster.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot from 2025-06-23 17-18-49](https://github.com/user-attachments/assets/561539fd-69a1-4a37-8a2c-d1c887725650)
