### PR TITLE
feat: add provision to handle google user authentication

### DIFF
--- a/src/components/Cards/OtherCards.tsx
+++ b/src/components/Cards/OtherCards.tsx
@@ -1,13 +1,6 @@
-import {
-  Avatar,
-  Card,
-  Divider,
-  Group,
-  Stack,
-  Text,
-  Tooltip,
-} from "@mantine/core";
+import { Box, Card, Divider, Group, Stack, Text, Tooltip } from "@mantine/core";
 import { PiBuildingsBold } from "react-icons/pi";
+import { ProfileAvatar } from "../Common";
 
 function UserProfileCard({ user }: { user: any }) {
   const userStats = [
@@ -26,13 +19,9 @@ function UserProfileCard({ user }: { user: any }) {
           backgroundImage: `url("data:image/svg+xml,%3Csvg width='12' height='16' viewBox='0 0 12 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 .99C4 .445 4.444 0 5 0c.552 0 1 .45 1 .99v4.02C6 5.555 5.556 6 5 6c-.552 0-1-.45-1-.99V.99zm6 8c0-.546.444-.99 1-.99.552 0 1 .45 1 .99v4.02c0 .546-.444.99-1 .99-.552 0-1-.45-1-.99V8.99z' fill='%23dde2e7' fill-opacity='0.54' fill-rule='evenodd'/%3E%3C/svg%3E")`,
         }}
       />
-      <Avatar
-        src="https://raw.githubusercontent.com/mantinedev/mantine/master/.demo/avatars/avatar-9.png"
-        size={140}
-        radius={80}
-        mx="auto"
-        mt={-90}
-      />
+      <Box mx="auto" mt={-90}>
+        <ProfileAvatar user={user} size={140} />
+      </Box>
       <Text ta="center" fz="1.3rem" fw={500} mt="sm">
         {user?.name}
       </Text>

--- a/src/components/Common.tsx
+++ b/src/components/Common.tsx
@@ -97,7 +97,7 @@ export const UserDropDown = () => {
                 lh={1}
                 display={{ base: "none", sm: "block" }}
               >
-                {user.username}
+                {user.username || user.name}
               </Text>
             </Group>
             <FiChevronDown size={16} />
@@ -124,7 +124,7 @@ export const UserDropDown = () => {
             />
             <Stack gap={2}>
               <Text fw={500} size="sm" lh={1} mr={3}>
-                {user.username}
+                {user.username || user.name}
               </Text>
               <Text size="xs" c="dimmed">
                 {user.email}

--- a/src/components/Common.tsx
+++ b/src/components/Common.tsx
@@ -33,6 +33,41 @@ export const Logo = () => {
   );
 };
 
+export const ProfileAvatar = ({
+  user,
+  size = 30,
+}: {
+  user: any;
+  size?: number;
+}) => {
+  return (
+    <>
+      {user?.profile_picture ? (
+        <img
+          src={user?.profile_picture}
+          alt={user.name}
+          referrerPolicy="no-referrer"
+          style={{
+            width: size,
+            height: size,
+            borderRadius: "50%",
+            objectFit: "cover",
+            border: "1px solid #e0e0e0",
+          }}
+        />
+      ) : (
+        <Avatar
+          alt={user.username}
+          name={user.name || user.username}
+          radius="xl"
+          size={size}
+          color="initials"
+        />
+      )}
+    </>
+  );
+};
+
 export const UserDropDown = () => {
   const { colorScheme, setColorScheme } = useMantineColorScheme();
   const { logout, user } = useAuth();
@@ -84,13 +119,7 @@ export const UserDropDown = () => {
         >
           <Group gap={10} display={{ base: "none", sm: "flex" }}>
             <Group gap={7}>
-              <Avatar
-                alt={user.username}
-                name={user.name}
-                radius="xl"
-                size={30}
-                color="initials"
-              />
+              <ProfileAvatar user={user} />
               <Text
                 fw={500}
                 size="sm"
@@ -103,25 +132,14 @@ export const UserDropDown = () => {
             <FiChevronDown size={16} />
           </Group>
           <Group display={{ base: "flex", sm: "none" }}>
-            <Avatar
-              alt={user.username}
-              name={user.name}
-              radius="xl"
-              size={30}
-              color="initials"
-            />
+            <ProfileAvatar user={user} />
           </Group>
         </UnstyledButton>
       </Menu.Target>
       <Menu.Dropdown>
         <Menu.Item onClick={() => navigate(`/profile/${user?.id}`)}>
           <Group gap={10}>
-            <Avatar
-              alt={user.username}
-              name={user.name}
-              radius="xl"
-              color="initials"
-            />
+            <ProfileAvatar user={user} />
             <Stack gap={2}>
               <Text fw={500} size="sm" lh={1} mr={3}>
                 {user.username || user.name}

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -6,8 +6,6 @@ export const BLOG_URL = import.meta.env.VITE_APP_BLOG_URL;
 export const STATUS_MONITORING_URL = import.meta.env.VITE_APP_MONITORING_APP;
 //mira Url
 export const MIRA_API_URL = import.meta.env.VITE_APP_MIRA_API_URL;
-//github auth urls
-export const GIT_REDIRECT_URL = `https://github.com/login/oauth/authorize?client_id=${import.meta.env.VITE_APP_GITHUB_CLEINT_ID}&scope=read:user,user:email`;
 export const FLUTTER_WAVE_PUBLIC_KEY = import.meta.env
   .VITE_APP_FLUTTERWAVE_PUBLIC_KEY_TESTING;
 //for live exchange rate
@@ -23,3 +21,7 @@ export const ACTIVITY_LOGS_API_URL = import.meta.env
   .VITE_APP_ACTIVITY_LOGS_API_URL;
 export const MONITORING_API_URL = import.meta.env.VITE_APP_MONITORING_API_URL;
 export const MLOPS_API_URL = import.meta.env.VITE_APP_MLOPS_API_URL;
+
+// GitHub and Google OAuth URLs
+export const GIT_REDIRECT_URL = `https://github.com/login/oauth/authorize?client_id=${import.meta.env.VITE_APP_GITHUB_CLEINT_ID}&scope=read:user,user:email`;
+export const GOOGLE_REDIRECT_URL = `https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?response_type=code&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&scope=profile%20email&client_id=${import.meta.env.VITE_GOOGLE_CLIENT_ID}&service=lso&o2v=2&flowName=GeneralOAuthFlow`;

--- a/src/pages/Auth/loginPage.tsx
+++ b/src/pages/Auth/loginPage.tsx
@@ -13,7 +13,7 @@ import {
   Text,
   TextInput,
 } from "@mantine/core";
-import { FaGithub } from "react-icons/fa";
+import { FaGithub, FaGoogle } from "react-icons/fa";
 import { useForm } from "@mantine/form";
 import { upperFirst, useToggle } from "@mantine/hooks";
 import usePost from "@/utils/usePost";
@@ -27,10 +27,11 @@ import {
   MdOutlinePerson,
   MdOutlineBusiness,
 } from "react-icons/md";
-import { GIT_REDIRECT_URL } from "@/config";
 import { GuestHeader } from "@/components/Header";
 import { GuestFooter } from "@/components/Footer";
 import { API_USERS } from "@/utils/apis";
+import useGet from "@/utils/useGet";
+import { GIT_REDIRECT_URL, GOOGLE_REDIRECT_URL } from "@/config";
 
 export function LoginForm(props: PaperProps) {
   const { login, loggedIn } = useAuth();
@@ -47,6 +48,12 @@ export function LoginForm(props: PaperProps) {
     success: gitLoginSuccess,
     data: gitUserDetails,
   } = usePost();
+  const {
+    getData: googleOAuth,
+    loading: googleLogin,
+    success: googleLoginSuccess,
+    data: googleUserDetails,
+  } = useGet();
   const {
     uploadData: loginUser,
     submitting: loggingIn,
@@ -152,6 +159,14 @@ export function LoginForm(props: PaperProps) {
     });
   };
 
+  const initiateGoogleLogin = (code: string) => {
+    googleOAuth({
+      api: `${API_USERS}/oauth/google`,
+      params: { code },
+      errorMessage: "Failed to authorize Google user",
+    });
+  };
+
   useEffect(() => {
     if (loginSuccess && !passwordReset) {
       login(loginDetails);
@@ -189,16 +204,31 @@ export function LoginForm(props: PaperProps) {
   }, [gitLoginSuccess]);
 
   useEffect(() => {
+    if (googleLoginSuccess) {
+      login(googleUserDetails);
+      navigate("/");
+    }
+  }, [googleLoginSuccess]);
+
+  useEffect(() => {
     const queryParams = new URLSearchParams(window.location.search);
     const code = queryParams.get("code");
-    if (code) {
+    const oauth = queryParams.get("oauth");
+    if (oauth === "google" && code) {
+      localStorage.clear();
+      initiateGoogleLogin(code);
+    } else if (code) {
       localStorage.clear();
       initiateGitHubLogin(code);
     }
   }, []);
 
+  // OAuth handlers
   const handleGithubAuth = () => {
     window.location.href = GIT_REDIRECT_URL;
+  };
+  const handleGoogleAuth = () => {
+    window.location.href = GOOGLE_REDIRECT_URL;
   };
 
   return (
@@ -232,27 +262,31 @@ export function LoginForm(props: PaperProps) {
                 flex={1}
               >
                 {gitLogin ? (
-                  <Loader size="sm" color="white" />
+                  <Loader size="sm" color="gray" />
                 ) : (
                   "Continue with GitHub"
                 )}
               </Button>
-              {/* <Button
-              radius="xl"
-              flex={1}
-              leftSection={
-                <FaGoogle
-                  style={{
-                    color: "#EA4335",
-                  }}
-                />
-              }
-              variant="default"
-              style={{ borderColor: "theme.red" }}
-              onClick={handleGoogleAuth}
-            >
-              Google
-            </Button> */}
+              <Button
+                radius="xl"
+                flex={1}
+                leftSection={
+                  <FaGoogle
+                    style={{
+                      color: "#EA4335",
+                    }}
+                  />
+                }
+                variant="default"
+                style={{ borderColor: "theme.red" }}
+                onClick={handleGoogleAuth}
+              >
+                {googleLogin ? (
+                  <Loader size="sm" color="gray" />
+                ) : (
+                  "Continue with Google"
+                )}
+              </Button>
             </Group>
             <Divider
               label="Or continue with email"


### PR DESCRIPTION
# Description

- This PR adds the google authentication flow for users at the frontend to complement the backend implementation here - https://github.com/crane-cloud/backend/pull/609

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## ClickUp Ticket ID

https://app.clickup.com/t/8699mxyn5

## How Can This Been Tested?

You need the following `env` variables to test this functionality
- `VITE_GOOGLE_CLIENT_ID=` 
- `VITE_REDIRECT_URI=`

After running this branch locally checkout the `LoginPage` on this route `http://localhost:5173/login` and attempt to authenticate with the `Continue with Google` option

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

![Screenshot 2025-07-02 at 6 16 24 PM](https://github.com/user-attachments/assets/8aec5077-52e0-40f7-bf88-1b52a0c3ae5c)
![Screenshot 2025-07-02 at 5 17 49 PM](https://github.com/user-attachments/assets/66ac7071-47f5-46d4-a7bc-9281b6f7894b)
![Screenshot 2025-07-02 at 5 18 18 PM](https://github.com/user-attachments/assets/29700123-292b-4b57-a6b7-4e538c1aa989)
![Screenshot 2025-07-02 at 5 18 49 PM](https://github.com/user-attachments/assets/27f3d7a6-c6a4-4ace-a2fe-25081c6b7181)
