### PR TITLE
feat: added a paste option for environment variables on app deployment

### DIFF
--- a/src/components/Forms/CreateAppForm.tsx
+++ b/src/components/Forms/CreateAppForm.tsx
@@ -102,6 +102,7 @@ export const CreateSingleAppForm = (props: {
   const [envVariables, setEnvVariables] = useState([{ key: "", value: "" }]);
   const [pasteModalOpened, setPasteModalOpened] = useState(false);
   const [pastedContent, setPastedContent] = useState("");
+  const [formatError, setFormatError] = useState<string | null>(null);
 
   const navigate = useNavigate();
   useEffect(() => {
@@ -119,8 +120,9 @@ export const CreateSingleAppForm = (props: {
     return lines
       .map((line) => {
         const [key, ...values] = line.split("=");
-        // eslint-disable-next-line curly
-        if (!key || values.length === 0) return null;
+        if (!key || values.length === 0) {
+          return null;
+        }
         return {
           key: key.trim(),
           value: values.join("=").trim(),
@@ -129,9 +131,35 @@ export const CreateSingleAppForm = (props: {
       .filter(Boolean) as { key: string; value: string }[];
   };
 
+  const validateEnvFormat = (content: string) => {
+    if (!content.trim()) {
+      setFormatError(null);
+      return true;
+    }
+
+    const invalidLines = content
+      .split("\n")
+      .filter((line) => line.trim() && !line.includes("="));
+
+    if (invalidLines.length > 0) {
+      setFormatError(
+        `Invalid format in line(s): Each line must follow a KEY=VALUE format.`,
+      );
+      return false;
+    }
+
+    setFormatError(null);
+    return true;
+  };
+
   const addVariablesFromPaste = () => {
-    // eslint-disable-next-line curly
-    if (!pastedContent) return;
+    if (!pastedContent) {
+      return;
+    }
+
+    if (!validateEnvFormat(pastedContent)) {
+      return;
+    }
 
     const newVariables = parseVariablesFromContent(pastedContent);
     if (newVariables.length > 0) {
@@ -147,6 +175,12 @@ export const CreateSingleAppForm = (props: {
     }
     setPastedContent("");
     setPasteModalOpened(false);
+  };
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const content = e.currentTarget.value;
+    setPastedContent(content);
+    validateEnvFormat(content);
   };
 
   const removeEnvVariable = (index: number) => {
@@ -345,6 +379,7 @@ export const CreateSingleAppForm = (props: {
               opened={pasteModalOpened}
               onClose={() => {
                 setPastedContent("");
+                setFormatError(null);
                 setPasteModalOpened(false);
               }}
               title="Add from .env"
@@ -353,7 +388,7 @@ export const CreateSingleAppForm = (props: {
               <Stack>
                 <Text size="sm" c="dimmed">
                   Paste your .env contents to add multiple environment variables
-                  at once. Each line should be in KEY=VALUE format.
+                  at once.
                 </Text>
 
                 <Textarea
@@ -362,14 +397,33 @@ export const CreateSingleAppForm = (props: {
                   maxRows={10}
                   autosize
                   value={pastedContent}
-                  onChange={(e) => setPastedContent(e.currentTarget.value)}
+                  onChange={handleContentChange}
+                  styles={{
+                    input: {
+                      borderColor: formatError
+                        ? "var(--mantine-color-red-6)"
+                        : undefined,
+                      "&:focus": {
+                        borderColor: formatError
+                          ? "var(--mantine-color-red-6)"
+                          : undefined,
+                      },
+                    },
+                  }}
                 />
+
+                {formatError && (
+                  <Text size="sm" color="red">
+                    {formatError}
+                  </Text>
+                )}
 
                 <Group justify="flex-end" mt="md">
                   <Button
                     variant="outline"
                     onClick={() => {
                       setPastedContent("");
+                      setFormatError(null);
                       setPasteModalOpened(false);
                     }}
                   >
@@ -378,7 +432,7 @@ export const CreateSingleAppForm = (props: {
                   <Button
                     variant="filled"
                     onClick={addVariablesFromPaste}
-                    disabled={!pastedContent.trim()}
+                    disabled={!pastedContent.trim() || !!formatError}
                   >
                     Add Variables
                   </Button>

--- a/src/components/Forms/CreateAppForm.tsx
+++ b/src/components/Forms/CreateAppForm.tsx
@@ -12,6 +12,8 @@ import {
   Tabs,
   Text,
   TextInput,
+  Textarea,
+  Modal,
   Tooltip,
 } from "@mantine/core";
 import TitleText from "../TitleText";
@@ -98,6 +100,8 @@ export const CreateSingleAppForm = (props: {
     useForm();
   const { uploadData, submitting, error, success } = usePost();
   const [envVariables, setEnvVariables] = useState([{ key: "", value: "" }]);
+  const [pasteModalOpened, setPasteModalOpened] = useState(false);
+  const [pastedContent, setPastedContent] = useState("");
 
   const navigate = useNavigate();
   useEffect(() => {
@@ -108,6 +112,41 @@ export const CreateSingleAppForm = (props: {
 
   const addEnvVariable = () => {
     setEnvVariables([...envVariables, { key: "", value: "" }]);
+  };
+
+  const parseVariablesFromContent = (content: string) => {
+    const lines = content.split("\n");
+    return lines
+      .map((line) => {
+        const [key, ...values] = line.split("=");
+        // eslint-disable-next-line curly
+        if (!key || values.length === 0) return null;
+        return {
+          key: key.trim(),
+          value: values.join("=").trim(),
+        };
+      })
+      .filter(Boolean) as { key: string; value: string }[];
+  };
+
+  const addVariablesFromPaste = () => {
+    // eslint-disable-next-line curly
+    if (!pastedContent) return;
+
+    const newVariables = parseVariablesFromContent(pastedContent);
+    if (newVariables.length > 0) {
+      if (
+        envVariables.length === 1 &&
+        !envVariables[0].key &&
+        !envVariables[0].value
+      ) {
+        setEnvVariables([...newVariables]);
+      } else {
+        setEnvVariables([...envVariables, ...newVariables]);
+      }
+    }
+    setPastedContent("");
+    setPasteModalOpened(false);
   };
 
   const removeEnvVariable = (index: number) => {
@@ -239,10 +278,7 @@ export const CreateSingleAppForm = (props: {
               leftSection={<HiCommandLine />}
             />
             {showEnvs && (
-              <Fieldset
-                legend="Environment Variables"
-                // description="Add environment variables for your application"
-              >
+              <Fieldset legend="Environment Variables">
                 <Stack gap="sm">
                   {envVariables.map((env, index) => (
                     <Flex key={index} gap="md" align="flex-end">
@@ -257,7 +293,6 @@ export const CreateSingleAppForm = (props: {
                           handleEnvChange(index, "key", e.target.value)
                         }
                         flex={1}
-                        //   required
                       />
                       <TextInput
                         label="Value"
@@ -270,7 +305,6 @@ export const CreateSingleAppForm = (props: {
                           handleEnvChange(index, "value", e.target.value)
                         }
                         flex={1}
-                        //   required
                       />
                       {envVariables.length > 1 && (
                         <Button
@@ -286,17 +320,71 @@ export const CreateSingleAppForm = (props: {
                       )}
                     </Flex>
                   ))}
-                  <Button
-                    variant="outline"
-                    leftSection={<IoMdAdd />}
-                    onClick={addEnvVariable}
-                    mt="sm"
-                  >
-                    Add Variable
-                  </Button>
+                  <Flex justify="flex-end" gap="sm">
+                    <Button
+                      variant="outline"
+                      leftSection={<IoMdAdd />}
+                      onClick={addEnvVariable}
+                      mt="sm"
+                    >
+                      Add Variable
+                    </Button>
+                    <Button
+                      variant="outline"
+                      leftSection={<TbCopy />}
+                      onClick={() => setPasteModalOpened(true)}
+                      mt="sm"
+                    >
+                      Paste Variables
+                    </Button>
+                  </Flex>
                 </Stack>
               </Fieldset>
             )}
+            <Modal
+              opened={pasteModalOpened}
+              onClose={() => {
+                setPastedContent("");
+                setPasteModalOpened(false);
+              }}
+              title="Add from .env"
+              size="lg"
+            >
+              <Stack>
+                <Text size="sm" c="dimmed">
+                  Paste your .env contents to add multiple environment variables
+                  at once. Each line should be in KEY=VALUE format.
+                </Text>
+
+                <Textarea
+                  placeholder={`KEY_1=VALUE_1\nKEY_2=VALUE_2\nKEY_3=VALUE_3`}
+                  minRows={5}
+                  maxRows={10}
+                  autosize
+                  value={pastedContent}
+                  onChange={(e) => setPastedContent(e.currentTarget.value)}
+                />
+
+                <Group justify="flex-end" mt="md">
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setPastedContent("");
+                      setPasteModalOpened(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="filled"
+                    onClick={addVariablesFromPaste}
+                    disabled={!pastedContent.trim()}
+                  >
+                    Add Variables
+                  </Button>
+                </Group>
+              </Stack>
+            </Modal>
             <Divider mt="md" />
             <Group justify="flex-end">
               <Button


### PR DESCRIPTION
# Description

This PR adds functionality to paste multiple environment variables at once from .env file format in the application deployment form. The implementation includes:

A new "Paste Variables" button that opens a modal dialog

Modal with textarea for pasting .env content and clear formatting instructions

Logic to parse and validate the pasted variables

## Type of change
- [ ] New feature (non-breaking change which adds functionality)


## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?

1.Navigate to the application deployment form

2.Click "Paste Variables" button in the Environment Variables section

3.In the modal that appears:

Paste content in .env format (KEY=VALUE per line)

Try various formats (valid, invalid, empty lines)

Test the Cancel button

Test the Add Variables button

4.Verify:

Variables are parsed correctly

First empty position is filled if available

Invalid lines are skipped

State is properly maintained

UI remains responsive


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots
<img width="642" height="161" alt="Capture" src="https://github.com/user-attachments/assets/7d849ea7-3afc-4811-8f35-0cb8868f91f6" />
<img width="619" height="313" alt="paste" src="https://github.com/user-attachments/assets/8bdebb07-ce9c-4f81-83a7-36ebdf17c66c" />

