### PR TITLE
ft: add admin-namespaces table

### DIFF
--- a/src/hooks/cluster/useNamespaces.ts
+++ b/src/hooks/cluster/useNamespaces.ts
@@ -31,7 +31,7 @@ const useNamespaces = ({ cluster_id }: any) => {
       return row;
     });
   };
-  const dataParent = "Namespaces";
+  const dataParent = "namespaces";
   const apiRoute = `/clusters/${cluster_id}/namespaces`;
 
   return { tableColumns, tableData, apiRoute, dataParent };

--- a/src/hooks/cluster/useNamespaces.ts
+++ b/src/hooks/cluster/useNamespaces.ts
@@ -1,4 +1,4 @@
-import { useSetAdminClusterSidebar,} from "@/utils/helpers";
+import { useSetAdminClusterSidebar } from "@/utils/helpers";
 import moment from "moment";
 
 const useNamespaces = ({ cluster_id }: any) => {
@@ -18,7 +18,7 @@ const useNamespaces = ({ cluster_id }: any) => {
     if (!Array.isArray(data)) {
       return [];
     }
-    return data.map((item: any) => {                 
+    return data.map((item: any) => {
       const row = {
         // ...item,
         name: item?.metadata?.name,

--- a/src/hooks/cluster/useNamespaces.ts
+++ b/src/hooks/cluster/useNamespaces.ts
@@ -1,18 +1,14 @@
-import {
-  formatClusterServicePorts,
-  useSetAdminClusterSidebar,
-} from "@/utils/helpers";
+import { useSetAdminClusterSidebar,} from "@/utils/helpers";
 import moment from "moment";
 
-const useServices = ({ cluster_id }: any) => {
+const useNamespaces = ({ cluster_id }: any) => {
   useSetAdminClusterSidebar();
 
   const tableColumns = () => [
     { id: "name", header: "Name" },
-    { id: "type", header: "Type" },
-    { id: "clusterIP", header: "Cluster IP" },
-    { id: "ports", header: "Ports" },
+    { id: "labels", header: "Labels" },
     { id: "age", header: "Age" },
+    { id: "status", header: "Status" },
   ];
 
   const tableData = (data: any) => {
@@ -26,18 +22,19 @@ const useServices = ({ cluster_id }: any) => {
       const row = {
         // ...item,
         name: item?.metadata?.name,
-        type: item?.spec?.type,
-        clusterIP: item?.spec?.clusterIP,
-        ports: formatClusterServicePorts(item?.spec?.ports),
+        labels: Object.entries(item?.metadata?.labels || {})
+          .map(([key, value]) => `${key}=${value}`)
+          .join(", "),
         age: moment(item?.metadata?.creationTimestamp).fromNow(),
+        status: item?.status?.phase,
       };
       return row;
     });
   };
-  const dataParent = "services";
-  const apiRoute = `/clusters/${cluster_id}/services`;
+  const dataParent = "Namespaces";
+  const apiRoute = `/clusters/${cluster_id}/namespaces`;
 
   return { tableColumns, tableData, apiRoute, dataParent };
 };
 
-export default useServices;
+export default useNamespaces;

--- a/src/hooks/cluster/useServices.ts
+++ b/src/hooks/cluster/useServices.ts
@@ -22,7 +22,7 @@ const useServices = ({ cluster_id }: any) => {
     if (!Array.isArray(data)) {
       return [];
     }
-    return data.map((item: any) => {                 
+    return data.map((item: any) => {
       const row = {
         // ...item,
         name: item?.metadata?.name,

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -16,7 +16,7 @@ export const registerHooks: Record<string, any> = {
   // cluster
   volumes: useVolumes,
   services: useServices,
-  namespaces: useNamespaces
+  namespaces: useNamespaces,
 };
 
 export const sourceApis: Record<string, string> = {

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -5,6 +5,7 @@ import { useProjects } from "../useProjects";
 import { useUsers } from "../useUsers";
 import useServices from "../cluster/useServices";
 import { useApps } from "../useApps";
+import useNamespaces from "../cluster/useNamespaces";
 
 // handle register creation
 export const registerHooks: Record<string, any> = {
@@ -15,6 +16,7 @@ export const registerHooks: Record<string, any> = {
   // cluster
   volumes: useVolumes,
   services: useServices,
+  namespaces: useNamespaces
 };
 
 export const sourceApis: Record<string, string> = {


### PR DESCRIPTION
This pull request adds the Namespaces table to the admin dashboard. It shows the list of namespaces for a cluster with columns like Name, Labels, Age, and Status.

I created a new hook called `useNamespaces` which fetches the data and prepares it for the table. This is part of showing cluster-related resources in the UI.

**Type of change**

New feature (adds functionality)

-**Clickup Ticket ID**

This task is part of the clickup card about adding the Namespaces table view.
[https://app.clickup.com/t/8699gw4uk](url)


To test it:

1. Run the app with `yarn dev`.
2. Go to the Namespaces page from the left sidebar in the admin view.
3. It should try to fetch namespaces for the selected cluster.
4. If the cluster is running and connected properly, it will show the data in the table.
5. You can also check the Network tab in DevTools to see if the `/namespaces` API is called.


Checklist:

 [x] I followed the code style used in the project
 [x] I checked my code and it works without errors
 [x] I added some comments to explain parts of the code
 [x] There are no warnings when I run the project
 [x] There are no other changes that this depends on

Screenshots

![image](https://github.com/user-attachments/assets/580233cf-907a-45fd-8b1c-ead0e6906585)



