### PR TITLE
feat: add initial custom domain functionality

### DIFF
--- a/src/config.tsx
+++ b/src/config.tsx
@@ -25,3 +25,8 @@ export const MLOPS_API_URL = import.meta.env.VITE_APP_MLOPS_API_URL;
 // GitHub and Google OAuth URLs
 export const GIT_REDIRECT_URL = `https://github.com/login/oauth/authorize?client_id=${import.meta.env.VITE_APP_GITHUB_CLEINT_ID}&scope=read:user,user:email`;
 export const GOOGLE_REDIRECT_URL = `https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?response_type=code&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&scope=profile%20email&client_id=${import.meta.env.VITE_GOOGLE_CLIENT_ID}&service=lso&o2v=2&flowName=GeneralOAuthFlow`;
+
+// Custom domain IP address
+// This is the IP address that users will point their custom domains to.
+export const CUSTOM_DOMAIN_IP =
+  import.meta.env.VITE_CUSTOM_DOMAIN_IP || "102.134.147.233";

--- a/src/pages/Apps/AppSettingsPage.tsx
+++ b/src/pages/Apps/AppSettingsPage.tsx
@@ -29,6 +29,17 @@ import {
   Text,
   Tooltip,
   TextInput,
+  Table as MantineTable,
+  Alert,
+  ActionIcon,
+  CopyButton,
+  Paper,
+  Modal,
+  Code,
+  List,
+  ThemeIcon,
+  Textarea,
+  Collapse,
 } from "@mantine/core";
 import { useContext, useEffect, useState } from "react";
 import {
@@ -38,15 +49,24 @@ import {
   HiPencil,
   HiPlus,
   HiTrash,
+  HiPencil as IconEdit,
+  HiCheck as IconCheck,
+  HiExclamationTriangle as IconAlertTriangle,
+  HiGlobeAlt as IconWorld,
+  HiArrowPath as IconRotateClockwise,
+  HiXMark as IconX,
 } from "react-icons/hi2";
-import { FiCalendar } from "react-icons/fi";
+import { FiCalendar, FiExternalLink } from "react-icons/fi";
 import { LiaDocker } from "react-icons/lia";
+import { FaCheck } from "react-icons/fa6";
 
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { TbCheck, TbCopy } from "react-icons/tb";
 import { useClipboard } from "@mantine/hooks";
 import { useAuth } from "@/utils/AuthContext";
 import { MenuContext } from "@/components/Layouts/DashboardLayout";
+import { FaArrowDown, FaArrowUp } from "react-icons/fa";
+import { CUSTOM_DOMAIN_IP } from "@/config";
 
 const AppSettingsPage = () => {
   const { app_id } = useParams();
@@ -67,6 +87,7 @@ const AppSettingsPage = () => {
           <Tabs.Tab value="general">General</Tabs.Tab>
           <Tabs.Tab value="ci/cd">CI / CD</Tabs.Tab>
           <Tabs.Tab value="deployments">Deployments</Tabs.Tab>
+          <Tabs.Tab value="domains">Domains</Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="general" pt={10}>
@@ -77,6 +98,9 @@ const AppSettingsPage = () => {
         </Tabs.Panel>
         <Tabs.Panel value="ci/cd" pt={10}>
           <CICDTab app={app} />
+        </Tabs.Panel>
+        <Tabs.Panel value="domains" pt={10}>
+          <DomainsTab app={app} setRefresh={setRefresh} />
         </Tabs.Panel>
       </Tabs>
     </div>
@@ -212,16 +236,6 @@ const GeneralTab = ({
     },
   ];
 
-  const appSingleInfo = [
-    {
-      label: "Application Link",
-      value: app?.url || "N/A",
-    },
-    {
-      label: "Internal Link",
-      value: app?.internal_url || "N/A",
-    },
-  ];
   return (
     <Stack gap={30}>
       <Stack gap={0}>
@@ -235,19 +249,6 @@ const GeneralTab = ({
                     <Text className="subtitle">{info.label}</Text>
                     <Text size="sm">{info.value}</Text>
                   </Stack>
-                </Flex>
-              </Grid.Col>
-            ))}
-            <Grid.Col span={{ base: 12, md: 12, lg: 12 }}>
-              <Divider />
-            </Grid.Col>
-            {appSingleInfo.map((info) => (
-              <Grid.Col span={{ base: 12, md: 12, lg: 12 }}>
-                <Flex gap={20}>
-                  <Text className="subtitle">{info.label}</Text>
-                  <Text size="sm" flex={1}>
-                    {info.value}
-                  </Text>
                 </Flex>
               </Grid.Col>
             ))}
@@ -284,7 +285,7 @@ const GeneralTab = ({
         </Flex>
       </Stack>
       <Stack gap={0}>
-        <TitleText>Danger Zone</TitleText>
+        <TitleText>Manage App</TitleText>
         <Card p="lg" radius="md" withBorder>
           <Stack gap={10}>
             <Group justify="space-between" align="center">
@@ -697,6 +698,462 @@ const CICDTab = ({ app }: { app: any }) => {
           </Card>
         </Stack>
       </Stack>
+    </div>
+  );
+};
+
+const DomainsTab = ({
+  app,
+  setRefresh,
+}: {
+  app: any;
+  setRefresh: (refresh: boolean) => void;
+}) => {
+  const [newDomain, setNewDomain] = useState("");
+  const [isAddingDomain, setIsAddingDomain] = useState(false);
+  const [isEditingCustomDomain, setIsEditingCustomDomain] = useState(false);
+  const [customDomainValue, setCustomDomainValue] = useState(app?.url || "");
+  const [isDnsInstructionsOpen, setIsDnsInstructionsOpen] = useState(false);
+
+  const {
+    uploadData: addCustomDomain,
+    submitting: addingCustomDomain,
+    success: addedCustomDomainSuccess,
+    error: addCustomDomainError,
+  } = usePost();
+  const {
+    uploadData: revertCustomDomain,
+    submitting: revertingCustomDomain,
+    success: revertedCustomDomainSuccess,
+    error: verificationError,
+  } = usePost();
+
+  useEffect(() => {
+    if (addedCustomDomainSuccess) {
+      setRefresh(true);
+      setNewDomain("");
+      setCustomDomainValue("");
+      setIsAddingDomain(false);
+      setIsEditingCustomDomain(false);
+    }
+  }, [addedCustomDomainSuccess]);
+
+  useEffect(() => {
+    if (revertedCustomDomainSuccess) {
+      setRefresh(true);
+      setCustomDomainValue(app?.url || "");
+    }
+  }, [revertedCustomDomainSuccess]);
+
+  interface DnsRecord {
+    type: string;
+    name: string;
+    value: string;
+    ttl: string;
+    description: string;
+  }
+
+  const dnsInstructions = [
+    {
+      title: "Record Type",
+      value: "A",
+      description: "Select A-record type",
+    },
+    {
+      title: "Host",
+      value: "app",
+      description: "This will point to your domain",
+    },
+    {
+      title: "Address/Value",
+      value: CUSTOM_DOMAIN_IP,
+      description: "IP address we provide",
+    },
+    {
+      title: "TTL",
+      value: "1 Hour",
+      description: "Time to live setting",
+    },
+  ];
+
+  const dnsRecords: DnsRecord[] = [
+    {
+      type: "A",
+      name: "app",
+      value: CUSTOM_DOMAIN_IP,
+      ttl: "1 Hour",
+      description: "Points to your domain",
+    },
+    {
+      type: "A",
+      name: "@",
+      value: CUSTOM_DOMAIN_IP,
+      ttl: "1 Hour",
+      description: "Root domain pointer",
+    },
+  ];
+
+  const handleAddDomain = async () => {
+    if (!app?.id || (!newDomain.trim() && !customDomainValue.trim())) {
+      return;
+    }
+
+    addCustomDomain({
+      api: "apps",
+      id: app?.id,
+      method: "PATCH",
+      params: {
+        custom_domain: newDomain.trim() || customDomainValue.trim(),
+      },
+    });
+  };
+
+  const handleRevertDomain = async () => {
+    if (!app?.id) {
+      return;
+    }
+
+    revertCustomDomain({
+      api: `apps/${app?.id}/revert_url`,
+      method: "PATCH",
+    });
+  };
+
+  const renderDnsInstructions = () => (
+    <Stack gap="md" mt="md">
+      <Group justify="flex-start">
+        <Button
+          variant="subtle"
+          color="blue"
+          size="sm"
+          leftSection={
+            isDnsInstructionsOpen ? (
+              <FaArrowUp size={16} />
+            ) : (
+              <FaArrowDown size={16} />
+            )
+          }
+          onClick={() => setIsDnsInstructionsOpen(!isDnsInstructionsOpen)}
+        >
+          {isDnsInstructionsOpen
+            ? "Hide DNS Setup Instructions"
+            : "View DNS Setup Instructions"}
+        </Button>
+      </Group>
+
+      <Collapse in={isDnsInstructionsOpen}>
+        <Paper p="md" withBorder radius="md">
+          <Alert
+            icon={<IconAlertTriangle size={16} />}
+            color="blue"
+            variant="light"
+            radius="md"
+            mb="md"
+          >
+            <Text size="sm" fw={500}>
+              DNS Configuration Required
+            </Text>
+            <Text size="sm" c="dimmed" mt={4}>
+              Configure your DNS provider with the following settings to connect
+              your custom domain
+            </Text>
+          </Alert>
+
+          <Tabs defaultValue="dns-records" variant="outline">
+            <Tabs.List>
+              <Tabs.Tab value="dns-records">Required DNS Records</Tabs.Tab>
+              <Tabs.Tab value="instructions">Step-by-Step Guide</Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value="dns-records" pt="md">
+              <Text size="sm" c="dimmed" mb="md">
+                Add these DNS records to your domain provider to connect your
+                custom domain.
+              </Text>
+
+              <MantineTable>
+                <MantineTable.Thead>
+                  <MantineTable.Tr>
+                    <MantineTable.Th>Type</MantineTable.Th>
+                    <MantineTable.Th>Name</MantineTable.Th>
+                    <MantineTable.Th>Value</MantineTable.Th>
+                    <MantineTable.Th>TTL</MantineTable.Th>
+                    <MantineTable.Th>Action</MantineTable.Th>
+                  </MantineTable.Tr>
+                </MantineTable.Thead>
+                <MantineTable.Tbody>
+                  {dnsRecords.map((record, index) => (
+                    <MantineTable.Tr key={index}>
+                      <MantineTable.Td>
+                        <Badge variant="light" color="blue">
+                          {record.type}
+                        </Badge>
+                      </MantineTable.Td>
+                      <MantineTable.Td>
+                        <Code>{record.name}</Code>
+                      </MantineTable.Td>
+                      <MantineTable.Td>
+                        <Code>{record.value}</Code>
+                      </MantineTable.Td>
+                      <MantineTable.Td>
+                        <Text size="sm">{record.ttl}</Text>
+                      </MantineTable.Td>
+                      <MantineTable.Td>
+                        <CopyButton value={record.value}>
+                          {({ copied, copy }) => (
+                            <Tooltip label={copied ? "Copied" : "Copy Value"}>
+                              <ActionIcon
+                                variant="subtle"
+                                color={copied ? "green" : "gray"}
+                                onClick={copy}
+                                size="sm"
+                              >
+                                {copied ? (
+                                  <IconCheck size={14} />
+                                ) : (
+                                  <TbCopy size={14} />
+                                )}
+                              </ActionIcon>
+                            </Tooltip>
+                          )}
+                        </CopyButton>
+                      </MantineTable.Td>
+                    </MantineTable.Tr>
+                  ))}
+                </MantineTable.Tbody>
+              </MantineTable>
+            </Tabs.Panel>
+
+            <Tabs.Panel value="instructions" pt="md">
+              <Text size="sm" fw={500} mb="md">
+                Follow these steps in your DNS provider dashboard:
+              </Text>
+
+              <List spacing="xs" size="sm">
+                {dnsInstructions.map((instruction, index) => (
+                  <List.Item key={index}>
+                    <Group gap="xs">
+                      <Text fw={500}>{instruction.title}:</Text>
+                      <Code>{instruction.value}</Code>
+                      <Text c="dimmed" size="xs">
+                        {instruction.description}
+                      </Text>
+                    </Group>
+                  </List.Item>
+                ))}
+              </List>
+
+              <Alert color="blue" variant="light" mt="md">
+                <Text size="sm">
+                  After configuring your DNS records, it may take up to 24 hours
+                  for changes to propagate. You can verify your domain
+                  configuration once the DNS changes are active.
+                </Text>
+              </Alert>
+            </Tabs.Panel>
+          </Tabs>
+        </Paper>
+      </Collapse>
+    </Stack>
+  );
+
+  return (
+    <div>
+      <TitleText>Domains</TitleText>
+
+      <Card p="lg" radius="md" withBorder mb={20}>
+        <Stack gap="md">
+          <Group gap="sm">
+            <Text className="subtitle" size="sm">
+              Application URL:
+            </Text>
+            <Text
+              component={Link}
+              size="sm"
+              to={app?.url}
+              target="_blank"
+              className="link"
+            >
+              {app?.url}
+              <FiExternalLink />
+            </Text>
+          </Group>
+          <Group gap="sm">
+            <Text className="subtitle" size="sm">
+              Internal URL:
+            </Text>
+            <Text size="sm">{app?.internal_url || "N/A"}</Text>
+          </Group>
+        </Stack>
+      </Card>
+
+      {/* Custom Domain Section */}
+      {app?.has_custom_domain ? (
+        <Card p="md" withBorder radius="md">
+          <Group justify="space-between" align="flex-start" mb="md">
+            <Text fw={500} size="lg">
+              Custom Domain
+            </Text>
+            <Group gap="sm">
+              <Button
+                variant="subtle"
+                color="blue"
+                size="sm"
+                leftSection={<IconEdit size={16} />}
+                onClick={() => setIsEditingCustomDomain(!isEditingCustomDomain)}
+              >
+                Edit Domain
+              </Button>
+              <Button
+                variant="subtle"
+                color="blue"
+                size="sm"
+                leftSection={<IconRotateClockwise size={16} />}
+                onClick={handleRevertDomain}
+                loading={revertingCustomDomain}
+              >
+                Revert to Default
+              </Button>
+            </Group>
+          </Group>
+
+          {isEditingCustomDomain ? (
+            <Stack gap="md">
+              <Textarea
+                label="Domain Name"
+                placeholder="Enter your custom domain here"
+                value={customDomainValue}
+                onChange={(e) => setCustomDomainValue(e.currentTarget.value)}
+                error={verificationError.data?.message}
+                autosize
+                minRows={1}
+              />
+              <Group gap="sm">
+                <Button
+                  leftSection={<FaCheck size={16} />}
+                  onClick={handleAddDomain}
+                  loading={addingCustomDomain}
+                  disabled={!customDomainValue.trim()}
+                >
+                  Save Changes
+                </Button>
+                <Button
+                  variant="subtle"
+                  leftSection={<IconX size={16} />}
+                  onClick={() => {
+                    setIsEditingCustomDomain(false);
+                    setCustomDomainValue(app?.url || "");
+                  }}
+                >
+                  Cancel
+                </Button>
+              </Group>
+            </Stack>
+          ) : (
+            <Stack gap="md">
+              <Card p="sm" withBorder radius="sm">
+                <Text size="sm" c="dimmed" mb="xs">
+                  Current Custom Domain:
+                </Text>
+                <Text>{app?.url || "N/A"}</Text>
+              </Card>
+            </Stack>
+          )}
+
+          {renderDnsInstructions()}
+        </Card>
+      ) : (
+        <Card
+          p="xl"
+          withBorder
+          radius="md"
+          style={{
+            minHeight: "200px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            border: "2px dashed #dee2e6",
+          }}
+        >
+          <Stack align="center" gap="md">
+            <ThemeIcon size="xl" variant="light" color="gray">
+              <IconWorld size={24} />
+            </ThemeIcon>
+            <Text size="lg" c="dimmed" ta="center">
+              No custom domain configured
+            </Text>
+            <Text size="sm" c="dimmed" ta="center" maw={400}>
+              Add a custom domain to make your application accessible through
+              your own domain name.
+            </Text>
+            <Button
+              variant="light"
+              leftSection={<HiPlus size={16} />}
+              onClick={() => setIsAddingDomain(true)}
+            >
+              Add Custom Domain
+            </Button>
+          </Stack>
+        </Card>
+      )}
+
+      <Modal
+        opened={isAddingDomain}
+        onClose={() => setIsAddingDomain(false)}
+        title="Add Custom Domain"
+        size="lg"
+      >
+        <Stack gap="md">
+          <Alert
+            icon={<IconAlertTriangle size={16} />}
+            color="blue"
+            variant="light"
+            radius="md"
+          >
+            <Text size="sm" fw={500} mb="xs">
+              Accepted Domain Formats
+            </Text>
+            <List size="sm" spacing="xs">
+              <List.Item>
+                <Code>example.com</Code> - Root domain
+              </List.Item>
+              <List.Item>
+                <Code>www.example.com</Code> - Subdomain with www
+              </List.Item>
+              <List.Item>
+                <Code>app.example.com</Code> - Custom subdomain
+              </List.Item>
+              <List.Item>
+                <Code>my-app.example.com</Code> - Subdomain with hyphens
+              </List.Item>
+            </List>
+            <Text size="xs" c="dimmed" mt="xs">
+              Note: Do not include http:// or https:// in your domain name
+            </Text>
+          </Alert>
+
+          <TextInput
+            label="Domain Name"
+            placeholder="Enter your domain here"
+            value={newDomain}
+            onChange={(e) => setNewDomain(e.currentTarget.value)}
+            error={addCustomDomainError?.data?.message}
+          />
+
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={() => setIsAddingDomain(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAddDomain}
+              loading={addingCustomDomain}
+              disabled={!newDomain.trim()}
+            >
+              {addingCustomDomain ? "Adding..." : "Add Domain"}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </div>
   );
 };

--- a/src/pages/Apps/AppSettingsPage.tsx
+++ b/src/pages/Apps/AppSettingsPage.tsx
@@ -37,9 +37,8 @@ import {
   Modal,
   Code,
   List,
-  ThemeIcon,
-  Textarea,
   Collapse,
+  Box,
 } from "@mantine/core";
 import { useContext, useEffect, useState } from "react";
 import {
@@ -49,16 +48,11 @@ import {
   HiPencil,
   HiPlus,
   HiTrash,
-  HiPencil as IconEdit,
   HiCheck as IconCheck,
   HiExclamationTriangle as IconAlertTriangle,
-  HiGlobeAlt as IconWorld,
-  HiArrowPath as IconRotateClockwise,
-  HiXMark as IconX,
 } from "react-icons/hi2";
 import { FiCalendar, FiExternalLink } from "react-icons/fi";
 import { LiaDocker } from "react-icons/lia";
-import { FaCheck } from "react-icons/fa6";
 
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { TbCheck, TbCopy } from "react-icons/tb";
@@ -67,10 +61,13 @@ import { useAuth } from "@/utils/AuthContext";
 import { MenuContext } from "@/components/Layouts/DashboardLayout";
 import { FaArrowDown, FaArrowUp } from "react-icons/fa";
 import { CUSTOM_DOMAIN_IP } from "@/config";
+import { GoPlus } from "react-icons/go";
+import { HiRefresh } from "react-icons/hi";
 
 const AppSettingsPage = () => {
   const { app_id } = useParams();
-  const { app, setRefresh } = useGetApp(app_id || "");
+  const [refresh, setRefresh] = useState<number>(0);
+  const { app } = useGetApp(app_id || "", refresh);
   const { setContainerSize } = useContext(MenuContext);
 
   useEffect(() => {
@@ -114,7 +111,7 @@ const GeneralTab = ({
   setRefresh,
 }: {
   app: any;
-  setRefresh: (refresh: boolean) => void;
+  setRefresh: React.Dispatch<React.SetStateAction<number>>;
 }) => {
   const [deleteConfirmOpened, setDeleteConfirmOpened] = useState(false);
   const [disableConfirmOpened, setDisableConfirmOpened] = useState(false);
@@ -161,7 +158,7 @@ const GeneralTab = ({
   }, [enabledAppSuccess, disabledAppSuccess]);
 
   useEffect(() => {
-    setRefresh(true);
+    setRefresh((prev) => prev + 1);
   }, [addedEnvVariablesSuccess]);
 
   const submitEnvVariables = () => {
@@ -411,7 +408,7 @@ const GeneralTab = ({
               showEnvs={false}
               showTitle={false}
               onCancel={() => setUpdateConfirmOpened(false)}
-              refresh={() => setRefresh(true)}
+              refresh={() => setRefresh((prev) => prev + 1)}
             />
           </ModalConfirm>
 
@@ -707,44 +704,8 @@ const DomainsTab = ({
   setRefresh,
 }: {
   app: any;
-  setRefresh: (refresh: boolean) => void;
+  setRefresh: React.Dispatch<React.SetStateAction<number>>;
 }) => {
-  const [newDomain, setNewDomain] = useState("");
-  const [isAddingDomain, setIsAddingDomain] = useState(false);
-  const [isEditingCustomDomain, setIsEditingCustomDomain] = useState(false);
-  const [customDomainValue, setCustomDomainValue] = useState(app?.url || "");
-  const [isDnsInstructionsOpen, setIsDnsInstructionsOpen] = useState(false);
-
-  const {
-    uploadData: addCustomDomain,
-    submitting: addingCustomDomain,
-    success: addedCustomDomainSuccess,
-    error: addCustomDomainError,
-  } = usePost();
-  const {
-    uploadData: revertCustomDomain,
-    submitting: revertingCustomDomain,
-    success: revertedCustomDomainSuccess,
-    error: verificationError,
-  } = usePost();
-
-  useEffect(() => {
-    if (addedCustomDomainSuccess) {
-      setRefresh(true);
-      setNewDomain("");
-      setCustomDomainValue("");
-      setIsAddingDomain(false);
-      setIsEditingCustomDomain(false);
-    }
-  }, [addedCustomDomainSuccess]);
-
-  useEffect(() => {
-    if (revertedCustomDomainSuccess) {
-      setRefresh(true);
-      setCustomDomainValue(app?.url || "");
-    }
-  }, [revertedCustomDomainSuccess]);
-
   interface DnsRecord {
     type: string;
     name: string;
@@ -793,17 +754,107 @@ const DomainsTab = ({
     },
   ];
 
-  const handleAddDomain = async () => {
-    if (!app?.id || (!newDomain.trim() && !customDomainValue.trim())) {
+  const [newDomain, setNewDomain] = useState("");
+  const [isAddingDomain, setIsAddingDomain] = useState(false);
+  const [isDnsInstructionsOpen, setIsDnsInstructionsOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [domainValue, setDomainValue] = useState(app?.url || "");
+  const [editingType, setEditingType] = useState<
+    "custom" | "default" | "internal" | null
+  >(null);
+  const [domains, setDomains] = useState([
+    {
+      type: "default",
+      value: app?.url,
+      status: app?.status || "active",
+    },
+    {
+      type: "internal",
+      value: app?.internal_url,
+      status: app?.status || "active",
+    },
+  ]);
+
+  const {
+    uploadData: addCustomDomain,
+    submitting: addingCustomDomain,
+    success: addedCustomDomainSuccess,
+    error: addCustomDomainError,
+  } = usePost();
+  const {
+    uploadData: revertCustomDomain,
+    submitting: revertingCustomDomain,
+    success: revertedCustomDomainSuccess,
+    error: revertCustomDomainError,
+  } = usePost();
+
+  useEffect(() => {
+    if (addedCustomDomainSuccess) {
+      setRefresh((prev) => prev + 1);
+      setNewDomain("");
+      setIsAddingDomain(false);
+      setEditOpen(false);
+      setEditingType(null);
+    }
+  }, [addedCustomDomainSuccess]);
+
+  useEffect(() => {
+    if (revertedCustomDomainSuccess) {
+      setEditOpen(false);
+      setEditingType(null);
+      setRefresh((prev) => prev + 1);
+    }
+  }, [revertedCustomDomainSuccess]);
+
+  const handleEdit = (type: "custom" | "default", value: string) => {
+    const cleanValue = value?.replace(/^https?:\/\//, "");
+    setEditingType(type);
+    setDomainValue(cleanValue);
+    setEditOpen(true);
+  };
+
+  const handleCancel = () => {
+    setEditOpen(false);
+    setEditingType(null);
+    setDomainValue("");
+  };
+
+  const handleSave = () => {
+    if (!app?.id || !domainValue.trim()) {
       return;
     }
+
+    const cleanUrl = domainValue.trim().replace(/^https?:\/\//, "");
+    addCustomDomain({
+      api: "apps",
+      id: app?.id,
+      method: "PATCH",
+      params: {
+        custom_domain: cleanUrl,
+      },
+    });
+  };
+
+  const handleAddDomain = async () => {
+    if (!app?.id || !newDomain.trim()) {
+      return;
+    }
+
+    setDomains((prev) => [
+      {
+        type: "custom",
+        value: newDomain,
+        status: "pending",
+      },
+      ...prev,
+    ]);
 
     addCustomDomain({
       api: "apps",
       id: app?.id,
       method: "PATCH",
       params: {
-        custom_domain: newDomain.trim() || customDomainValue.trim(),
+        custom_domain: newDomain.trim(),
       },
     });
   };
@@ -957,203 +1008,206 @@ const DomainsTab = ({
     </Stack>
   );
 
-  return (
-    <div>
-      <TitleText>Domains</TitleText>
-
-      <Card p="lg" radius="md" withBorder mb={20}>
-        <Stack gap="md">
-          <Group gap="sm">
-            <Text className="subtitle" size="sm">
-              Application URL:
-            </Text>
-            <Text
-              component={Link}
-              size="sm"
-              to={app?.url}
-              target="_blank"
-              className="link"
-            >
-              {app?.url}
-              <FiExternalLink />
-            </Text>
-          </Group>
-          <Group gap="sm">
-            <Text className="subtitle" size="sm">
-              Internal URL:
-            </Text>
-            <Text size="sm">{app?.internal_url || "N/A"}</Text>
-          </Group>
-        </Stack>
-      </Card>
-
-      {/* Custom Domain Section */}
-      {app?.has_custom_domain ? (
-        <Card p="md" withBorder radius="md">
-          <Group justify="space-between" align="flex-start" mb="md">
-            <Text fw={500} size="lg">
-              Custom Domain
-            </Text>
-            <Group gap="sm">
-              <Button
-                variant="subtle"
-                color="blue"
-                size="sm"
-                leftSection={<IconEdit size={16} />}
-                onClick={() => setIsEditingCustomDomain(!isEditingCustomDomain)}
+  const renderDomainRow = (
+    value: string,
+    badge?: string,
+    type?: "custom" | "default" | "internal",
+  ) => (
+    <Box py="sm">
+      <Group justify="space-between" align="flex-start">
+        <Group align="center">
+          <Stack gap={6} align="flex-start">
+            {type !== "internal" ? (
+              <Text
+                component={Link}
+                size="md"
+                to={app?.url}
+                target="_blank"
+                className="link"
               >
-                Edit Domain
+                {value}
+                {badge === "Current" && <FiExternalLink />}
+              </Text>
+            ) : (
+              <Text size="md">{value}</Text>
+            )}
+            {badge === "Current" && (
+              <Badge color="green" size="xs" leftSection={<TbCheck />}>
+                {badge}
+              </Badge>
+            )}
+          </Stack>
+        </Group>
+        <Group>
+          <Group>
+            {type !== "internal" &&
+              !(type === "default" && value?.includes("cranecloud.io")) && (
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => type && handleEdit(type, value)}
+                >
+                  Edit
+                </Button>
+              )}
+          </Group>
+        </Group>
+      </Group>
+      <Collapse in={editOpen && editingType === type}>
+        <Stack gap="md" mt="md">
+          <TextInput
+            label="Domain"
+            value={domainValue}
+            onChange={(e) => setDomainValue(e.currentTarget.value)}
+            autoFocus
+            error={
+              revertCustomDomainError?.data?.message ||
+              addCustomDomainError?.data?.message
+            }
+          />
+          <Group justify="space-between" mt="sm">
+            <Group>
+              {badge === "Current" && (
+                <Button
+                  variant="outline"
+                  leftSection={<HiRefresh size={16} />}
+                  onClick={handleRevertDomain}
+                  loading={revertingCustomDomain}
+                  disabled={revertingCustomDomain}
+                >
+                  Revert to Default
+                </Button>
+              )}
+            </Group>
+            <Group>
+              <Button variant="default" onClick={handleCancel}>
+                Cancel
               </Button>
               <Button
-                variant="subtle"
-                color="blue"
-                size="sm"
-                leftSection={<IconRotateClockwise size={16} />}
-                onClick={handleRevertDomain}
-                loading={revertingCustomDomain}
+                variant="filled"
+                onClick={handleSave}
+                loading={addingCustomDomain}
+                disabled={!domainValue.trim() || addingCustomDomain}
               >
-                Revert to Default
+                Save
               </Button>
             </Group>
           </Group>
+        </Stack>
+      </Collapse>
+    </Box>
+  );
 
-          {isEditingCustomDomain ? (
-            <Stack gap="md">
-              <Textarea
-                label="Domain Name"
-                placeholder="Enter your custom domain here"
-                value={customDomainValue}
-                onChange={(e) => setCustomDomainValue(e.currentTarget.value)}
-                error={verificationError.data?.message}
-                autosize
-                minRows={1}
-              />
-              <Group gap="sm">
+  useEffect(() => {
+    if (app?.url || app?.internal_url) {
+      setDomains([
+        {
+          type: "default",
+          value: app?.url,
+          status: app?.status || "active",
+        },
+        {
+          type: "internal",
+          value: app?.internal_url,
+          status: app?.status || "active",
+        },
+      ]);
+    }
+  }, [app?.url, app?.internal_url, app?.status]);
+
+  return (
+    <div>
+      <div>
+        <TitleText
+          rightSection={
+            <>
+              <Group gap="sm" justify="flex-end">
                 <Button
-                  leftSection={<FaCheck size={16} />}
-                  onClick={handleAddDomain}
-                  loading={addingCustomDomain}
-                  disabled={!customDomainValue.trim()}
+                  leftSection={<GoPlus />}
+                  onClick={() => setIsAddingDomain(true)}
                 >
-                  Save Changes
-                </Button>
-                <Button
-                  variant="subtle"
-                  leftSection={<IconX size={16} />}
-                  onClick={() => {
-                    setIsEditingCustomDomain(false);
-                    setCustomDomainValue(app?.url || "");
-                  }}
-                >
-                  Cancel
+                  Add Domain
                 </Button>
               </Group>
-            </Stack>
-          ) : (
-            <Stack gap="md">
-              <Card p="sm" withBorder radius="sm">
-                <Text size="sm" c="dimmed" mb="xs">
-                  Current Custom Domain:
-                </Text>
-                <Text>{app?.url || "N/A"}</Text>
-              </Card>
-            </Stack>
-          )}
-
-          {renderDnsInstructions()}
-        </Card>
-      ) : (
-        <Card
-          p="xl"
-          withBorder
-          radius="md"
-          style={{
-            minHeight: "200px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            border: "2px dashed #dee2e6",
-          }}
+            </>
+          }
         >
-          <Stack align="center" gap="md">
-            <ThemeIcon size="xl" variant="light" color="gray">
-              <IconWorld size={24} />
-            </ThemeIcon>
-            <Text size="lg" c="dimmed" ta="center">
-              No custom domain configured
-            </Text>
-            <Text size="sm" c="dimmed" ta="center" maw={400}>
-              Add a custom domain to make your application accessible through
-              your own domain name.
-            </Text>
-            <Button
+          Domains
+        </TitleText>
+
+        <Modal
+          opened={isAddingDomain}
+          onClose={() => setIsAddingDomain(false)}
+          title="Add Custom Domain"
+          size="lg"
+        >
+          <Stack gap="md">
+            <Alert
+              icon={<IconAlertTriangle size={16} />}
+              color="blue"
               variant="light"
-              leftSection={<HiPlus size={16} />}
-              onClick={() => setIsAddingDomain(true)}
+              radius="md"
             >
-              Add Custom Domain
-            </Button>
+              <Text size="sm" fw={500} mb="xs">
+                Accepted Domain Formats
+              </Text>
+              <List size="sm" spacing="xs">
+                <List.Item>
+                  <Code>example.com</Code> - Root domain
+                </List.Item>
+                <List.Item>
+                  <Code>www.example.com</Code> - Subdomain with www
+                </List.Item>
+                <List.Item>
+                  <Code>app.example.com</Code> - Custom subdomain
+                </List.Item>
+                <List.Item>
+                  <Code>my-app.example.com</Code> - Subdomain with hyphens
+                </List.Item>
+              </List>
+              <Text size="xs" c="dimmed" mt="xs">
+                Note: Do not include http:// or https:// in your domain name
+              </Text>
+            </Alert>
+
+            <TextInput
+              label="Domain Name"
+              placeholder="Enter your domain here"
+              value={newDomain}
+              onChange={(e) => setNewDomain(e.currentTarget.value)}
+              error={addCustomDomainError?.data?.message}
+            />
+
+            <Group justify="flex-end">
+              <Button variant="subtle" onClick={() => setIsAddingDomain(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleAddDomain}
+                loading={addingCustomDomain}
+                disabled={!newDomain.trim()}
+              >
+                {addingCustomDomain ? "Adding..." : "Add Domain"}
+              </Button>
+            </Group>
           </Stack>
-        </Card>
-      )}
+        </Modal>
+      </div>
 
-      <Modal
-        opened={isAddingDomain}
-        onClose={() => setIsAddingDomain(false)}
-        title="Add Custom Domain"
-        size="lg"
-      >
-        <Stack gap="md">
-          <Alert
-            icon={<IconAlertTriangle size={16} />}
-            color="blue"
-            variant="light"
-            radius="md"
-          >
-            <Text size="sm" fw={500} mb="xs">
-              Accepted Domain Formats
-            </Text>
-            <List size="sm" spacing="xs">
-              <List.Item>
-                <Code>example.com</Code> - Root domain
-              </List.Item>
-              <List.Item>
-                <Code>www.example.com</Code> - Subdomain with www
-              </List.Item>
-              <List.Item>
-                <Code>app.example.com</Code> - Custom subdomain
-              </List.Item>
-              <List.Item>
-                <Code>my-app.example.com</Code> - Subdomain with hyphens
-              </List.Item>
-            </List>
-            <Text size="xs" c="dimmed" mt="xs">
-              Note: Do not include http:// or https:// in your domain name
-            </Text>
-          </Alert>
+      <Card withBorder radius="md" mb="md" p="md">
+        {domains.map((domain, idx) => (
+          <Box key={domain.type + domain.value}>
+            {renderDomainRow(
+              domain.value,
+              domain.type === "default" ? "Current" : "",
+              domain.type as "custom" | "default" | "internal",
+            )}
+            {idx < domains.length - 1 && <Divider my="sm" />}
+          </Box>
+        ))}
+      </Card>
 
-          <TextInput
-            label="Domain Name"
-            placeholder="Enter your domain here"
-            value={newDomain}
-            onChange={(e) => setNewDomain(e.currentTarget.value)}
-            error={addCustomDomainError?.data?.message}
-          />
-
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={() => setIsAddingDomain(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleAddDomain}
-              loading={addingCustomDomain}
-              disabled={!newDomain.trim()}
-            >
-              {addingCustomDomain ? "Adding..." : "Add Domain"}
-            </Button>
-          </Group>
-        </Stack>
-      </Modal>
+      {renderDnsInstructions()}
     </div>
   );
 };

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -72,19 +72,18 @@ export const useGetProject = (project_id: string) => {
   return { project, cluster, loading, success, refresh, setRefresh };
 };
 
-export const useGetApp = (app_id: string) => {
+export const useGetApp = (app_id: string, refresh?: number) => {
   const { setMenuType, setProjectId, setAppId, setTitle, setSubtitle } =
     useContext(MenuContext);
   const { data: appData, getData, success, loading } = useGet();
   const [app, setApp] = useState<any>({});
-  const [refresh, setRefresh] = useState(false);
 
   useEffect(() => {
     getData({
       id: app_id,
       api: `/apps`,
     });
-  }, [refresh]);
+  }, [app_id, refresh]);
 
   useEffect(() => {
     if (success) {
@@ -117,7 +116,7 @@ export const useGetApp = (app_id: string) => {
     }
   }, [setMenuType, setAppId, app_id, appData, success]);
 
-  return { app, loading, success, refresh, setRefresh };
+  return { app, loading, success, refresh };
 };
 
 export const useGetAdminCluster = (cluster_id: string) => {


### PR DESCRIPTION
# Description

This PR adds the `Domains` section in the App Settings page.
It brings back the previous functionality from the old UI, allowing users to:
 - Add a custom domain for their app.
 - Revert from a custom domain back to the default Crane Cloud URL. 
 - View clear instructions for adding DNS records to their domain provider.

Currently, the frontend only receives `app?.url` and `app?.internal_url` and it would be beneficial if the backend could provide a `default_url` property that is always accessible, even when a custom domain is set.

This would allow the UI to always display the default Crane Cloud domain alongside any custom domains.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## ClickUp Ticket ID

https://app.clickup.com/t/8699q1c8a

## How Can This Been Tested?

- Checkout the App settings of any deployed application and visit the `Domains` tab to test out the adding of a custom domain as well as the process of reverting it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="2930" height="1036" alt="Screenshot 2025-07-15 at 10 28 52 AM" src="https://github.com/user-attachments/assets/36c3c431-4dd0-4bc0-b89c-ade8cdd217f2" />
<img width="2930" height="1596" alt="Screenshot 2025-07-15 at 10 29 23 AM" src="https://github.com/user-attachments/assets/f418540d-ff81-4511-9eb4-1fe20d04562b" />
<img width="2930" height="1200" alt="Screenshot 2025-07-15 at 10 29 34 AM" src="https://github.com/user-attachments/assets/8ad7f763-8dfd-45d9-b304-700eab6ab0ab" />
