### PR TITLE
Ft/user profile improvement

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,5 +43,5 @@ export default tseslint.config(
         },
       ],
     },
-  }
+  },
 );

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -71,6 +71,7 @@ export const DashboardRoutes = [
   { path: "/", element: <LandingPage /> },
   { path: "/profile/:user_id", element: <UserProfilePage /> },
   { path: "/users/profile/settings", element: <UserProfileSettingsPage /> },
+  { path: "/:username", element: <UserProfilePage /> },
   // Projects
   { path: "/projects/create", element: <CreateProjectForm /> },
   { path: "/projects/:project_id", element: <ProjectDetailsPage /> },

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,11 +9,16 @@ import AppMetrics from "./pages/Apps/AppMetrics";
 import HealthCheck from "./components/HealthCheck";
 import ClustersPage from "./pages/admin/ClustersPage";
 import ClusterSettingsPage from "./pages/admin/cluster/ClusterSettingsPage";
+
 // import { HomePage } from "./pages/Home.page";
 const AppsListPage = React.lazy(() => import("./pages/Apps/AppsListPage"));
 const ProjectSettingsPage = React.lazy(
   () => import("./pages/Projects/ProjectSettingsPage"),
 );
+const UserProfileSettingsPage = React.lazy(
+  () => import("./pages/Users/UserProfileSettingsPage"),
+);
+
 const ProjectUsers = React.lazy(() => import("./pages/Projects/ProjectUsers"));
 const ProjectMetrics = React.lazy(
   () => import("./pages/Projects/ProjectMetrics"),
@@ -65,6 +70,7 @@ export const DashboardRoutes = [
   { path: "/login", element: <LoginPage /> },
   { path: "/", element: <LandingPage /> },
   { path: "/profile/:user_id", element: <UserProfilePage /> },
+  { path: "/users/profile/settings", element: <UserProfileSettingsPage /> },
   // Projects
   { path: "/projects/create", element: <CreateProjectForm /> },
   { path: "/projects/:project_id", element: <ProjectDetailsPage /> },

--- a/src/components/Cards/OtherCards.tsx
+++ b/src/components/Cards/OtherCards.tsx
@@ -1,32 +1,21 @@
-import {
-  Box,
-  Card,
-  Divider,
-  Group,
-  Stack,
-  Text,
-  Tooltip,
-  Anchor,
-} from "@mantine/core";
+import { Box, Card, Divider, Group, Stack, Text, Tooltip } from "@mantine/core";
 import { PiBuildingsBold } from "react-icons/pi";
 import { FaGithub, FaLinkedin, FaTwitter } from "react-icons/fa";
 import { ProfileAvatar } from "../Common";
 import { Link } from "react-router-dom";
 
 function UserProfileCard({ user }: { user: any }) {
-  console.log("user", user);
   const userStats = [
     { value: user?.follower_count, label: "Followers" },
     { value: user?.following_count, label: "Follows" },
     { value: user?.apps_count, label: "Apps" },
   ];
   const socialLinks = user?.social_links || {};
-  console.log("socialLinks", socialLinks);
+
   const links = Object.entries(socialLinks).map(([key, value]) => ({
     platform: key,
     url: value,
   }));
-  console.log("links", links);
 
   const socialLinksIcons = {
     github: <FaGithub />,

--- a/src/components/Cards/OtherCards.tsx
+++ b/src/components/Cards/OtherCards.tsx
@@ -60,12 +60,14 @@ function UserProfileCard({ user }: { user: any }) {
       </Text>
       <Stack gap={4}>
         {user?.biography && (
-          <Text fz="sm" c="dimmed" ta="center">
+          <Text fz="sm" c="black" ta="center" lineClamp={3} fw={300}>
             {user?.biography}
           </Text>
         )}
+        <Divider my="md" />
+
         {user?.organisation && (
-          <Group gap={5} fz="0.9rem">
+          <Group gap={5} fz="0.9rem" fw={600} mt="sm">
             <PiBuildingsBold size={17} />
             {user?.organisation}
           </Group>

--- a/src/components/Cards/OtherCards.tsx
+++ b/src/components/Cards/OtherCards.tsx
@@ -1,14 +1,38 @@
-import { Box, Card, Divider, Group, Stack, Text, Tooltip } from "@mantine/core";
+import {
+  Box,
+  Card,
+  Divider,
+  Group,
+  Stack,
+  Text,
+  Tooltip,
+  Anchor,
+} from "@mantine/core";
 import { PiBuildingsBold } from "react-icons/pi";
+import { FaGithub, FaLinkedin, FaTwitter } from "react-icons/fa";
 import { ProfileAvatar } from "../Common";
+import { Link } from "react-router-dom";
 
 function UserProfileCard({ user }: { user: any }) {
+  console.log("user", user);
   const userStats = [
     { value: user?.follower_count, label: "Followers" },
     { value: user?.following_count, label: "Follows" },
     { value: user?.apps_count, label: "Apps" },
   ];
+  const socialLinks = user?.social_links || {};
+  console.log("socialLinks", socialLinks);
+  const links = Object.entries(socialLinks).map(([key, value]) => ({
+    platform: key,
+    url: value,
+  }));
+  console.log("links", links);
 
+  const socialLinksIcons = {
+    github: <FaGithub />,
+    linkedin: <FaLinkedin />,
+    twitter: <FaTwitter />,
+  };
   return (
     <Card withBorder padding="xl" radius="md" w={350}>
       <Card.Section
@@ -23,29 +47,38 @@ function UserProfileCard({ user }: { user: any }) {
         <ProfileAvatar user={user} size={140} />
       </Box>
       <Text ta="center" fz="1.3rem" fw={500} mt="sm">
-        {user?.name}
+        {user?.username}
       </Text>
       <Text ta="center" fz="sm" c="dimmed">
         {user?.email}
       </Text>
       <StatsList stats={userStats} />
       <Divider my="md" />
-      <Stack gap={2}>
-        <Text>
+
+      <Text fz="sm" mb="md" c="dimmed" ta="center">
+        Joined Cranecloud {user?.age}
+      </Text>
+      <Stack gap={4}>
+        {user?.biography && (
+          <Text fz="sm" c="dimmed" ta="center">
+            {user?.biography}
+          </Text>
+        )}
+        {user?.organisation && (
           <Group gap={5} fz="0.9rem">
             <PiBuildingsBold size={17} />
-            {user?.organization || "Makerere University"}
+            {user?.organisation}
           </Group>
-        </Text>
-        <Text fz="sm" c="dimmed">
-          Joined Cranecloud {user?.age}
-        </Text>
+        )}
+        {links.map((link, index) => (
+          <Link key={index} to={link.url as string} target="_blank">
+            <Group gap={5} fz="0.9rem">
+              {socialLinksIcons[link.platform as keyof typeof socialLinksIcons]}
+              {link.url as string}
+            </Group>
+          </Link>
+        ))}
       </Stack>
-      {/* {authUser?.id !== user?.id && (
-        <Button fullWidth radius="md" mt="xl" size="md" variant="default">
-          Follow
-        </Button>
-      )} */}
     </Card>
   );
 }

--- a/src/components/Common.tsx
+++ b/src/components/Common.tsx
@@ -86,11 +86,12 @@ export const UserDropDown = () => {
     {
       label: "Account settings",
       icon: <IoSettingsOutline size={16} />,
-      action: () => navigate(`/profile/${user?.id}`),
+      action: () => navigate(`/users/profile/settings`),
     },
     {
       label: "Change account",
       icon: <GoArrowSwitch size={16} />,
+      action: () => navigate(`/users/profile/settings`),
     },
     {
       label: "Logout",

--- a/src/components/Forms/UpdateProfileForm.tsx
+++ b/src/components/Forms/UpdateProfileForm.tsx
@@ -46,10 +46,11 @@ export const UpdateProfileForm = ({
 
   return (
     <form onSubmit={handleSubmit}>
-      <Stack gap={10}>
+      <Stack gap={15}>
         <TextInput
           label="Username"
           placeholder="Enter your username"
+          description="This will be your public username. Do not use spaces or special characters."
           value={username}
           onChange={(e) => setUsername(e.currentTarget.value)}
           required
@@ -61,6 +62,15 @@ export const UpdateProfileForm = ({
           placeholder="Enter your email"
           value={email}
           onChange={(e) => setEmail(e.currentTarget.value)}
+          disabled
+          required
+        />
+
+        <TextInput
+          label="Organisation"
+          placeholder="Your organisation or company"
+          value={organisation}
+          onChange={(e) => setOrganisation(e.currentTarget.value)}
           required
         />
 
@@ -72,18 +82,16 @@ export const UpdateProfileForm = ({
           maxRows={3}
         />
 
-        <TextInput
-          label="Organisation"
-          placeholder="Your organisation or company"
-          value={organisation}
-          onChange={(e) => setOrganisation(e.currentTarget.value)}
-        />
-
         <Group justify="flex-end" mt="md">
           <Button variant="outline" onClick={onCancel} disabled={submitting}>
             Cancel
           </Button>
-          <Button type="submit" loading={submitting}>
+          <Button
+            type="submit"
+            loading={submitting}
+            variant="filled"
+            color="dark"
+          >
             Save
           </Button>
         </Group>

--- a/src/components/Forms/UpdateProfileForm.tsx
+++ b/src/components/Forms/UpdateProfileForm.tsx
@@ -22,14 +22,18 @@ export const UpdateProfileForm = ({
 
   useEffect(() => {
     if (success) {
-      if (onSuccess) onSuccess();
+      if (onSuccess) {
+        onSuccess();
+      }
     }
   }, [success, onSuccess]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!user?.id) return;
+    if (!user?.id) {
+      return;
+    }
 
     uploadData({
       api: "users",

--- a/src/components/Forms/UpdateProfileForm.tsx
+++ b/src/components/Forms/UpdateProfileForm.tsx
@@ -1,0 +1,93 @@
+import { Button, Stack, TextInput, Textarea, Group } from "@mantine/core";
+import { useState, useEffect } from "react";
+import usePost from "@/utils/usePost";
+
+type UpdateProfileForm = {
+  user: any; // your user object, can type more strictly if you want
+  onCancel: () => void;
+  onSuccess?: () => void;
+};
+
+export const UpdateProfileForm = ({
+  user,
+  onCancel,
+  onSuccess,
+}: UpdateProfileForm) => {
+  const [username, setUsername] = useState(user?.username || "");
+  const [email, setEmail] = useState(user?.email || "");
+  const [biography, setBiography] = useState(user?.biography || "");
+  const [organisation, setOrganisation] = useState(user?.organisation || "");
+
+  const { uploadData, submitting, success } = usePost();
+
+  useEffect(() => {
+    if (success) {
+      if (onSuccess) onSuccess();
+    }
+  }, [success, onSuccess]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!user?.id) return;
+
+    uploadData({
+      api: "users",
+      id: user.id,
+      method: "PATCH",
+      params: {
+        username,
+        email,
+        biography,
+        organisation,
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack gap={10}>
+        <TextInput
+          label="Username"
+          placeholder="Enter your username"
+          value={username}
+          onChange={(e) => setUsername(e.currentTarget.value)}
+          required
+        />
+
+        <TextInput
+          label="Email"
+          type="email"
+          placeholder="Enter your email"
+          value={email}
+          onChange={(e) => setEmail(e.currentTarget.value)}
+          required
+        />
+
+        <Textarea
+          label="Biography"
+          placeholder="Tell us about yourself"
+          value={biography}
+          onChange={(e) => setBiography(e.currentTarget.value)}
+          maxRows={3}
+        />
+
+        <TextInput
+          label="Organisation"
+          placeholder="Your organisation or company"
+          value={organisation}
+          onChange={(e) => setOrganisation(e.currentTarget.value)}
+        />
+
+        <Group justify="flex-end" mt="md">
+          <Button variant="outline" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button type="submit" loading={submitting}>
+            Save
+          </Button>
+        </Group>
+      </Stack>
+    </form>
+  );
+};

--- a/src/pages/Auth/loginPage.tsx
+++ b/src/pages/Auth/loginPage.tsx
@@ -219,39 +219,50 @@ export function LoginForm(props: PaperProps) {
       gitOAuth({ api: `${API_USERS}/oauth`, params: { code } });
     }
   }, []);
-  
+
   const validatepassword = (value: string) => {
-  form.setFieldValue("password", value);
-  setPassword(value);
+    form.setFieldValue("password", value);
+    setPassword(value);
 
-  const hasUppercase = /[A-Z]/.test(value);
-  const hasLowercase = /[a-z]/.test(value);
-  const hasNumber = /[0-9]/.test(value);
-  const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(value);
+    const hasUppercase = /[A-Z]/.test(value);
+    const hasLowercase = /[a-z]/.test(value);
+    const hasNumber = /[0-9]/.test(value);
+    const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(value);
 
-  if (value.length < 6) {
-    form.setFieldError("password", "Password must be at least 6 characters");
-  } else if (!hasUppercase) {
-    form.setFieldError("password", "Password must include at least one uppercase letter");
-  } else if (!hasLowercase) {
-    form.setFieldError("password", "Password must include at least one lowercase letter");
-  } else if (!hasNumber) {
-    form.setFieldError("password", "Password must include at least one number");
-  } else if (!hasSpecialChar) {
-    form.setFieldError("password", "Password must include at least one special character");
-  } else {
-    form.clearFieldError("password");
-  }
-
-  if (type === "register") {
-    if (value === form.values.confirmPassword) {
-      setConfirmFeedback("match");
+    if (value.length < 6) {
+      form.setFieldError("password", "Password must be at least 6 characters");
+    } else if (!hasUppercase) {
+      form.setFieldError(
+        "password",
+        "Password must include at least one uppercase letter",
+      );
+    } else if (!hasLowercase) {
+      form.setFieldError(
+        "password",
+        "Password must include at least one lowercase letter",
+      );
+    } else if (!hasNumber) {
+      form.setFieldError(
+        "password",
+        "Password must include at least one number",
+      );
+    } else if (!hasSpecialChar) {
+      form.setFieldError(
+        "password",
+        "Password must include at least one special character",
+      );
     } else {
-      setConfirmFeedback("mismatch");
+      form.clearFieldError("password");
     }
-  }
-};
 
+    if (type === "register") {
+      if (value === form.values.confirmPassword) {
+        setConfirmFeedback("match");
+      } else {
+        setConfirmFeedback("mismatch");
+      }
+    }
+  };
 
   return (
     <Stack justify="center" mt="lg">

--- a/src/pages/Users/UserProfilePage.tsx
+++ b/src/pages/Users/UserProfilePage.tsx
@@ -1,14 +1,5 @@
-import {
-  Anchor,
-  Button,
-  Card,
-  Flex,
-  Group,
-  Stack,
-  Text,
-  Tooltip,
-} from "@mantine/core";
-import { FaGithub, FaLinkedin, FaTwitter, FaEdit } from "react-icons/fa";
+import { Anchor, Button, Card, Flex, Group, Stack, Text } from "@mantine/core";
+import { FaGithub, FaLinkedin, FaTwitter } from "react-icons/fa";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/utils/AuthContext";
@@ -112,7 +103,7 @@ const UserProfilePage = () => {
           )}
 
           {!currentUser?.social_links?.length && (
-            <Text color="dimmed" mt="md"></Text>
+            <Text color="dimmed" mt="md" />
           )}
         </Stack>
       </Flex>

--- a/src/pages/Users/UserProfilePage.tsx
+++ b/src/pages/Users/UserProfilePage.tsx
@@ -1,56 +1,123 @@
-import UserProfileCard, { StatsList } from "@/components/Cards/OtherCards";
-import TitleText from "@/components/TitleText";
+import {
+  Anchor,
+  Button,
+  Card,
+  Flex,
+  Group,
+  Stack,
+  Text,
+  Tooltip,
+} from "@mantine/core";
+import { FaGithub, FaLinkedin, FaTwitter, FaEdit } from "react-icons/fa";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/utils/AuthContext";
 import { useSetContainerSize, useSetNoSidebar } from "@/utils/helpers";
 import useGet from "@/utils/useGet";
-import { Card, Flex, Stack } from "@mantine/core";
-import React, { useEffect } from "react";
+import UserProfileCard, { StatsList } from "@/components/Cards/OtherCards";
+import TitleText from "@/components/TitleText";
+
+const socialIconMap: Record<string, React.ReactNode> = {
+  github: <FaGithub />,
+  twitter: <FaTwitter />,
+  linkedin: <FaLinkedin />,
+};
 
 const UserProfilePage = () => {
   const { user } = useAuth();
   const { getData: getUser, data: userData } = useGet();
+  const navigate = useNavigate();
 
   useSetNoSidebar();
   useSetContainerSize("lg");
+
   useEffect(() => {
     if (user) {
-      getUser({ api: `/users/${user?.id}` });
+      getUser({ api: `/users/${user.id}` });
     }
-  }, []);
+  }, [user?.id]);
+
+  const currentUser = userData?.data?.user || {};
 
   const userStats = (user: any) => [
-    { value: user?.projects_count, label: "Projects" },
-    { value: user?.apps_count, label: "Apps" },
+    { value: user?.projects_count || 0, label: "Projects" },
+    { value: user?.apps_count || 0, label: "Apps" },
     {
-      value: user?.followed_projects_count,
+      value: user?.followed_projects_count || 0,
       label: "Projects Followed",
-      tooltip: "The total number of projects you follow",
+      tooltip: "Total number of projects you follow",
     },
     {
-      value: user?.projects_followers_count,
+      value: user?.projects_followers_count || 0,
       label: "Projects Followers",
-      tooltip: "The total number of users who follow your projects",
+      tooltip: "Total users who follow your projects",
     },
   ];
 
   return (
-    <div>
+    <Stack>
       <TitleText>User Profile</TitleText>
-      <Flex gap={20}>
-        <UserProfileCard user={userData?.data?.user || {}} />
-        <Stack style={{ flex: 1 }}>
-          <TitleText>Stats</TitleText>
-          <Card withBorder padding="xl" radius="md">
-            <StatsList
-              justify="space-between"
-              stats={userStats(userData?.data?.user)}
-            />
+
+      <Flex gap="lg" align="flex-start" justify="space-between" wrap="wrap">
+        {/* LEFT: Profile Card */}
+        <Stack>
+          <UserProfileCard user={currentUser} />
+        </Stack>
+
+        {/* RIGHT: Stats + Edit + Social */}
+        <Stack flex={1}>
+          <TitleText
+            rightSection={
+              <Button
+                variant="filled"
+                color="dark"
+                onClick={() => navigate("/users/profile/settings")}
+              >
+                Edit Profile
+              </Button>
+            }
+          >
+            Stats
+          </TitleText>
+
+          <Card withBorder radius="md" padding="xl">
+            <StatsList justify="space-between" stats={userStats(currentUser)} />
           </Card>
+
+          {/* Social Media Section */}
+          {currentUser?.social_links?.length > 0 && (
+            <Stack mt="lg">
+              <TitleText>Social Media</TitleText>
+              <Card withBorder radius="md" padding="md">
+                <Stack>
+                  {currentUser.social_links.map(
+                    (
+                      link: { platform: string; url: string },
+                      index: number,
+                    ) => (
+                      <Group key={index} justify="space-between">
+                        <Group>
+                          {socialIconMap[link.platform.toLowerCase()] ?? null}
+                          <Text fw={500}>{link.platform}</Text>
+                        </Group>
+                        <Anchor href={link.url} target="_blank" color="blue">
+                          {link.url}
+                        </Anchor>
+                      </Group>
+                    ),
+                  )}
+                </Stack>
+              </Card>
+            </Stack>
+          )}
+
+          {!currentUser?.social_links?.length && (
+            <Text color="dimmed" mt="md"></Text>
+          )}
         </Stack>
       </Flex>
-    </div>
+    </Stack>
   );
 };
 
 export default UserProfilePage;
- 

--- a/src/pages/Users/UserProfileSettingsPage.tsx
+++ b/src/pages/Users/UserProfileSettingsPage.tsx
@@ -1,0 +1,333 @@
+import {
+  Button,
+  Card,
+  Divider,
+  Flex,
+  Group,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useEffect, useState, useContext } from "react";
+import { HiPencil, HiPlus } from "react-icons/hi2";
+import { useParams } from "react-router-dom";
+
+import TitleText from "@/components/TitleText";
+import { ModalConfirm } from "@/components/Elements/Modals";
+import { beautify, useGetApp } from "@/utils/helpers";
+import usePost from "@/utils/usePost";
+import { MenuContext } from "@/components/Layouts/DashboardLayout";
+import { useAuth } from "@/utils/AuthContext";
+import useGet from "@/utils/useGet";
+import { BiTransferAlt } from "react-icons/bi";
+import { UpdateProfileForm } from "@/components/Forms/UpdateProfileForm";
+import { publicDecrypt } from "crypto";
+import { FaLock } from "react-icons/fa6";
+import { FaLockOpen } from "react-icons/fa";
+
+const UserProfileSettingsPage = () => {
+  const { user } = useAuth();
+  const [refresh, setRefresh] = useState<number>(0);
+  const { getData: getUser, data: userData } = useGet();
+  const { setContainerSize } = useContext(MenuContext);
+
+  useEffect(() => {
+    setContainerSize("md");
+    return () => setContainerSize("xl");
+  }, [setContainerSize]);
+
+  useEffect(() => {
+    if (user) {
+      getUser({ api: `/users/${user.id}` });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user?.id) {
+      getUser({ api: `/users/${user.id}` });
+    }
+  }, [user?.id, refresh]);
+
+  return (
+    <div>
+      <SocialLinksTab user={userData?.data?.user} setRefresh={setRefresh} />
+    </div>
+  );
+};
+
+export default UserProfileSettingsPage;
+
+const SocialLinksTab = ({
+  user,
+  setRefresh,
+}: {
+  user: any;
+  setRefresh: React.Dispatch<React.SetStateAction<number>>;
+}) => {
+  console.log("User in SocialLinksTab:", user);
+
+  const [userSocialLinks, setUserSocialLinks] = useState<
+    { platform: string; url: string }[]
+  >([]);
+  const [socialModal, setSocialModal] = useState(false);
+  const [updateModal, setUpdateModal] = useState(false);
+  const [visibilityModal, setVisibilityModal] = useState(false);
+  const [visibility, setVisibility] = useState(true);
+
+  useEffect(() => {
+    if (user?.is_public !== undefined) {
+      setVisibility(user.is_public);
+    }
+  }, [user]);
+
+  const {
+    uploadData: updateProfile,
+    submitting: saving,
+    success: savedSuccess,
+  } = usePost();
+
+  useEffect(() => {
+    if (savedSuccess) {
+      setSocialModal(false);
+      setRefresh((prev) => prev + 1);
+    }
+  }, [savedSuccess]);
+
+  const submitSocialLinks = () => {
+    const socialLinks = userSocialLinks.reduce(
+      (acc, link) => {
+        if (link.platform && link.url) {
+          acc[link.platform] = link.url;
+        }
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+
+    updateProfile({
+      api: "users",
+      id: user.id,
+      method: "PATCH",
+      params: { social_links: socialLinks },
+    });
+    setSocialModal(false);
+  };
+
+  const handleVisibilitySave = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.checked;
+    console.log("New visibility:", visibility);
+    updateProfile({
+      api: "users",
+      id: user.id,
+      method: "PATCH",
+      params: { is_public: value },
+    });
+    setVisibilityModal(false);
+    // Optionally refresh user data here
+  };
+  console.log(visibility);
+
+  const socialLinks = user?.social_links || {};
+  const links =
+    Object.entries(socialLinks).map(([key, value]) => ({
+      platform: key,
+      url: value,
+    })) || [];
+
+  useEffect(() => {
+    setUserSocialLinks(links as { platform: string; url: string }[]);
+  }, [user]);
+
+  return (
+    <Stack gap={30}>
+      {/* Social Links */}
+      <Stack gap={0}>
+        <TitleText>Social Media Links</TitleText>
+        {userSocialLinks.length > 0 ? (
+          <SocialMediaLinksTable links={userSocialLinks} />
+        ) : (
+          <Text className="subtext">Add your social media profiles here.</Text>
+        )}
+        <Flex justify="flex-end" mt="md">
+          <Button
+            variant="outline"
+            onClick={() => setSocialModal(true)}
+            leftSection={userSocialLinks.length > 0 ? <HiPencil /> : <HiPlus />}
+          >
+            {userSocialLinks.length > 0 ? "Update Links" : "Add Links"}
+          </Button>
+        </Flex>
+      </Stack>
+
+      {/* User Profile */}
+      <Stack gap={0}>
+        <TitleText>Manage Profile</TitleText>
+        <Card p="lg" radius="md" withBorder>
+          <Stack gap={10} mt="md">
+            <Group justify="space-between" align="center">
+              <Stack gap={0}>
+                <Text className="title">Toggle Profile Visibility</Text>
+                <Text className="subtext">
+                  Make your profile {user?.is_public ? "private" : "public"}.
+                </Text>
+              </Stack>
+              <Switch
+                checked={visibility}
+                onChange={handleVisibilitySave}
+                color="var(--mantine-color-gray-2)"
+                size="lg"
+                onLabel={
+                  <FaLockOpen size={12} color="var(--mantine-color-teal-6)" />
+                }
+                offLabel={
+                  <FaLock size={12} color="var(--mantine-color-teal-6)" />
+                }
+              />
+            </Group>
+          </Stack>
+          <Divider my="md" />
+          <Stack gap={10}>
+            <Group justify="space-between">
+              <Stack gap={0}>
+                <Text className="title">Update profile</Text>
+                <Text className="subtext">
+                  Modify the profile name and description
+                </Text>
+              </Stack>
+              <Button variant="outline" onClick={() => setUpdateModal(true)}>
+                Update
+              </Button>
+            </Group>
+          </Stack>
+
+          {/* Modals */}
+          <ModalConfirm
+            opened={updateModal}
+            onClose={() => setUpdateModal(false)}
+            title="Update Profile Information"
+            buttonText="Update"
+            size="xl"
+            showFooterActions={false}
+            onConfirm={() => {}}
+          >
+            <UpdateProfileForm
+              user={user}
+              onCancel={() => setUpdateModal(false)}
+              onSuccess={() => {
+                setUpdateModal(false);
+                setRefresh((prev) => prev + 1);
+              }}
+            />
+          </ModalConfirm>
+
+          <ModalConfirm
+            opened={socialModal}
+            onClose={() => setSocialModal(false)}
+            title="Social Media Links"
+            buttonText="Save Links"
+            size="xl"
+            onConfirm={submitSocialLinks}
+          >
+            <SocialMediaLinksForm
+              links={userSocialLinks}
+              setLinks={setUserSocialLinks}
+              loading={saving}
+            />
+          </ModalConfirm>
+        </Card>
+      </Stack>
+    </Stack>
+  );
+};
+
+const SocialMediaLinksForm = ({
+  links = [],
+  setLinks,
+  loading,
+}: {
+  links: { platform: string; url: string }[];
+  setLinks: (val: any) => void;
+  loading: boolean;
+}) => {
+  const handleChange = (index: number, field: string, value: string) => {
+    const newLinks = [...links];
+    if (field === "url") {
+      // Ensure URL starts with http:// or https://
+      if (
+        value &&
+        !value.startsWith("http://") &&
+        !value.startsWith("https://")
+      ) {
+        value = "https://" + value;
+      }
+    }
+    (newLinks[index] as any)[field] = value;
+    setLinks(newLinks);
+  };
+
+  const addLink = () => {
+    setLinks([...links, { platform: "", url: "" }]);
+  };
+
+  const removeLink = (index: number) => {
+    const newLinks = [...links];
+    newLinks.splice(index, 1);
+    setLinks(newLinks);
+  };
+
+  return (
+    <Stack>
+      {links?.map((link, index) => (
+        <Group key={index} grow align="center" gap="md">
+          <TextInput
+            label="Platform"
+            placeholder="e.g. Twitter"
+            value={link.platform}
+            onChange={(e) => handleChange(index, "platform", e.target.value)}
+          />
+          <TextInput
+            label="URL"
+            placeholder="https://twitter.com/yourhandle"
+            value={link.url}
+            onChange={(e) => handleChange(index, "url", e.target.value)}
+          />
+          <Button
+            color="red"
+            variant="light"
+            mt="lg"
+            onClick={() => removeLink(index)}
+          >
+            Remove
+          </Button>
+        </Group>
+      ))}
+      <Button variant="outline" onClick={addLink} loading={loading}>
+        Add Social Media Link
+      </Button>
+    </Stack>
+  );
+};
+
+const SocialMediaLinksTable = ({
+  links,
+}: {
+  links: { platform: string; url: string }[];
+}) => {
+  return (
+    <Card withBorder>
+      <Stack>
+        {links.map((link, index) => (
+          <Flex key={index} justify="space-between">
+            <Text fw={500}>{beautify(link.platform)}</Text>
+            <Text size="sm" color="blue">
+              <a href={link.url} target="_blank" rel="noopener noreferrer">
+                {link.url}
+              </a>
+            </Text>
+          </Flex>
+        ))}
+      </Stack>
+    </Card>
+  );
+};

--- a/src/pages/Users/UserProfileSettingsPage.tsx
+++ b/src/pages/Users/UserProfileSettingsPage.tsx
@@ -74,6 +74,9 @@ const SocialLinksTab = ({
   const [updateModal, setUpdateModal] = useState(false);
   const [visibilityModal, setVisibilityModal] = useState(false);
   const [visibility, setVisibility] = useState(true);
+  const [makePrivateConfirmOpened, setMakePrivateConfirmOpened] =
+    useState(false);
+  const [makePublicConfirmOpened, setMakePublicConfirmOpened] = useState(false);
 
   useEffect(() => {
     if (user?.is_public !== undefined) {
@@ -124,9 +127,35 @@ const SocialLinksTab = ({
       params: { is_public: value },
     });
     setVisibilityModal(false);
-    // Optionally refresh user data here
+    refreshProfile();
+  };
+
+  const refreshProfile = () => {
+    setRefresh((prev) => prev + 1);
   };
   console.log(visibility);
+
+  const handleMakePrivate = () => {
+    updateProfile({
+      api: "users",
+      id: user.id,
+      method: "PATCH",
+      params: { is_public: false },
+    });
+    setMakePrivateConfirmOpened(false);
+    refreshProfile();
+  };
+
+  const handleMakePublic = () => {
+    updateProfile({
+      api: "users",
+      id: user.id,
+      method: "PATCH",
+      params: { is_public: true },
+    });
+    setMakePublicConfirmOpened(false);
+    refreshProfile();
+  };
 
   const socialLinks = user?.social_links || {};
   const links =
@@ -172,18 +201,31 @@ const SocialLinksTab = ({
                   Make your profile {user?.is_public ? "private" : "public"}.
                 </Text>
               </Stack>
-              <Switch
-                checked={visibility}
-                onChange={handleVisibilitySave}
-                color="var(--mantine-color-gray-2)"
-                size="lg"
-                onLabel={
-                  <FaLockOpen size={12} color="var(--mantine-color-teal-6)" />
-                }
-                offLabel={
-                  <FaLock size={12} color="var(--mantine-color-teal-6)" />
-                }
-              />
+              {/* Visibility Toggle */}
+              <Stack gap={10} mt="md">
+                <Group justify="space-between" align="center">
+                  <Stack gap={0}></Stack>
+                  {visibility ? (
+                    <Button
+                      variant="outline"
+                      color="black"
+                      onClick={() => setMakePrivateConfirmOpened(true)}
+                      leftSection={<FaLock />}
+                    >
+                      Private
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      color="green"
+                      onClick={() => setMakePublicConfirmOpened(true)}
+                      leftSection={<FaLockOpen />}
+                    >
+                      Public
+                    </Button>
+                  )}
+                </Group>
+              </Stack>
             </Group>
           </Stack>
           <Divider my="md" />
@@ -195,7 +237,11 @@ const SocialLinksTab = ({
                   Modify the profile name and description
                 </Text>
               </Stack>
-              <Button variant="outline" onClick={() => setUpdateModal(true)}>
+              <Button
+                variant="outline"
+                onClick={() => setUpdateModal(true)}
+                leftSection={<HiPencil />}
+              >
                 Update
               </Button>
             </Group>
@@ -219,6 +265,32 @@ const SocialLinksTab = ({
                 setRefresh((prev) => prev + 1);
               }}
             />
+          </ModalConfirm>
+
+          <ModalConfirm
+            opened={makePrivateConfirmOpened}
+            onClose={() => setMakePrivateConfirmOpened(false)}
+            title="Make Profile Private"
+            buttonText="Confirm"
+            buttonColor="black"
+            onConfirm={handleMakePrivate}
+            leftSection={<FaLock />}
+          >
+            Are you sure you want to make your profile <b>private</b>? It will
+            no longer be publicly visible.
+          </ModalConfirm>
+
+          <ModalConfirm
+            opened={makePublicConfirmOpened}
+            onClose={() => setMakePublicConfirmOpened(false)}
+            title="Make Profile Public"
+            buttonText="Confirm"
+            buttonColor="green"
+            onConfirm={handleMakePublic}
+            leftSection={<FaLockOpen />}
+          >
+            Are you sure you want to make your profile <b>public</b>? It will be
+            visible to everyone.
           </ModalConfirm>
 
           <ModalConfirm

--- a/src/pages/Users/UserProfileSettingsPage.tsx
+++ b/src/pages/Users/UserProfileSettingsPage.tsx
@@ -5,24 +5,20 @@ import {
   Flex,
   Group,
   Stack,
-  Switch,
   Text,
   TextInput,
 } from "@mantine/core";
 import { useEffect, useState, useContext } from "react";
 import { HiPencil, HiPlus } from "react-icons/hi2";
-import { useParams } from "react-router-dom";
 
 import TitleText from "@/components/TitleText";
 import { ModalConfirm } from "@/components/Elements/Modals";
-import { beautify, useGetApp } from "@/utils/helpers";
+import { beautify } from "@/utils/helpers";
 import usePost from "@/utils/usePost";
 import { MenuContext } from "@/components/Layouts/DashboardLayout";
 import { useAuth } from "@/utils/AuthContext";
 import useGet from "@/utils/useGet";
-import { BiTransferAlt } from "react-icons/bi";
 import { UpdateProfileForm } from "@/components/Forms/UpdateProfileForm";
-import { publicDecrypt } from "crypto";
 import { FaLock } from "react-icons/fa6";
 import { FaLockOpen } from "react-icons/fa";
 
@@ -65,14 +61,11 @@ const SocialLinksTab = ({
   user: any;
   setRefresh: React.Dispatch<React.SetStateAction<number>>;
 }) => {
-  console.log("User in SocialLinksTab:", user);
-
   const [userSocialLinks, setUserSocialLinks] = useState<
     { platform: string; url: string }[]
   >([]);
   const [socialModal, setSocialModal] = useState(false);
   const [updateModal, setUpdateModal] = useState(false);
-  const [visibilityModal, setVisibilityModal] = useState(false);
   const [visibility, setVisibility] = useState(true);
   const [makePrivateConfirmOpened, setMakePrivateConfirmOpened] =
     useState(false);
@@ -117,23 +110,9 @@ const SocialLinksTab = ({
     setSocialModal(false);
   };
 
-  const handleVisibilitySave = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.currentTarget.checked;
-    console.log("New visibility:", visibility);
-    updateProfile({
-      api: "users",
-      id: user.id,
-      method: "PATCH",
-      params: { is_public: value },
-    });
-    setVisibilityModal(false);
-    refreshProfile();
-  };
-
   const refreshProfile = () => {
     setRefresh((prev) => prev + 1);
   };
-  console.log(visibility);
 
   const handleMakePrivate = () => {
     updateProfile({
@@ -204,7 +183,7 @@ const SocialLinksTab = ({
               {/* Visibility Toggle */}
               <Stack gap={10} mt="md">
                 <Group justify="space-between" align="center">
-                  <Stack gap={0}></Stack>
+                  <Stack gap={0} />
                   {visibility ? (
                     <Button
                       variant="outline"
@@ -331,7 +310,8 @@ const SocialMediaLinksForm = ({
         !value.startsWith("http://") &&
         !value.startsWith("https://")
       ) {
-        value = "https://" + value;
+        const newValue = `https://${value}`;
+        (newLinks[index] as any)[field] = newValue;
       }
     }
     (newLinks[index] as any)[field] = value;


### PR DESCRIPTION
# Description
This PR updates the User Profile and User Profile Settings pages.
Users can now edit their name, email, organization, bio, and social links.
Changes appear immediately on the profile page after saving.
A new switch allows users to make their profile public or private with a confirmation modal.

#Type of change 
  - [ ] New feature (non-breaking change which adds functionality)

## Trello Ticket ID
https://app.clickup.com/t/869a03twr

## How Can This Been Tested?
-Go to the user profile page then click the edit button to navgate to the user profile settings page to edit your info.
-Save and check if changes show up instantly on the profile page.
-Add/edit social links and confirm that https:// auto-fills.
-Use the visibility switch and confirm the modal appears and the status updates.
-Type a long bio and check that you can’t go beyond the limit.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots
<img width="1035" height="587" alt="image" src="https://github.com/user-attachments/assets/5f2b1839-692f-4090-8418-32feecc66cf2" />
<img width="909" height="513" alt="image" src="https://github.com/user-attachments/assets/2b5c59a5-844f-4cc8-8c3e-f2316793eb64" />
<img width="982" height="571" alt="image" src="https://github.com/user-attachments/assets/7cc8d7d9-52b9-4d93-9734-e79696e2c1ca" />
<img width="904" height="546" alt="image" src="https://github.com/user-attachments/assets/2f70119d-ceac-4894-910e-347a4e740c48" />
<img width="954" height="602" alt="image" src="https://github.com/user-attachments/assets/fdec29cd-1231-45e2-8149-8f26ffb01444" />
