### PR TITLE
feat: added database metrics on the admin side

### DIFF
--- a/src/components/Layouts/RegisterLayoutHandler.tsx
+++ b/src/components/Layouts/RegisterLayoutHandler.tsx
@@ -12,6 +12,7 @@ import { Table } from "../Elements/CustomTable";
 import { Button, Stack } from "@mantine/core";
 import TitleText from "../TitleText";
 import { SimpleDetailsCard } from "../Cards/DetailsCard";
+import { LineLargeMetricChart } from "../Elements/Charts";
 // import DetailsCard from "../common/DetailsCards";
 // import { TableFilter } from "../common/TableFilter";
 // interface TExportData {
@@ -56,12 +57,15 @@ const RegisterLayoutHandler = (props: any) => {
     createTitle,
     metaData,
     tableTotals,
+    graphData,
+    fetchingGraphData,
     // externalFilters,
     initialFilters,
     isExternalRoute,
     showTitle,
     apiRoute,
     dataParent,
+    graphTitle,
   } =
     source && registerHooks[source]
       ? registerHooks[source]({ ...register_params, ...params, status })
@@ -118,6 +122,9 @@ const RegisterLayoutHandler = (props: any) => {
   // };
 
   function getTitle() {
+    if (tableTitle) {
+      return tableTitle;
+    }
     return `${tableTitle || beautify(source)} ${filters?.stringValue || "List"} `;
   }
 
@@ -174,6 +181,21 @@ const RegisterLayoutHandler = (props: any) => {
         />
       )}
 
+      {graphData && (
+        <LineLargeMetricChart
+          title={graphTitle || getTitle()}
+          data={graphData}
+          showAllXValues
+          filters={filters}
+          setFilters={setFilter}
+          // setFilters={(data) => setFilter({ filters, ...data })}
+          height={250}
+          valueFormatter={(value) => `${value}`}
+          // (setFilters={() => {}}
+          // currentChart={bigChart}
+          isLoading={fetchingGraphData || registerData?.loading}
+        />
+      )}
       <Table
         title={title || getTitle()}
         loading={loading}

--- a/src/hooks/useDatabases.tsx
+++ b/src/hooks/useDatabases.tsx
@@ -7,9 +7,20 @@ import { Link } from "react-router-dom";
 
 export const useDatabases = () => {
   const { getData: getMetaData, data: metaDataData } = useGet();
+  const {
+    getData: getDatabaseGraphData,
+    data: databaseGraphData,
+    loading: fetchingGraphData,
+  } = useGet();
   useEffect(() => {
     getMetaData({
       api: `${DATABASE_API_URL}/databases/stats`,
+      isExternal: true,
+    });
+  }, []);
+  useEffect(() => {
+    getDatabaseGraphData({
+      api: `${DATABASE_API_URL}/databases/graph`,
       isExternal: true,
     });
   }, []);
@@ -81,6 +92,18 @@ export const useDatabases = () => {
 
   const isExternalRoute = true;
   const showTitle = false;
+  const tableTitle = "Database Summary";
+  const graphTitle = "graphTitle";
 
-  return { tableColumns, tableData, isExternalRoute, showTitle, metaData };
+  return {
+    tableColumns,
+    tableData,
+    isExternalRoute,
+    showTitle,
+    metaData,
+    graphData: databaseGraphData?.data?.graph_data,
+    fetchingGraphData,
+    tableTitle,
+    graphTitle,
+  };
 };


### PR DESCRIPTION
# Description

This PR introduces a metrics summary and line chart visualization for platform databases. The metrics section displays total databases, along with MySQL and PostgreSQL breakdowns. A trend chart is also included, with date range filtering support for better insights into database creation trends over time.

## Type of change


- [ ] New feature (non-breaking change which adds functionality)


## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?
Navigate to the Database List page.

Confirm that a metrics summary section is visible above the table.

Ensure that the line chart shows database creation trends over time.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots
<img width="1065" height="376" alt="graph" src="https://github.com/user-attachments/assets/af1bbc6f-382a-43d8-a506-bb79c24d11a4" />


