### PR TITLE
feat: add badges for hugging face and mlflow deployments

### DIFF
--- a/src/components/Cards/AppsCard.tsx
+++ b/src/components/Cards/AppsCard.tsx
@@ -1,18 +1,32 @@
 import { beautify } from "@/utils/helpers";
+import { MODAL_SERVERS } from "@/utils/constants";
 import { Anchor, Card, Flex, Group, Pill, Stack, Text } from "@mantine/core";
 import { GoClock } from "react-icons/go";
 import { HiMiniCubeTransparent } from "react-icons/hi2";
 import { PiCubeLight, PiShareFatThin } from "react-icons/pi";
 import { SiJupyter } from "react-icons/si";
+import React from "react";
 
 const AppsCard = (props: any) => {
   const { app, project_id } = props;
+
+  const modalServerEntry =
+    app.model_server &&
+    MODAL_SERVERS.find((server) => server.value === app.model_server);
+
+  const modalServerIcon = modalServerEntry?.icon;
+  const modalServerColor = modalServerEntry?.color || "gray";
 
   return (
     <Card p="md" radius="md" withBorder>
       <Group wrap="nowrap" gap={10}>
         {app.is_notebook ? (
           <SiJupyter size={35} color="#f57c00" />
+        ) : modalServerIcon ? (
+          React.createElement(modalServerIcon, {
+            size: 35,
+            color: modalServerColor,
+          })
         ) : (
           <PiCubeLight size={35} color="gray" />
         )}
@@ -59,7 +73,7 @@ const AppsCard = (props: any) => {
       <Group justify="space-between" mt="md">
         <Group gap={10} align="center">
           {app?.is_notebook && (
-            <Pill w="fit-content">
+            <Pill w="fit-content" py={2}>
               <Flex
                 gap={5}
                 wrap="nowrap"
@@ -74,6 +88,24 @@ const AppsCard = (props: any) => {
               </Flex>
             </Pill>
           )}
+
+          {app.model_server && (
+            <Pill w="fit-content" py={2}>
+              <Flex gap={5} align="center" wrap="nowrap">
+                {modalServerIcon &&
+                  React.createElement(modalServerIcon, {
+                    size: 13,
+                    color: modalServerColor,
+                  })}
+                <Text size="xs" truncate>
+                  {app.model_server === "HUGGINGFACE_SERVER"
+                    ? beautify(app.task)
+                    : modalServerEntry?.label}
+                </Text>
+              </Flex>
+            </Pill>
+          )}
+
           <Flex gap={5} c="var(--mantine-color-dark-3)" align="center">
             <GoClock size={13} />
             <Text size="xs">{app.age}</Text>


### PR DESCRIPTION
# Description

- This PR improves the visual presentation of app cards for Hugging Face, MLflow, and other modal server deployments.
- For Hugging Face deployments, the card displays the model's task in a pill; for MLflow and other servers, their names are shown in the pill.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Clickup Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?

- Run this branch locally.
- Deploy apps with different modal servers (Hugging Face, MLflow, Sklearn, etc.).
- Confirm that the correct icon and color appear for each modal server.
- For Hugging Face, check that the task is shown in the pill; for others, the server name is shown.
- Verify pill content is vertically centered and visually consistent.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="2926" height="918" alt="Screenshot 2025-08-08 at 9 27 49 AM" src="https://github.com/user-attachments/assets/cddce5a2-f4d2-43e7-bbe8-1c733be7a639" />
