### PR TITLE
feat: add volume claims list for admin

### DIFF
--- a/src/hooks/cluster/useVolumeClaims.ts
+++ b/src/hooks/cluster/useVolumeClaims.ts
@@ -9,13 +9,9 @@ const useVolumeClaims = ({ cluster_id }: any) => {
     { id: "namespace", header: "Namespace" },
     { id: "storage_class", header: "Storage Class" },
     { id: "size", header: "Size" },
-    
     { id: "age", header: "Age" },
     { id: "status", header: "Status" },
   ];
-
-  
-
   const tableData = (data: any) => {
     console.log(data);
     if (!data || !Array.isArray(data)) {
@@ -27,12 +23,10 @@ const useVolumeClaims = ({ cluster_id }: any) => {
       namespace: item?.metadata?.namespace,
       storage_class: item?.spec?.storageClassName,
       size: item?.spec?.resources?.requests?.storage,
-      
       age: moment(item?.metadata?.creationTimestamp).fromNow(),
       status: item?.status?.phase,
     }));
   };
-
   const dataParent = "pvcs"; // make sure your API response structure matches this
   const apiRoute = `/clusters/${cluster_id}/pvcs`;
 

--- a/src/hooks/cluster/useVolumeClaims.ts
+++ b/src/hooks/cluster/useVolumeClaims.ts
@@ -13,7 +13,6 @@ const useVolumeClaims = ({ cluster_id }: any) => {
     { id: "status", header: "Status" },
   ];
   const tableData = (data: any) => {
-    console.log(data);
     if (!data || !Array.isArray(data)) {
       return [];
     }

--- a/src/hooks/cluster/useVolumeClaims.ts
+++ b/src/hooks/cluster/useVolumeClaims.ts
@@ -1,0 +1,42 @@
+import { useSetAdminClusterSidebar } from "@/utils/helpers";
+import moment from "moment";
+
+const useVolumeClaims = ({ cluster_id }: any) => {
+  useSetAdminClusterSidebar();
+
+  const tableColumns = () => [
+    { id: "name", header: "Name" },
+    { id: "namespace", header: "Namespace" },
+    { id: "storage_class", header: "Storage Class" },
+    { id: "size", header: "Size" },
+    
+    { id: "age", header: "Age" },
+    { id: "status", header: "Status" },
+  ];
+
+  
+
+  const tableData = (data: any) => {
+    console.log(data);
+    if (!data || !Array.isArray(data)) {
+      return [];
+    }
+
+    return data.map((item: any) => ({
+      name: item?.metadata?.name,
+      namespace: item?.metadata?.namespace,
+      storage_class: item?.spec?.storageClassName,
+      size: item?.spec?.resources?.requests?.storage,
+      
+      age: moment(item?.metadata?.creationTimestamp).fromNow(),
+      status: item?.status?.phase,
+    }));
+  };
+
+  const dataParent = "pvcs"; // make sure your API response structure matches this
+  const apiRoute = `/clusters/${cluster_id}/pvcs`;
+
+  return { tableColumns, tableData, apiRoute, dataParent };
+};
+
+export default useVolumeClaims;

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -5,6 +5,7 @@ import { useProjects } from "../useProjects";
 import { useUsers } from "../useUsers";
 import useServices from "../cluster/useServices";
 import { useApps } from "../useApps";
+import useVolumeClaims from "../cluster/useVolumeClaims";
 
 // handle register creation
 export const registerHooks: Record<string, any> = {
@@ -15,6 +16,7 @@ export const registerHooks: Record<string, any> = {
   // cluster
   volumes: useVolumes,
   services: useServices,
+  volume_claims: useVolumeClaims
 };
 
 export const sourceApis: Record<string, string> = {

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -23,7 +23,6 @@ export const registerHooks: Record<string, any> = {
   volume_claims: useVolumeClaims,
   namespaces: useNamespaces,
   nodes: useNodeList,
-
 };
 
 export const sourceApis: Record<string, string> = {

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -16,7 +16,7 @@ export const registerHooks: Record<string, any> = {
   // cluster
   volumes: useVolumes,
   services: useServices,
-  volume_claims: useVolumeClaims
+  volume_claims: useVolumeClaims,
 };
 
 export const sourceApis: Record<string, string> = {


### PR DESCRIPTION
# Description

This PR adds the Volume Claims List view to the Admin dashboard. It enables administrators to view Persistent Volume Claims (PVCs) for a specific cluster, showing relevant details such as name, namespace, storage class, size, age, status, and the pods using them.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Trello Ticket ID
(https://app.clickup.com/t/8699g16mm)

## How Can This Been Tested?
1.Checkout the branch:
git checkout ft/volume-claims-list-admin
2.Start the development server:
yarn dev
3.Navigate to an Admin Cluster view and go to the Volume Claims tab.

4.Ensure the table renders correctly, even if no data is present.

5.If PVCs exist, check that columns display: Name, Namespace, Storage Class, Size, status, Age

6.Verified that incorrect API paths show an empty table instead of crashing.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots


![claims](https://github.com/user-attachments/assets/868fcc27-ab13-4312-9f71-f4713f0d4aa6)





