### PR TITLE
feat(socials): add landing, explore and tags detail pages

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -48,6 +48,8 @@ const ProjectDetailsPage = React.lazy(
   () => import("./pages/Projects/ProjectDetailsPage"),
 );
 const AdminDashboard = React.lazy(() => import("./pages/admin/DashboardPage"));
+const ExplorePage = React.lazy(() => import("./pages/ExplorePage"));
+const TagDetailsPage = React.lazy(() => import("./pages/TagDetailsPage"));
 const GenericRegister = React.lazy(
   () => import("./components/Layouts/GenericRegister"),
 );
@@ -71,6 +73,8 @@ export const DashboardRoutes = [
   { path: "/health", element: <HealthCheck /> },
   { path: "/login", element: <LoginPage /> },
   { path: "/", element: <LandingPage /> },
+  { path: "/explore", element: <ExplorePage /> },
+  { path: "/tags/:tagName", element: <TagDetailsPage /> },
   { path: "/profile/:user_id", element: <UserProfilePage /> },
   { path: "/users/profile/settings", element: <UserProfileSettingsPage /> },
   { path: "/:username", element: <UserProfilePage /> },

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -18,7 +18,9 @@ const ProjectSettingsPage = React.lazy(
 const UserProfileSettingsPage = React.lazy(
   () => import("./pages/Users/UserProfileSettingsPage"),
 );
-
+const ProjectListPage = React.lazy(
+  () => import("./pages/Projects/ProjectListPage"),
+);
 const ProjectUsers = React.lazy(() => import("./pages/Projects/ProjectUsers"));
 const ProjectMetrics = React.lazy(
   () => import("./pages/Projects/ProjectMetrics"),
@@ -73,12 +75,14 @@ export const DashboardRoutes = [
   { path: "/users/profile/settings", element: <UserProfileSettingsPage /> },
   { path: "/:username", element: <UserProfilePage /> },
   // Projects
+  { path: "/projects", element: <ProjectListPage /> },
   { path: "/projects/create", element: <CreateProjectForm /> },
   { path: "/projects/:project_id", element: <ProjectDetailsPage /> },
   { path: "/projects/:project_id/apps", element: <AppsListPage /> },
   { path: "/projects/:project_id/settings", element: <ProjectSettingsPage /> },
   { path: "/projects/:project_id/users", element: <ProjectUsers /> },
   { path: "/projects/:project_id/metrics", element: <ProjectMetrics /> },
+
   // Applications
   { path: "/projects/:project_id/apps/create", element: <CreateAppForm /> },
   { path: "/projects/:project_id/apps/:app_id", element: <AppDetailPage /> },

--- a/src/components/Cards/AppsCard.tsx
+++ b/src/components/Cards/AppsCard.tsx
@@ -1,8 +1,9 @@
 import { beautify } from "@/utils/helpers";
 import { Anchor, Card, Flex, Group, Pill, Stack, Text } from "@mantine/core";
+import { FiLayers } from "react-icons/fi";
 import { GoClock } from "react-icons/go";
 import { HiMiniCubeTransparent } from "react-icons/hi2";
-import { PiCubeLight, PiShareFatThin } from "react-icons/pi";
+import { PiShareFatThin } from "react-icons/pi";
 import { SiJupyter } from "react-icons/si";
 
 const AppsCard = (props: any) => {
@@ -14,7 +15,7 @@ const AppsCard = (props: any) => {
         {app.is_notebook ? (
           <SiJupyter size={35} color="#f57c00" />
         ) : (
-          <PiCubeLight size={35} color="gray" />
+          <FiLayers size={20} color="gray" />
         )}
         <Stack gap={3} flex={1}>
           <Anchor

--- a/src/components/Cards/ProjectsCard.tsx
+++ b/src/components/Cards/ProjectsCard.tsx
@@ -17,11 +17,12 @@ import { HiLockClosed } from "react-icons/hi2";
 import { RiBookLine } from "react-icons/ri";
 import { GoClock } from "react-icons/go";
 import { LiaUserSolid } from "react-icons/lia";
-import { IoPersonAddOutline, IoRocketOutline } from "react-icons/io5";
+import { IoPersonAddOutline } from "react-icons/io5";
 import usePost from "@/utils/usePost";
 import { API_PROJECTS } from "@/utils/apis";
 import { useNavigate } from "react-router-dom";
 import { formatAgo, formatPlural } from "@/utils/helpers";
+import { FiLayers } from "react-icons/fi";
 
 export type ProjectUserRecord = {
   user: {
@@ -220,11 +221,8 @@ const ProjectsCard = (props: any) => {
               color="theme.dark"
               w="fit-content"
             >
-              <Flex gap={2} align="center" justify="center" wrap="nowrap">
-                <IoRocketOutline
-                  size={14}
-                  color="var(--mantine-color-dimmed)"
-                />
+              <Flex gap={3} align="center" justify="center" wrap="nowrap">
+                <FiLayers size={12} color="var(--mantine-color-dimmed)" />
                 <Text size="sm" c="dimmed" className="no-wrap">
                   {formatPlural(project.apps_count, "app")}
                 </Text>

--- a/src/components/Elements/Elements.tsx
+++ b/src/components/Elements/Elements.tsx
@@ -20,7 +20,7 @@ import {
 } from "@mantine/core";
 import { TbCopy } from "react-icons/tb";
 import { ReactNode, useContext, useEffect, useState } from "react";
-import { PiCubeLight, PiFlask } from "react-icons/pi";
+import { PiFlask } from "react-icons/pi";
 import { GoDatabase } from "react-icons/go";
 import { RiRobot2Line } from "react-icons/ri";
 import { ModalConfirm } from "@/components/Elements/Modals";
@@ -32,6 +32,7 @@ import { IoIosArrowDown } from "react-icons/io";
 import { returnObject } from "@/utils/helpers";
 import useGet from "@/utils/useGet";
 import { MenuContext } from "../Layouts/DashboardLayout";
+import { FiLayers } from "react-icons/fi";
 
 export const LinkWithText = styled(Link)`
   display: flex;
@@ -181,7 +182,7 @@ export const AddServiceButton = ({
   const menuItems = [
     {
       label: "Deploy Application",
-      icon: <PiCubeLight />,
+      icon: <FiLayers />,
       onClick: () => navigate(`/projects/${project_id}/apps/create`),
     },
     ...returnObject(!dontShowDatabase, [

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,6 +35,7 @@ import { Logo, UserDropDown } from "./Common";
 import { Link, useNavigate } from "react-router-dom";
 import Search from "./Elements/Search";
 import { useAuth } from "@/utils/AuthContext";
+import { IoAirplaneOutline } from "react-icons/io5";
 
 interface HeaderProps {
   opened: boolean;
@@ -63,6 +64,19 @@ export const DashboardHeader = ({ opened, toggle }: HeaderProps) => {
               Admin
             </Pill>
           )}
+
+          <Link
+            to="/explore"
+            style={{ textDecoration: "none", paddingLeft: "10px" }}
+          >
+            <Group gap={5}>
+              <Text fw={700}>Explore</Text>
+              <IoAirplaneOutline
+                size={18}
+                style={{ transform: "rotate(315deg)" }}
+              />
+            </Group>
+          </Link>
         </Group>
         <Group>
           <Search />

--- a/src/components/Lists/CompactProjectsList.tsx
+++ b/src/components/Lists/CompactProjectsList.tsx
@@ -1,0 +1,283 @@
+import React, { useEffect, useMemo } from "react";
+import {
+  Card,
+  Group,
+  Title,
+  Stack,
+  Text,
+  Badge,
+  Button,
+  Avatar,
+  Box,
+  Skeleton,
+} from "@mantine/core";
+import { FiCode, FiLock, FiUsers, FiPlus, FiLayers } from "react-icons/fi";
+import { Link } from "react-router-dom";
+import useGet from "@/utils/useGet";
+import { API_PROJECTS } from "@/utils/apis";
+import { formatAgo } from "@/utils/helpers";
+
+interface CompactProjectsListProps {
+  title?: string;
+  maxItems?: number;
+  showCreateButton?: boolean;
+  showPrivacyIcons?: boolean;
+}
+
+const CompactProjectsList = ({
+  title = "Your Projects",
+  maxItems = 8,
+  showCreateButton = true,
+  showPrivacyIcons = true,
+}: CompactProjectsListProps) => {
+  const { data: projectsData, getData, loading } = useGet();
+
+  useEffect(() => {
+    getData({
+      api: `${API_PROJECTS}`,
+      params: { page: 1, per_page: maxItems },
+    });
+  }, []);
+
+  const projects = useMemo(() => {
+    if (!projectsData?.data?.projects) {
+      return [];
+    }
+
+    const owned = projectsData.data.projects || [];
+    const invited = (projectsData.data.pending_invitations || []).map(
+      (project: any) => ({
+        ...project,
+        is_invited: true,
+      }),
+    );
+
+    return [...invited, ...owned].slice(0, maxItems);
+  }, [projectsData, maxItems]);
+
+  const renderProjectItem = (project: any) => (
+    <Card
+      key={project.id}
+      p="xs"
+      radius="md"
+      withBorder
+      component={Link}
+      to={`/projects/${project.id}`}
+      style={{
+        textDecoration: "none",
+        color: "inherit",
+        cursor: "pointer",
+        transition: "all 0.2s ease",
+        background: "linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%)",
+        border: "1px solid #dee2e6",
+        position: "relative",
+        overflow: "hidden",
+        minHeight: "75px",
+      }}
+      className="hover:shadow-md"
+    >
+      {/* Privacy indicator overlay */}
+      {showPrivacyIcons && (
+        <Box
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            zIndex: 1,
+          }}
+        >
+          {project.is_invited && (
+            <Badge size="xs" color="orange" variant="filled">
+              Invited
+            </Badge>
+          )}
+          {!project.is_invited && (
+            <Group gap={5} align="center" justify="flex-end">
+              {project.is_private && (
+                <FiLock size={10} style={{ color: "#6c757d" }} />
+              )}
+              <FiLayers size={10} style={{ color: "#6c757d" }} />
+              <Text size="xs" fw={500} style={{ color: "#6c757d" }}>
+                {project.apps_count || 0} apps
+              </Text>
+            </Group>
+          )}
+        </Box>
+      )}
+
+      <Group align="center" gap="xs" style={{ height: "100%" }}>
+        <Avatar
+          size="sm"
+          radius="sm"
+          color="blue"
+          variant="gradient"
+          gradient={{ from: "blue", to: "cyan" }}
+        >
+          <FiCode size={14} />
+        </Avatar>
+
+        <Box style={{ flex: 1, minWidth: 0 }}>
+          <Group justify="space-between" align="flex-start" mb={2}>
+            <Text
+              size="sm"
+              fw={600}
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                flex: 1,
+                lineHeight: 1.2,
+              }}
+            >
+              {project.name}
+            </Text>
+          </Group>
+
+          {/* Project Description */}
+          {project.description && (
+            <Text
+              size="xs"
+              c="dimmed"
+              mb={4}
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                lineHeight: 1.3,
+              }}
+            >
+              {project.description}
+            </Text>
+          )}
+
+          <Group justify="space-between" align="center">
+            <Group gap="sm">
+              {/* Users Count */}
+              {project.users_count && (
+                <Group gap={2}>
+                  <FiUsers size={10} color="#6c757d" />
+                  <Text size="xs" c="dimmed" fw={500}>
+                    {project.users_count}
+                  </Text>
+                </Group>
+              )}
+
+              {/* Last Updated */}
+              {project.updated_at && (
+                <Text size="xs" c="dimmed">
+                  {formatAgo(project.updated_at)}
+                </Text>
+              )}
+            </Group>
+          </Group>
+        </Box>
+      </Group>
+    </Card>
+  );
+
+  const renderSkeleton = () => (
+    <Stack gap="xs">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Card
+          key={index}
+          p="xs"
+          radius="md"
+          withBorder
+          style={{ minHeight: "75px" }}
+        >
+          <Group gap="xs" style={{ height: "100%" }}>
+            <Skeleton height={32} width={32} radius="sm" />
+            <Box style={{ flex: 1 }}>
+              <Skeleton height={14} mb={2} width="70%" />
+              <Skeleton height={12} mb={4} width="85%" />
+              <Group justify="space-between">
+                <Group gap="sm">
+                  <Skeleton height={10} width={20} />
+                  <Skeleton height={10} width={40} />
+                </Group>
+              </Group>
+            </Box>
+          </Group>
+        </Card>
+      ))}
+    </Stack>
+  );
+
+  return (
+    <Card p="md" withBorder radius="lg">
+      <Group mb="sm" justify="space-between">
+        <Group gap="xs">
+          <FiCode size={18} />
+          <Title order={4} size="md">
+            {title}
+          </Title>
+        </Group>
+
+        {showCreateButton && (
+          <Button
+            component={Link}
+            to="/projects/create"
+            variant="light"
+            size="xs"
+            color="dark"
+            leftSection={<FiPlus size={14} />}
+          >
+            Add
+          </Button>
+        )}
+      </Group>
+
+      {loading ? (
+        renderSkeleton()
+      ) : projects.length > 0 ? (
+        <Stack gap="xs">
+          {projects.map(renderProjectItem)}
+
+          {projectsData?.data?.pagination?.total > maxItems && (
+            <Button
+              component={Link}
+              to="/projects"
+              variant="subtle"
+              size="xs"
+              fullWidth
+              mt="sm"
+            >
+              +{projectsData.data.pagination.total - maxItems} more
+            </Button>
+          )}
+        </Stack>
+      ) : (
+        <Stack gap="md" ta="center" py="lg">
+          <Box>
+            <Avatar
+              size="lg"
+              radius="md"
+              color="gray"
+              variant="light"
+              mx="auto"
+              mb="sm"
+            >
+              <FiCode size={20} />
+            </Avatar>
+            <Text size="sm" c="dimmed" fw={500}>
+              No projects yet
+            </Text>
+          </Box>
+          {showCreateButton && (
+            <Button
+              component={Link}
+              to="/projects/new"
+              variant="light"
+              size="xs"
+              leftSection={<FiPlus size={14} />}
+            >
+              Create Project
+            </Button>
+          )}
+        </Stack>
+      )}
+    </Card>
+  );
+};
+
+export default CompactProjectsList;

--- a/src/components/Navbars/LeftMenu.tsx
+++ b/src/components/Navbars/LeftMenu.tsx
@@ -35,9 +35,10 @@ import {
 } from "react-icons/io5";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { LuLogs } from "react-icons/lu";
-import { PiCubeLight, PiFlask } from "react-icons/pi";
+import { PiFlask } from "react-icons/pi";
 import { SelectProject } from "../Elements/Elements";
 import { HiOutlineDatabase } from "react-icons/hi";
+import { FiLayers } from "react-icons/fi";
 
 export type TLeftMenuType =
   | "home"
@@ -123,7 +124,7 @@ const LeftMenu = React.memo(
         },
         {
           label: "Applications",
-          icon: PiCubeLight,
+          icon: FiLayers,
           key: "applications",
           link: "/admin/apps/list",
         },
@@ -264,7 +265,7 @@ const LeftMenu = React.memo(
         },
         {
           label: "Applications",
-          icon: PiCubeLight,
+          icon: FiLayers,
           key: "applications",
           link: `/projects/${project_id}/apps`,
         },

--- a/src/components/Trending/SuggestedUsers.tsx
+++ b/src/components/Trending/SuggestedUsers.tsx
@@ -74,8 +74,6 @@ export default function SuggestedUsers({
     if (onFollow) {
       onFollow(username);
     }
-    // Default behavior - could integrate with API
-    console.log(`Following user: ${username}`);
   };
 
   return (
@@ -126,11 +124,11 @@ export default function SuggestedUsers({
                       Follow
                     </Button>
                   </Group>
-                  
+
                   <Text size="xs" c="dimmed" mb={4} style={{ lineHeight: 1.3 }}>
                     {user.bio}
                   </Text>
-                  
+
                   {showTags && (
                     <Group gap="xs" mb={4}>
                       {user.tags.map((tag) => (
@@ -140,7 +138,7 @@ export default function SuggestedUsers({
                       ))}
                     </Group>
                   )}
-                  
+
                   <Group gap="sm">
                     <Text size="xs" c="dimmed">
                       {user.followers} followers

--- a/src/components/Trending/SuggestedUsers.tsx
+++ b/src/components/Trending/SuggestedUsers.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import {
+  Card,
+  Group,
+  Title,
+  Stack,
+  Badge,
+  Text,
+  Avatar,
+  Button,
+  Divider,
+  Anchor,
+} from "@mantine/core";
+import { FiUserPlus } from "react-icons/fi";
+
+interface SuggestedUser {
+  name: string;
+  username: string;
+  bio: string;
+  followers: number;
+  projects: number;
+  avatar: string;
+  tags: string[];
+  link?: string;
+}
+
+interface SuggestedUsersProps {
+  users?: SuggestedUser[];
+  title?: string;
+  showTags?: boolean;
+  onFollow?: (username: string) => void;
+}
+
+const defaultUsers: SuggestedUser[] = [
+  {
+    name: "Emily Rodriguez",
+    username: "emily-dev",
+    bio: "Frontend architect specializing in React and TypeScript",
+    followers: 892,
+    projects: 24,
+    avatar: "https://github.com/identicons/emily-dev.png",
+    tags: ["React", "TypeScript"],
+    link: "/users/emily-dev",
+  },
+  {
+    name: "David Kim",
+    username: "david-k8s",
+    bio: "Kubernetes expert and cloud infrastructure engineer",
+    followers: 567,
+    projects: 18,
+    avatar: "https://github.com/identicons/david-k8s.png",
+    tags: ["Kubernetes", "DevOps"],
+    link: "/users/david-k8s",
+  },
+  {
+    name: "Maria Santos",
+    username: "maria-ai",
+    bio: "Machine learning engineer building scalable AI solutions",
+    followers: 1240,
+    projects: 31,
+    avatar: "https://github.com/identicons/maria-ai.png",
+    tags: ["ML", "Python"],
+    link: "/users/maria-ai",
+  },
+];
+
+export default function SuggestedUsers({
+  users = defaultUsers,
+  title = "Suggested for You",
+  showTags = true,
+  onFollow,
+}: SuggestedUsersProps) {
+  const handleFollow = (username: string) => {
+    if (onFollow) {
+      onFollow(username);
+    }
+    // Default behavior - could integrate with API
+    console.log(`Following user: ${username}`);
+  };
+
+  return (
+    <Card p="md" withBorder radius="lg">
+      <Group mb="sm">
+        <FiUserPlus size={18} />
+        <Title order={4} size="md">
+          {title}
+        </Title>
+      </Group>
+      <Stack gap={0}>
+        {users.map((user, index) => (
+          <React.Fragment key={user.username}>
+            <div style={{ padding: "8px 0" }}>
+              <Group mb={4} align="flex-start">
+                <Avatar src={user.avatar} size="xs" />
+                <div style={{ flex: 1 }}>
+                  <Group justify="space-between" align="flex-start" mb={2}>
+                    <div style={{ flex: 1 }}>
+                      <Anchor
+                        href={user.link || "#"}
+                        size="sm"
+                        fw={500}
+                        c="dark"
+                        style={{
+                          lineHeight: 1.2,
+                          textDecoration: "none",
+                          display: "block",
+                        }}
+                        onMouseEnter={(e) => {
+                          e.currentTarget.style.textDecoration = "underline";
+                        }}
+                        onMouseLeave={(e) => {
+                          e.currentTarget.style.textDecoration = "none";
+                        }}
+                      >
+                        {user.name}
+                      </Anchor>
+                      <Text size="xs" c="dimmed" mb={4}>
+                        @{user.username}
+                      </Text>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() => handleFollow(user.username)}
+                    >
+                      Follow
+                    </Button>
+                  </Group>
+                  
+                  <Text size="xs" c="dimmed" mb={4} style={{ lineHeight: 1.3 }}>
+                    {user.bio}
+                  </Text>
+                  
+                  {showTags && (
+                    <Group gap="xs" mb={4}>
+                      {user.tags.map((tag) => (
+                        <Badge key={tag} size="xs" variant="light">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </Group>
+                  )}
+                  
+                  <Group gap="sm">
+                    <Text size="xs" c="dimmed">
+                      {user.followers} followers
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {user.projects} projects
+                    </Text>
+                  </Group>
+                </div>
+              </Group>
+            </div>
+            {index < users.length - 1 && <Divider color="gray.3" />}
+          </React.Fragment>
+        ))}
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/Trending/TrendingProjects.tsx
+++ b/src/components/Trending/TrendingProjects.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import {
+  Card,
+  Group,
+  Title,
+  Stack,
+  Badge,
+  Text,
+  Avatar,
+  Divider,
+  Anchor,
+} from "@mantine/core";
+import { FiCode, FiStar } from "react-icons/fi";
+
+interface TrendingProject {
+  name: string;
+  author: string;
+  stars: number;
+  language: string;
+  description: string;
+  avatar: string;
+  link?: string;
+}
+
+interface TrendingProjectsProps {
+  projects?: TrendingProject[];
+  title?: string;
+  compact?: boolean;
+}
+
+const defaultProjects: TrendingProject[] = [
+  {
+    name: "ai-chatbot",
+    author: "ai-team",
+    stars: 892,
+    language: "Python",
+    description: "Advanced AI chatbot with natural language processing",
+    avatar: "https://github.com/identicons/ai-team.png",
+    link: "/projects/ai-chatbot",
+  },
+  {
+    name: "k8s-dashboard",
+    author: "devops-pro",
+    stars: 654,
+    language: "React",
+    description: "Beautiful Kubernetes cluster management dashboard",
+    avatar: "https://github.com/identicons/devops-pro.png",
+    link: "/projects/k8s-dashboard",
+  },
+  {
+    name: "auth-service",
+    author: "security-team",
+    stars: 423,
+    language: "Go",
+    description: "Microservice for authentication and authorization",
+    avatar: "https://github.com/identicons/security-team.png",
+    link: "/projects/auth-service",
+  },
+];
+
+export default function TrendingProjects({
+  projects = defaultProjects,
+  title = "Trending Projects",
+  compact = false,
+}: TrendingProjectsProps) {
+  return (
+    <Card p="md" withBorder radius="lg">
+      <Group mb="sm">
+        <FiCode size={18} />
+        <Title order={4} size="md">
+          {title}
+        </Title>
+      </Group>
+      <Stack gap={0}>
+        {projects.map((project, index) => (
+          <React.Fragment key={project.name}>
+            <div style={{ padding: "8px 0" }}>
+              <Group mb={4} align="flex-start">
+                <Avatar src={project.avatar} size="xs" />
+                <div style={{ flex: 1 }}>
+                  <Group justify="space-between" align="flex-start" mb={2}>
+                    <Anchor
+                      href={project.link || "#"}
+                      size="sm"
+                      fw={500}
+                      c="dark"
+                      style={{
+                        lineHeight: 1.2,
+                        textDecoration: "none",
+                        "&:hover": {
+                          textDecoration: "underline",
+                        },
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.textDecoration = "underline";
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.textDecoration = "none";
+                      }}
+                    >
+                      {project.name}
+                    </Anchor>
+                    <Badge size="xs" variant="light">
+                      {project.language}
+                    </Badge>
+                  </Group>
+                  <Text size="xs" c="dimmed" mb={4}>
+                    by {project.author}
+                  </Text>
+                  {!compact && (
+                    <Text
+                      size="xs"
+                      c="dimmed"
+                      mb={4}
+                      style={{ lineHeight: 1.3 }}
+                    >
+                      {project.description}
+                    </Text>
+                  )}
+                  <Group gap={4}>
+                    <FiStar size={10} color="#6c757d" />
+                    <Text size="xs" c="dimmed">
+                      {project.stars}
+                    </Text>
+                  </Group>
+                </div>
+              </Group>
+            </div>
+            {index < projects.length - 1 && <Divider color="gray.3" />}
+          </React.Fragment>
+        ))}
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/Trending/TrendingTags.tsx
+++ b/src/components/Trending/TrendingTags.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card, Group, Title, Stack, Badge, Text } from "@mantine/core";
 import { FiTrendingUp } from "react-icons/fi";
+import { Link } from "react-router-dom";
 
 interface TrendingTag {
   name: string;
@@ -36,7 +37,12 @@ export default function TrendingTags({
       <Stack gap="xs">
         {tags.map((tag) => (
           <Group key={tag.name} justify="space-between">
-            <Badge variant="light" style={{ cursor: "pointer" }}>
+            <Badge
+              variant="light"
+              component={Link}
+              to={`/tags/${tag.name}`}
+              style={{ cursor: "pointer", textDecoration: "none" }}
+            >
               #{tag.name}
             </Badge>
             <Group gap={4}>

--- a/src/components/Trending/TrendingTags.tsx
+++ b/src/components/Trending/TrendingTags.tsx
@@ -31,8 +31,10 @@ export default function TrendingTags({
   return (
     <Card p="lg" withBorder radius="lg">
       <Group mb="md">
-        <FiTrendingUp size={20} />
-        <Title order={4}>{title}</Title>
+        <FiTrendingUp size={18} />
+        <Title order={4} size="md">
+          {title}
+        </Title>
       </Group>
       <Stack gap="xs">
         {tags.map((tag) => (

--- a/src/components/Trending/TrendingTags.tsx
+++ b/src/components/Trending/TrendingTags.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Card, Group, Title, Stack, Badge, Text } from "@mantine/core";
+import { FiTrendingUp } from "react-icons/fi";
+
+interface TrendingTag {
+  name: string;
+  projects: number;
+  trend: string;
+}
+
+interface TrendingTagsProps {
+  tags?: TrendingTag[];
+  title?: string;
+  showTrend?: boolean;
+}
+
+const defaultTags: TrendingTag[] = [
+  { name: "kubernetes", projects: 450, trend: "+12%" },
+  { name: "react", projects: 380, trend: "+8%" },
+  { name: "machine-learning", projects: 290, trend: "+15%" },
+  { name: "devops", projects: 240, trend: "+5%" },
+  { name: "microservices", projects: 180, trend: "+9%" },
+];
+
+export default function TrendingTags({
+  tags = defaultTags,
+  title = "Trending Tags",
+  showTrend = true,
+}: TrendingTagsProps) {
+  return (
+    <Card p="lg" withBorder radius="lg">
+      <Group mb="md">
+        <FiTrendingUp size={20} />
+        <Title order={4}>{title}</Title>
+      </Group>
+      <Stack gap="xs">
+        {tags.map((tag) => (
+          <Group key={tag.name} justify="space-between">
+            <Badge variant="light" style={{ cursor: "pointer" }}>
+              #{tag.name}
+            </Badge>
+            <Group gap={4}>
+              <Text size="xs" c="dimmed">
+                {tag.projects}
+              </Text>
+              {showTrend && (
+                <Text size="xs" c="green">
+                  {tag.trend}
+                </Text>
+              )}
+            </Group>
+          </Group>
+        ))}
+      </Stack>
+    </Card>
+  );
+}

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -274,7 +274,7 @@ const ExplorePage = () => {
                   leftSection={<FiSearch size={16} />}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.currentTarget.value)}
-                  size="md"
+                  size="sm"
                 />
               </Grid.Col>
               <Grid.Col span={3}>
@@ -287,7 +287,7 @@ const ExplorePage = () => {
                   value={selectedCategory}
                   onChange={(value) => setSelectedCategory(value || "all")}
                   leftSection={<FiFilter size={16} />}
-                  size="md"
+                  size="sm"
                 />
               </Grid.Col>
               <Grid.Col span={3}>
@@ -302,7 +302,7 @@ const ExplorePage = () => {
                   value={sortBy}
                   onChange={(value) => setSortBy(value || "trending")}
                   leftSection={<FiTrendingUp size={16} />}
-                  size="md"
+                  size="sm"
                 />
               </Grid.Col>
             </Grid>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,0 +1,662 @@
+import React, { useState } from "react";
+import {
+  Container,
+  Title,
+  Text,
+  Group,
+  Stack,
+  Grid,
+  Card,
+  Badge,
+  Button,
+  Tabs,
+  TextInput,
+  Select,
+  Avatar,
+  Anchor,
+  Divider,
+  SimpleGrid,
+  Paper,
+  ThemeIcon,
+} from "@mantine/core";
+import {
+  FiSearch,
+  FiTrendingUp,
+  FiStar,
+  FiUsers,
+  FiCode,
+  FiTag,
+  FiFilter,
+  FiGitBranch,
+  FiLayers,
+  FiCalendar,
+  FiGlobe,
+  FiZap,
+} from "react-icons/fi";
+import { Link } from "react-router-dom";
+import { useSetContainerSize, useSetNoSidebar } from "@/utils/helpers";
+import TrendingProjects from "@/components/Trending/TrendingProjects";
+import SuggestedUsers from "@/components/Trending/SuggestedUsers";
+import TrendingTags from "@/components/Trending/TrendingTags";
+
+const ExplorePage = () => {
+  useSetNoSidebar();
+  useSetContainerSize("full");
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("all");
+  const [sortBy, setSortBy] = useState("trending");
+
+  // Mock data for featured content
+  const featuredProjects = [
+    {
+      name: "nextjs-starter-template",
+      author: "vercel-team",
+      description:
+        "Production-ready Next.js template with TypeScript, Tailwind CSS, and more",
+      stars: 3420,
+      forks: 890,
+      language: "TypeScript",
+      avatar: "https://github.com/identicons/vercel-team.png",
+      link: "/projects/nextjs-starter-template",
+      featured: true,
+      tags: ["nextjs", "typescript", "tailwind"],
+    },
+    {
+      name: "kubernetes-dashboard-pro",
+      author: "k8s-community",
+      description:
+        "Advanced Kubernetes dashboard with real-time monitoring and management",
+      stars: 2150,
+      forks: 450,
+      language: "React",
+      avatar: "https://github.com/identicons/k8s-community.png",
+      link: "/projects/kubernetes-dashboard-pro",
+      featured: true,
+      tags: ["kubernetes", "react", "monitoring"],
+    },
+    {
+      name: "ai-text-classifier",
+      author: "ml-innovations",
+      description:
+        "State-of-the-art text classification using transformer models",
+      stars: 1840,
+      forks: 320,
+      language: "Python",
+      avatar: "https://github.com/identicons/ml-innovations.png",
+      link: "/projects/ai-text-classifier",
+      featured: true,
+      tags: ["machine-learning", "nlp", "pytorch"],
+    },
+  ];
+
+  const categories = [
+    { value: "all", label: "All Categories", icon: FiGlobe },
+    { value: "web", label: "Web Development", icon: FiCode },
+    { value: "mobile", label: "Mobile Apps", icon: FiLayers },
+    { value: "ai", label: "AI & Machine Learning", icon: FiZap },
+    { value: "devops", label: "DevOps & Infrastructure", icon: FiGitBranch },
+    { value: "data", label: "Data Science", icon: FiTrendingUp },
+  ];
+
+  const popularTags = [
+    { name: "react", count: 1240, trend: "+18%", color: "blue" },
+    { name: "kubernetes", count: 890, trend: "+25%", color: "cyan" },
+    { name: "python", count: 1580, trend: "+12%", color: "green" },
+    { name: "typescript", count: 950, trend: "+20%", color: "indigo" },
+    { name: "machine-learning", count: 720, trend: "+35%", color: "purple" },
+    { name: "docker", count: 650, trend: "+15%", color: "orange" },
+    { name: "nextjs", count: 580, trend: "+28%", color: "gray" },
+    { name: "devops", count: 490, trend: "+22%", color: "red" },
+  ];
+
+  const topDevelopers = [
+    {
+      name: "Sarah Chen",
+      username: "sarah-fullstack",
+      bio: "Full-stack engineer building scalable web applications",
+      followers: 2340,
+      projects: 45,
+      avatar: "https://github.com/identicons/sarah-fullstack.png",
+      tags: ["React", "Node.js", "AWS"],
+      link: "/users/sarah-fullstack",
+    },
+    {
+      name: "Alex Thompson",
+      username: "alex-devops",
+      bio: "DevOps architect specializing in Kubernetes and cloud infrastructure",
+      followers: 1890,
+      projects: 32,
+      avatar: "https://github.com/identicons/alex-devops.png",
+      tags: ["Kubernetes", "AWS", "Terraform"],
+      link: "/users/alex-devops",
+    },
+    {
+      name: "Maya Patel",
+      username: "maya-ai",
+      bio: "AI researcher focusing on computer vision and NLP applications",
+      followers: 3120,
+      projects: 28,
+      avatar: "https://github.com/identicons/maya-ai.png",
+      tags: ["PyTorch", "TensorFlow", "Python"],
+      link: "/users/maya-ai",
+    },
+  ];
+
+  const recentlyActiveProjects = [
+    {
+      name: "chat-app-realtime",
+      author: "realtime-dev",
+      description: "Real-time chat application with WebSocket support",
+      stars: 456,
+      language: "JavaScript",
+      avatar: "https://github.com/identicons/realtime-dev.png",
+      lastCommit: "2 hours ago",
+      activity: "high",
+      link: "/projects/chat-app-realtime",
+    },
+    {
+      name: "blog-cms-headless",
+      author: "cms-builders",
+      description: "Headless CMS for modern blog websites",
+      stars: 623,
+      language: "TypeScript",
+      avatar: "https://github.com/identicons/cms-builders.png",
+      lastCommit: "4 hours ago",
+      activity: "high",
+      link: "/projects/blog-cms-headless",
+    },
+    {
+      name: "expense-tracker-mobile",
+      author: "mobile-team",
+      description: "Cross-platform expense tracking mobile application",
+      stars: 234,
+      language: "React Native",
+      avatar: "https://github.com/identicons/mobile-team.png",
+      lastCommit: "6 hours ago",
+      activity: "medium",
+      link: "/projects/expense-tracker-mobile",
+    },
+  ];
+
+  const renderFeaturedProject = (project: any) => (
+    <Card key={project.name} p="lg" radius="lg" withBorder>
+      <Stack gap="md">
+        <Group justify="space-between">
+          <Badge variant="gradient" gradient={{ from: "blue", to: "cyan" }}>
+            Featured
+          </Badge>
+          <Group gap="xs">
+            <FiStar size={14} color="#6c757d" />
+            <Text size="sm" c="dimmed">
+              {project.stars}
+            </Text>
+          </Group>
+        </Group>
+
+        <Group>
+          <Avatar src={project.avatar} size="md" radius="md" />
+          <Stack gap="xs" style={{ flex: 1 }}>
+            <Anchor
+              component={Link}
+              to={project.link}
+              size="lg"
+              fw={600}
+              style={{ textDecoration: "none" }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.textDecoration = "underline";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.textDecoration = "none";
+              }}
+            >
+              {project.name}
+            </Anchor>
+            <Text size="sm" c="dimmed">
+              by {project.author}
+            </Text>
+          </Stack>
+        </Group>
+
+        <Text size="sm" c="dimmed" style={{ lineHeight: 1.4 }}>
+          {project.description}
+        </Text>
+
+        <Group justify="space-between" align="center">
+          <Group gap="xs">
+            {project.tags.slice(0, 3).map((tag: string) => (
+              <Badge
+                key={tag}
+                size="xs"
+                variant="light"
+                component={Link}
+                to={`/tags/${tag}`}
+                style={{ cursor: "pointer", textDecoration: "none" }}
+              >
+                {tag}
+              </Badge>
+            ))}
+          </Group>
+          <Group gap="sm">
+            <Badge variant="light" color="gray">
+              {project.language}
+            </Badge>
+            <Group gap={4}>
+              <FiGitBranch size={12} color="#6c757d" />
+              <Text size="xs" c="dimmed">
+                {project.forks}
+              </Text>
+            </Group>
+          </Group>
+        </Group>
+      </Stack>
+    </Card>
+  );
+
+  return (
+    <Container size="xl" py="lg">
+      <Stack gap="xl">
+        {/* Header Section */}
+        <Stack gap="lg">
+          <Stack gap="xs">
+            <Title order={1}>Explore CraneCloud</Title>
+            <Text size="lg" c="dimmed">
+              Discover trending projects, talented developers, and popular
+              technologies in the community
+            </Text>
+          </Stack>
+          {/* Search and Filters */}
+          <Card p="lg" radius="lg" withBorder>
+            <Grid>
+              <Grid.Col span={6}>
+                <TextInput
+                  placeholder="Search projects, users, or tags..."
+                  leftSection={<FiSearch size={16} />}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.currentTarget.value)}
+                  size="md"
+                />
+              </Grid.Col>
+              <Grid.Col span={3}>
+                <Select
+                  placeholder="Category"
+                  data={categories.map((cat) => ({
+                    value: cat.value,
+                    label: cat.label,
+                  }))}
+                  value={selectedCategory}
+                  onChange={(value) => setSelectedCategory(value || "all")}
+                  leftSection={<FiFilter size={16} />}
+                  size="md"
+                />
+              </Grid.Col>
+              <Grid.Col span={3}>
+                <Select
+                  placeholder="Sort by"
+                  data={[
+                    { value: "trending", label: "Trending" },
+                    { value: "stars", label: "Most Stars" },
+                    { value: "recent", label: "Recently Updated" },
+                    { value: "newest", label: "Newest" },
+                  ]}
+                  value={sortBy}
+                  onChange={(value) => setSortBy(value || "trending")}
+                  leftSection={<FiTrendingUp size={16} />}
+                  size="md"
+                />
+              </Grid.Col>
+            </Grid>
+          </Card>
+        </Stack>
+
+        <Tabs defaultValue="overview">
+          <Tabs.List mb="xl">
+            <Tabs.Tab value="overview" leftSection={<FiGlobe size={16} />}>
+              Overview
+            </Tabs.Tab>
+            <Tabs.Tab value="projects" leftSection={<FiCode size={16} />}>
+              Projects
+            </Tabs.Tab>
+            <Tabs.Tab value="developers" leftSection={<FiUsers size={16} />}>
+              Developers
+            </Tabs.Tab>
+            <Tabs.Tab value="tags" leftSection={<FiTag size={16} />}>
+              Tags
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="overview">
+            <Grid>
+              {/* Featured Projects */}
+              <Grid.Col span={12}>
+                <Title order={2} mb="lg">
+                  🌟 Featured Projects
+                </Title>
+                <SimpleGrid
+                  cols={{ base: 1, md: 2, lg: 3 }}
+                  spacing="lg"
+                  mb="xl"
+                >
+                  {featuredProjects.map(renderFeaturedProject)}
+                </SimpleGrid>
+              </Grid.Col>
+
+              {/* Three Column Layout */}
+              <Grid.Col span={4}>
+                <Stack gap="lg">
+                  <TrendingProjects compact />
+                  <Card p="md" withBorder radius="lg">
+                    <Group mb="sm">
+                      <FiCalendar size={18} />
+                      <Title order={4} size="md">
+                        Recently Active
+                      </Title>
+                    </Group>
+                    <Stack gap="sm">
+                      {recentlyActiveProjects.map((project, index) => (
+                        <div key={project.name}>
+                          <Group gap="xs">
+                            <Avatar src={project.avatar} size="xs" />
+                            <div style={{ flex: 1 }}>
+                              <Text size="sm" fw={500}>
+                                {project.name}
+                              </Text>
+                              <Text size="xs" c="dimmed">
+                                {project.lastCommit}
+                              </Text>
+                            </div>
+                            <Badge
+                              size="xs"
+                              color={
+                                project.activity === "high" ? "green" : "orange"
+                              }
+                            >
+                              {project.activity}
+                            </Badge>
+                          </Group>
+                          {index < recentlyActiveProjects.length - 1 && (
+                            <Divider my="sm" color="gray.3" />
+                          )}
+                        </div>
+                      ))}
+                    </Stack>
+                  </Card>
+                </Stack>
+              </Grid.Col>
+
+              <Grid.Col span={4}>
+                <SuggestedUsers users={topDevelopers} title="Top Developers" />
+              </Grid.Col>
+
+              <Grid.Col span={4}>
+                <Stack gap="lg">
+                  <Card p="md" withBorder radius="lg">
+                    <Group mb="sm">
+                      <FiTag size={18} />
+                      <Title order={4} size="md">
+                        Popular Tags
+                      </Title>
+                    </Group>
+                    <Stack gap="xs">
+                      {popularTags.map((tag) => (
+                        <Group key={tag.name} justify="space-between">
+                          <Group gap="xs">
+                            <Badge
+                              variant="light"
+                              color={tag.color}
+                              component={Link}
+                              to={`/tags/${tag.name}`}
+                              style={{
+                                cursor: "pointer",
+                                textDecoration: "none",
+                              }}
+                            >
+                              #{tag.name}
+                            </Badge>
+                            <Text size="xs" c="dimmed">
+                              {tag.count} projects
+                            </Text>
+                          </Group>
+                          <Text size="xs" c="green" fw={500}>
+                            {tag.trend}
+                          </Text>
+                        </Group>
+                      ))}
+                    </Stack>
+                  </Card>
+
+                  <Card p="md" withBorder radius="lg">
+                    <Group mb="sm">
+                      <FiTrendingUp size={18} />
+                      <Title order={4} size="md">
+                        Quick Stats
+                      </Title>
+                    </Group>
+                    <SimpleGrid cols={2} spacing="sm">
+                      <Paper p="sm" bg="blue.0" radius="md">
+                        <Text size="lg" fw={700} c="blue">
+                          2.4K
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                          Active Projects
+                        </Text>
+                      </Paper>
+                      <Paper p="sm" bg="green.0" radius="md">
+                        <Text size="lg" fw={700} c="green">
+                          890
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                          Developers
+                        </Text>
+                      </Paper>
+                      <Paper p="sm" bg="orange.0" radius="md">
+                        <Text size="lg" fw={700} c="gray">
+                          1.2M
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                          Lines of Code
+                        </Text>
+                      </Paper>
+                      <Paper p="sm" bg="orange.0" radius="md">
+                        <Text size="lg" fw={700} c="orange">
+                          45K
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                          Deployments
+                        </Text>
+                      </Paper>
+                    </SimpleGrid>
+                  </Card>
+                </Stack>
+              </Grid.Col>
+            </Grid>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="projects">
+            <Grid>
+              <Grid.Col span={8}>
+                <Title order={3} mb="lg">
+                  All Projects
+                </Title>
+                <Stack gap="md">
+                  {[...featuredProjects, ...recentlyActiveProjects].map(
+                    (project, index) => (
+                      <Card
+                        key={`${project.name}-${index}`}
+                        p="md"
+                        withBorder
+                        radius="lg"
+                      >
+                        <Group justify="space-between" mb="sm">
+                          <Group>
+                            <Avatar src={project.avatar} size="sm" />
+                            <div>
+                              <Anchor
+                                component={Link}
+                                to={project.link || "#"}
+                                fw={600}
+                                style={{ textDecoration: "none" }}
+                              >
+                                {project.name}
+                              </Anchor>
+                              <Text size="xs" c="dimmed">
+                                by {project.author}
+                              </Text>
+                            </div>
+                          </Group>
+                          <Group gap="sm">
+                            <Group gap={4}>
+                              <FiStar size={12} color="#6c757d" />
+                              <Text size="xs" c="dimmed">
+                                {project.stars}
+                              </Text>
+                            </Group>
+                            <Badge size="xs" variant="light">
+                              {project.language}
+                            </Badge>
+                          </Group>
+                        </Group>
+                        <Text size="sm" c="dimmed">
+                          {project.description}
+                        </Text>
+                      </Card>
+                    ),
+                  )}
+                </Stack>
+              </Grid.Col>
+              <Grid.Col span={4}>
+                <TrendingTags />
+              </Grid.Col>
+            </Grid>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="developers">
+            <Title order={3} mb="lg">
+              Community Developers
+            </Title>
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+              {[...topDevelopers, ...topDevelopers].map((user, index) => (
+                <Card
+                  key={`${user.username}-${index}`}
+                  p="lg"
+                  withBorder
+                  radius="lg"
+                >
+                  <Group mb="md">
+                    <Avatar src={user.avatar} size="lg" />
+                    <div style={{ flex: 1 }}>
+                      <Anchor
+                        component={Link}
+                        to={user.link}
+                        size="lg"
+                        fw={600}
+                        style={{ textDecoration: "none" }}
+                      >
+                        {user.name}
+                      </Anchor>
+                      <Text size="sm" c="dimmed">
+                        @{user.username}
+                      </Text>
+                    </div>
+                    <Button variant="outline" size="sm">
+                      Follow
+                    </Button>
+                  </Group>
+                  <Text size="sm" c="dimmed" mb="md">
+                    {user.bio}
+                  </Text>
+                  <Group gap="xs" mb="md">
+                    {user.tags.map((tag) => (
+                      <Badge key={tag} size="xs" variant="light">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </Group>
+                  <Group gap="lg">
+                    <Text size="sm" c="dimmed">
+                      {user.followers} followers
+                    </Text>
+                    <Text size="sm" c="dimmed">
+                      {user.projects} projects
+                    </Text>
+                  </Group>
+                </Card>
+              ))}
+            </SimpleGrid>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="tags">
+            <Title order={3} mb="lg">
+              Explore by Technology
+            </Title>
+            <Grid>
+              <Grid.Col span={8}>
+                <SimpleGrid cols={4} spacing="md">
+                  {popularTags.map((tag) => (
+                    <Card
+                      key={tag.name}
+                      p="lg"
+                      withBorder
+                      radius="lg"
+                      ta="center"
+                      component={Link}
+                      to={`/tags/${tag.name}`}
+                      style={{
+                        cursor: "pointer",
+                        textDecoration: "none",
+                        color: "inherit",
+                        transition: "all 0.2s ease",
+                      }}
+                      className="hover:shadow-md"
+                    >
+                      <ThemeIcon
+                        size="xl"
+                        variant="light"
+                        color={tag.color}
+                        mx="auto"
+                        mb="md"
+                      >
+                        <FiTag size={24} />
+                      </ThemeIcon>
+                      <Title order={4} mb="xs">
+                        #{tag.name}
+                      </Title>
+                      <Text size="sm" c="dimmed" mb="xs">
+                        {tag.count} projects
+                      </Text>
+                      <Text size="xs" c="green" fw={500}>
+                        {tag.trend}
+                      </Text>
+                    </Card>
+                  ))}
+                </SimpleGrid>
+              </Grid.Col>
+              <Grid.Col span={4}>
+                <Card p="md" withBorder radius="lg">
+                  <Title order={4} mb="md">
+                    Category Distribution
+                  </Title>
+                  <Stack gap="sm">
+                    {categories.slice(1).map((category) => (
+                      <Group key={category.value} justify="space-between">
+                        <Group gap="xs">
+                          <category.icon size={16} />
+                          <Text size="sm">{category.label}</Text>
+                        </Group>
+                        <Text size="sm" c="dimmed">
+                          {Math.floor(Math.random() * 500) + 100} projects
+                        </Text>
+                      </Group>
+                    ))}
+                  </Stack>
+                </Card>
+              </Grid.Col>
+            </Grid>
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+    </Container>
+  );
+};
+
+export default ExplorePage;

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,13 +1,352 @@
 import React from "react";
-import ProjectsList from "@/components/Lists/ProjectsList";
+import {
+  Container,
+  Title,
+  Text,
+  Button,
+  Group,
+  Stack,
+  Grid,
+  Card,
+  Box,
+  Paper,
+  ActionIcon,
+  ScrollArea,
+  Select,
+  Avatar,
+} from "@mantine/core";
+import {
+  FiActivity,
+  FiSend,
+  FiPlus,
+  FiHeart,
+  FiMessageCircle,
+  FiShare2,
+  FiFilter,
+} from "react-icons/fi";
+import { Link } from "react-router-dom";
 import { useSetContainerSize, useSetNoSidebar } from "@/utils/helpers";
+import TrendingTags from "@/components/Trending/TrendingTags";
+import TrendingProjects from "@/components/Trending/TrendingProjects";
+import SuggestedUsers from "@/components/Trending/SuggestedUsers";
+import CompactProjectsList from "@/components/Lists/CompactProjectsList";
+
 const LandingPage = () => {
   useSetNoSidebar();
-  useSetContainerSize("lg");
+  useSetContainerSize("full");
+
+  // Mock data for dashboard - can be used for stats cards if needed
+  // const userStats = {
+  //   projects: 12,
+  //   followers: 148,
+  //   following: 89,
+  //   stars: 342,
+  // };
+
+  const quickActions = [
+    {
+      title: "Create New Project",
+      description: "Start a new project and deploy to the cloud",
+      icon: FiPlus,
+      color: "blue",
+      link: "/projects/new",
+    },
+    // {
+    //   title: "Deploy Application",
+    //   description: "Deploy your latest application build",
+    //   icon: FiSend,
+    //   color: "green",
+    //   link: "/apps/deploy",
+    // },
+    // {
+    //   title: "Create Database",
+    //   description: "Set up a new database instance",
+    //   icon: FiDatabase,
+    //   color: "purple",
+    //   link: "/databases/new",
+    // },
+    // {
+    //   title: "Manage Clusters",
+    //   description: "Monitor and configure your clusters",
+    //   icon: FiServer,
+    //   color: "orange",
+    //   link: "/admin/clusters",
+    // },
+  ];
+
+  const activityFeed = [
+    {
+      id: 1,
+      type: "star",
+      user: "sarah-dev",
+      avatar: "https://github.com/identicons/sarah-dev.png",
+      action: "starred",
+      target: "ml-training-pipeline",
+      targetType: "project",
+      timestamp: "2 hours ago",
+    },
+    {
+      id: 2,
+      type: "follow",
+      user: "mike-ops",
+      avatar: "https://github.com/identicons/mike-ops.png",
+      action: "started following",
+      target: "alex-chen",
+      targetType: "user",
+      timestamp: "4 hours ago",
+    },
+    {
+      id: 3,
+      type: "deploy",
+      user: "dev-team",
+      avatar: "https://github.com/identicons/dev-team.png",
+      action: "deployed",
+      target: "chat-app v2.1.0",
+      targetType: "app",
+      timestamp: "6 hours ago",
+    },
+    {
+      id: 4,
+      type: "fork",
+      user: "jane-coder",
+      avatar: "https://github.com/identicons/jane-coder.png",
+      action: "forked",
+      target: "kubernetes-config",
+      targetType: "project",
+      timestamp: "8 hours ago",
+    },
+    {
+      id: 5,
+      type: "comment",
+      user: "tech-lead",
+      avatar: "https://github.com/identicons/tech-lead.png",
+      action: "commented on",
+      target: "microservices-setup",
+      targetType: "project",
+      timestamp: "1 day ago",
+    },
+  ];
+
+  // Activity feed data - this could come from API
+  const activityFeedData = activityFeed;
+
   return (
+    <Container size="xl" py="sm">
+      {/* Welcome Header */}
+      {/* <Box mb="xl">
+        <Group justify="space-between" align="flex-end">
     <div>
-      <ProjectsList />
-    </div>
+            <Title order={2} mb="xs">
+              Welcome back! 👋
+            </Title>
+            <Text c="dimmed">
+              Here's what's happening in your CraneCloud community
+            </Text>
+          </div>
+          <Group>
+            <Input
+              placeholder="Search projects, users, tags..."
+              leftSection={<FiSearch size={16} />}
+              w={300}
+            />
+          </Group>
+        </Group>
+      </Box> */}
+
+      {/* Quick Stats */}
+      {/* <Grid mb="xl">
+        <Grid.Col span={3}>
+          <Card p="md" withBorder radius="md" ta="center">
+            <ThemeIcon size="lg" variant="light" color="blue" mx="auto" mb="xs">
+              <FiCode size={20} />
+            </ThemeIcon>
+            <Text size="xl" fw={700}>
+              {userStats.projects}
+            </Text>
+            <Text size="sm" c="dimmed">
+              Your Projects
+            </Text>
+          </Card>
+        </Grid.Col>
+        <Grid.Col span={3}>
+          <Card p="md" withBorder radius="md" ta="center">
+            <ThemeIcon
+              size="lg"
+              variant="light"
+              color="green"
+              mx="auto"
+              mb="xs"
+            >
+              <FiUsers size={20} />
+            </ThemeIcon>
+            <Text size="xl" fw={700}>
+              {userStats.followers}
+            </Text>
+            <Text size="sm" c="dimmed">
+              Followers
+            </Text>
+          </Card>
+        </Grid.Col>
+        <Grid.Col span={3}>
+          <Card p="md" withBorder radius="md" ta="center">
+            <ThemeIcon
+              size="lg"
+              variant="light"
+              color="purple"
+              mx="auto"
+              mb="xs"
+            >
+              <FiHeart size={20} />
+            </ThemeIcon>
+            <Text size="xl" fw={700}>
+              {userStats.following}
+            </Text>
+            <Text size="sm" c="dimmed">
+              Following
+            </Text>
+          </Card>
+        </Grid.Col>
+        <Grid.Col span={3}>
+          <Card p="md" withBorder radius="md" ta="center">
+            <ThemeIcon
+              size="lg"
+              variant="light"
+              color="yellow"
+              mx="auto"
+              mb="xs"
+            >
+              <FiStar size={20} />
+            </ThemeIcon>
+            <Text size="xl" fw={700}>
+              {userStats.stars}
+            </Text>
+            <Text size="sm" c="dimmed">
+              Stars Received
+            </Text>
+          </Card>
+        </Grid.Col>
+      </Grid> */}
+
+      {/* Main 3-Column Layout */}
+      <Grid>
+        {/* Left Column - Quick Actions & Your Activity */}
+        <Grid.Col span={3}>
+          <Stack gap="lg">
+            {/* Quick Actions */}
+            <Card p="lg" withBorder radius="lg">
+              <Group mb="md">
+                <FiSend size={20} />
+                <Title order={4}>Quick Actions</Title>
+              </Group>
+              <Stack gap="sm">
+                {quickActions.map((action) => (
+                  <Button
+                    key={action.title}
+                    component={Link}
+                    to={action.link}
+                    variant="subtle"
+                    justify="flex-start"
+                    leftSection={<action.icon size={16} />}
+                    color={action.color}
+                    fullWidth
+                  >
+                    <Box ta="left">
+                      <Text size="sm" fw={500}>
+                        {action.title}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {action.description}
+                      </Text>
+                    </Box>
+                  </Button>
+                ))}
+              </Stack>
+            </Card>
+
+            {/* projects list */}
+            <CompactProjectsList />
+          </Stack>
+        </Grid.Col>
+
+        {/* Center Column - Activity Feed */}
+        <Grid.Col span={6}>
+          <Card p="lg" withBorder radius="lg" h="100%">
+            <Group mb="lg" justify="space-between">
+              <Group>
+                <FiActivity size={20} />
+                <Title order={4}>Activity Feed</Title>
+              </Group>
+              <Group gap="xs">
+                <Button
+                  variant="subtle"
+                  size="xs"
+                  leftSection={<FiFilter size={14} />}
+                >
+                  Filter
+                </Button>
+                <Select
+                  data={["All Activity", "Following", "Your Activity"]}
+                  defaultValue="All Activity"
+                  size="xs"
+                  w={120}
+                />
+              </Group>
+            </Group>
+
+            <ScrollArea h={600}>
+              <Stack gap="md">
+                {activityFeedData.map((activity) => (
+                  <Paper key={activity.id} p="md" withBorder radius="md">
+                    <Group mb="sm">
+                      <Avatar src={activity.avatar} size="sm" />
+                      <div style={{ flex: 1 }}>
+                        <Group gap={4}>
+                          <Text size="sm" fw={500}>
+                            {activity.user}
+                          </Text>
+                          <Text size="sm" c="dimmed">
+                            {activity.action}
+                          </Text>
+                          <Text size="sm" fw={500} c="blue">
+                            {activity.target}
+                          </Text>
+                        </Group>
+                        <Text size="xs" c="dimmed">
+                          {activity.timestamp}
+                        </Text>
+                      </div>
+                      <Group gap="xs">
+                        <ActionIcon variant="subtle" size="sm">
+                          <FiHeart size={14} />
+                        </ActionIcon>
+                        <ActionIcon variant="subtle" size="sm">
+                          <FiMessageCircle size={14} />
+                        </ActionIcon>
+                        <ActionIcon variant="subtle" size="sm">
+                          <FiShare2 size={14} />
+                        </ActionIcon>
+                      </Group>
+                    </Group>
+                  </Paper>
+                ))}
+              </Stack>
+            </ScrollArea>
+          </Card>
+        </Grid.Col>
+
+        {/* Right Column - Trending & Suggestions */}
+        <Grid.Col span={3}>
+          <Stack gap="lg">
+            {/* Trending Projects */}
+            <TrendingProjects compact />
+            {/* Trending Tags */}
+            <TrendingTags />
+            {/* Suggested Users */}
+            <SuggestedUsers />
+          </Stack>
+        </Grid.Col>
+      </Grid>
+    </Container>
   );
 };
 

--- a/src/pages/Projects/ProjectListPage.tsx
+++ b/src/pages/Projects/ProjectListPage.tsx
@@ -1,0 +1,11 @@
+import ProjectsList from "@/components/Lists/ProjectsList";
+import { useSetContainerSize, useSetNoSidebar } from "@/utils/helpers";
+import React from "react";
+
+const ProjectListPage = () => {
+  useSetNoSidebar();
+  useSetContainerSize("xl");
+  return <ProjectsList />;
+};
+
+export default ProjectListPage;

--- a/src/pages/TagDetailsPage.tsx
+++ b/src/pages/TagDetailsPage.tsx
@@ -1,0 +1,714 @@
+import React, { useState } from "react";
+import {
+  Container,
+  Title,
+  Text,
+  Group,
+  Stack,
+  Grid,
+  Card,
+  Badge,
+  Button,
+  Box,
+  Avatar,
+  Anchor,
+  SimpleGrid,
+  ThemeIcon,
+  Progress,
+  Breadcrumbs,
+  Select,
+  Tabs,
+  ActionIcon,
+  Tooltip,
+  Center,
+} from "@mantine/core";
+import {
+  FiTrendingUp,
+  FiStar,
+  FiUsers,
+  FiCode,
+  FiTag,
+  FiGitBranch,
+  FiHeart,
+  FiBook,
+  FiGlobe,
+  FiArrowUp,
+  FiActivity,
+  FiFilter,
+  FiExternalLink,
+  FiGithub,
+  FiShare2,
+  FiBookmark,
+} from "react-icons/fi";
+import { Link, useParams } from "react-router-dom";
+import { useSetContainerSize, useSetNoSidebar } from "@/utils/helpers";
+
+const TagDetailsPage = () => {
+  useSetNoSidebar();
+  useSetContainerSize("full");
+
+  const { tagName } = useParams<{ tagName: string }>();
+  const [sortBy, setSortBy] = useState("trending");
+  const [_timeRange] = useState("week");
+
+  // Mock tag data based on the tag name
+  const getTagData = (tag: string) => {
+    const tagData: Record<string, any> = {
+      react: {
+        name: "React",
+        description: "A JavaScript library for building user interfaces",
+        category: "Frontend Framework",
+        projectCount: 1240,
+        developerCount: 892,
+        weeklyGrowth: 18,
+        totalStars: 45600,
+        color: "blue",
+        relatedTags: ["javascript", "typescript", "nextjs", "redux", "hooks"],
+        officialWebsite: "https://reactjs.org",
+        documentation: "https://reactjs.org/docs",
+        github: "https://github.com/facebook/react",
+      },
+      kubernetes: {
+        name: "Kubernetes",
+        description: "Production-Grade Container Orchestration",
+        category: "DevOps & Infrastructure",
+        projectCount: 890,
+        developerCount: 567,
+        weeklyGrowth: 25,
+        totalStars: 32400,
+        color: "cyan",
+        relatedTags: ["docker", "devops", "cloud", "microservices", "helm"],
+        officialWebsite: "https://kubernetes.io",
+        documentation: "https://kubernetes.io/docs",
+        github: "https://github.com/kubernetes/kubernetes",
+      },
+      python: {
+        name: "Python",
+        description:
+          "Python is a programming language that lets you work quickly",
+        category: "Programming Language",
+        projectCount: 1580,
+        developerCount: 1240,
+        weeklyGrowth: 12,
+        totalStars: 78900,
+        color: "green",
+        relatedTags: [
+          "django",
+          "flask",
+          "machine-learning",
+          "data-science",
+          "ai",
+        ],
+        officialWebsite: "https://python.org",
+        documentation: "https://docs.python.org",
+        github: "https://github.com/python/cpython",
+      },
+    };
+
+    return tagData[tag?.toLowerCase() || "react"] || tagData.react;
+  };
+
+  const tagData = getTagData(tagName || "react");
+
+  const trendingProjects = [
+    {
+      name: "modern-react-template",
+      author: "frontend-masters",
+      description:
+        "Modern React template with TypeScript, Vite, and best practices",
+      stars: 2340,
+      forks: 450,
+      language: "TypeScript",
+      avatar: "https://github.com/identicons/frontend-masters.png",
+      link: "/projects/modern-react-template",
+      lastUpdated: "2 days ago",
+      weeklyStars: 125,
+    },
+    {
+      name: "react-dashboard-pro",
+      author: "ui-builders",
+      description: "Professional dashboard template with React and Material-UI",
+      stars: 1890,
+      forks: 320,
+      language: "JavaScript",
+      avatar: "https://github.com/identicons/ui-builders.png",
+      link: "/projects/react-dashboard-pro",
+      lastUpdated: "1 day ago",
+      weeklyStars: 89,
+    },
+    {
+      name: "react-native-starter",
+      author: "mobile-dev-team",
+      description:
+        "Complete React Native starter with navigation and state management",
+      stars: 1456,
+      forks: 280,
+      language: "JavaScript",
+      avatar: "https://github.com/identicons/mobile-dev-team.png",
+      link: "/projects/react-native-starter",
+      lastUpdated: "3 days ago",
+      weeklyStars: 67,
+    },
+    {
+      name: "react-hooks-library",
+      author: "hooks-experts",
+      description: "Collection of custom React hooks for common use cases",
+      stars: 3240,
+      forks: 680,
+      language: "TypeScript",
+      avatar: "https://github.com/identicons/hooks-experts.png",
+      link: "/projects/react-hooks-library",
+      lastUpdated: "1 day ago",
+      weeklyStars: 156,
+    },
+  ];
+
+  const topDevelopers = [
+    {
+      name: "Sarah Johnson",
+      username: "sarah-react-dev",
+      bio: "Senior React developer with 8+ years of experience building scalable web applications",
+      followers: 3240,
+      projects: 45,
+      avatar: "https://github.com/identicons/sarah-react-dev.png",
+      contributions: 156,
+      link: "/users/sarah-react-dev",
+    },
+    {
+      name: "Michael Chen",
+      username: "mike-frontend",
+      bio: "Full-stack developer specializing in React and Node.js ecosystems",
+      followers: 2890,
+      projects: 38,
+      avatar: "https://github.com/identicons/mike-frontend.png",
+      contributions: 142,
+      link: "/users/mike-frontend",
+    },
+    {
+      name: "Emily Rodriguez",
+      username: "emily-ui-expert",
+      bio: "UI/UX engineer creating beautiful React components and design systems",
+      followers: 4120,
+      projects: 52,
+      avatar: "https://github.com/identicons/emily-ui-expert.png",
+      contributions: 203,
+      link: "/users/emily-ui-expert",
+    },
+  ];
+
+  const weeklyStats = {
+    newProjects: 24,
+    newDevelopers: 156,
+    totalContributions: 892,
+    topLanguage: "TypeScript",
+  };
+
+  const learningResources = [
+    {
+      title: "Official React Documentation",
+      description: "Comprehensive guide to React concepts and API",
+      type: "Documentation",
+      url: "https://reactjs.org/docs",
+      difficulty: "Beginner",
+    },
+    {
+      title: "React Patterns and Best Practices",
+      description:
+        "Advanced patterns for building maintainable React applications",
+      type: "Tutorial",
+      url: "#",
+      difficulty: "Advanced",
+    },
+    {
+      title: "Testing React Applications",
+      description:
+        "Complete guide to testing React components and applications",
+      type: "Course",
+      url: "#",
+      difficulty: "Intermediate",
+    },
+  ];
+
+  const breadcrumbItems = [
+    { title: "Explore", href: "/explore" },
+    { title: "Tags", href: "/explore#tags" },
+    { title: tagData.name, href: "#" },
+  ].map((item, index) => (
+    <Anchor key={index} component={Link} to={item.href} size="sm">
+      {item.title}
+    </Anchor>
+  ));
+
+  return (
+    <Container size="xl" py="lg">
+      <Stack gap="xl">
+        {/* Breadcrumbs */}
+        <Breadcrumbs>{breadcrumbItems}</Breadcrumbs>
+
+        {/* Header Section */}
+        <Stack gap="lg">
+          <Group justify="space-between" align="flex-start">
+            <Group>
+              <ThemeIcon size="xl" variant="light" color={tagData.color}>
+                <FiTag size={32} />
+              </ThemeIcon>
+              <div>
+                <Group gap="xs" mb="xs">
+                  <Title order={1}>#{tagData.name}</Title>
+                  <Badge variant="light" color={tagData.color} size="lg">
+                    {tagData.category}
+                  </Badge>
+                </Group>
+                <Text size="lg" c="dimmed" maw={600}>
+                  {tagData.description}
+                </Text>
+              </div>
+            </Group>
+
+            <Group>
+              <Tooltip label="Follow this tag">
+                <Button variant="outline" leftSection={<FiHeart size={16} />}>
+                  Follow
+                </Button>
+              </Tooltip>
+              <Tooltip label="Share tag">
+                <ActionIcon variant="outline" size="lg">
+                  <FiShare2 size={18} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          </Group>
+
+          {/* Tag Statistics */}
+          <Group gap="sm">
+            <Button
+              variant="light"
+              leftSection={<FiCode size={16} />}
+              size="md"
+              style={{ minWidth: "auto" }}
+            >
+              {tagData.projectCount.toLocaleString()} Projects
+            </Button>
+            <Button
+              variant="light"
+              leftSection={<FiUsers size={16} />}
+              size="md"
+              style={{ minWidth: "auto" }}
+            >
+              {tagData.developerCount.toLocaleString()} Developers
+            </Button>
+            <Button
+              variant="light"
+              leftSection={<FiStar size={16} />}
+              size="md"
+              style={{ minWidth: "auto" }}
+            >
+              {tagData.totalStars.toLocaleString()} Stars
+            </Button>
+            <Button
+              variant="light"
+              leftSection={<FiTrendingUp size={16} />}
+              size="md"
+              style={{ minWidth: "auto" }}
+            >
+              +{tagData.weeklyGrowth}% Growth
+            </Button>
+            {/* </Group>
+
+          {/* Quick Links 
+          <Group gap="sm"> */}
+            {tagData.officialWebsite && (
+              <Button
+                variant="light"
+                leftSection={<FiGlobe size={16} />}
+                rightSection={<FiExternalLink size={14} />}
+                component="a"
+                href={tagData.officialWebsite}
+                target="_blank"
+              >
+                Official Website
+              </Button>
+            )}
+            {tagData.documentation && (
+              <Button
+                variant="light"
+                leftSection={<FiBook size={16} />}
+                rightSection={<FiExternalLink size={14} />}
+                component="a"
+                href={tagData.documentation}
+                target="_blank"
+              >
+                Documentation
+              </Button>
+            )}
+            {tagData.github && (
+              <Button
+                variant="light"
+                leftSection={<FiGithub size={16} />}
+                rightSection={<FiExternalLink size={14} />}
+                component="a"
+                href={tagData.github}
+                target="_blank"
+              >
+                GitHub
+              </Button>
+            )}
+          </Group>
+        </Stack>
+
+        <Tabs defaultValue="projects">
+          <Tabs.List mb="xl">
+            <Tabs.Tab value="projects" leftSection={<FiCode size={16} />}>
+              Projects ({tagData.projectCount})
+            </Tabs.Tab>
+            <Tabs.Tab value="developers" leftSection={<FiUsers size={16} />}>
+              Developers ({tagData.developerCount})
+            </Tabs.Tab>
+            <Tabs.Tab value="analytics" leftSection={<FiActivity size={16} />}>
+              Analytics
+            </Tabs.Tab>
+            <Tabs.Tab value="resources" leftSection={<FiBook size={16} />}>
+              Learning Resources
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="projects">
+            <Grid>
+              <Grid.Col span={9}>
+                <Stack gap="lg">
+                  <Group justify="space-between">
+                    <Title order={3}>Trending Projects</Title>
+                    <Group>
+                      <Select
+                        data={[
+                          { value: "trending", label: "Trending" },
+                          { value: "stars", label: "Most Stars" },
+                          { value: "recent", label: "Recently Updated" },
+                          { value: "forks", label: "Most Forks" },
+                        ]}
+                        value={sortBy}
+                        onChange={(value) => setSortBy(value || "trending")}
+                        leftSection={<FiFilter size={16} />}
+                      />
+                    </Group>
+                  </Group>
+
+                  <Stack gap="md">
+                    {trendingProjects.map((project, index) => (
+                      <Card key={project.name} p="lg" withBorder radius="lg">
+                        <Grid>
+                          <Grid.Col span={8}>
+                            <Group mb="sm">
+                              <Avatar src={project.avatar} size="md" />
+                              <div style={{ flex: 1 }}>
+                                <Group gap="xs" mb={4}>
+                                  <Anchor
+                                    component={Link}
+                                    to={project.link}
+                                    size="lg"
+                                    fw={600}
+                                    style={{ textDecoration: "none" }}
+                                    onMouseEnter={(e) => {
+                                      e.currentTarget.style.textDecoration =
+                                        "underline";
+                                    }}
+                                    onMouseLeave={(e) => {
+                                      e.currentTarget.style.textDecoration =
+                                        "none";
+                                    }}
+                                  >
+                                    {project.name}
+                                  </Anchor>
+                                  <Badge size="sm" variant="light">
+                                    #{index + 1}
+                                  </Badge>
+                                </Group>
+                                <Text size="sm" c="dimmed" mb="xs">
+                                  by {project.author}
+                                </Text>
+                                <Text size="sm" c="dimmed" mb="sm">
+                                  {project.description}
+                                </Text>
+                                <Group gap="lg">
+                                  <Group gap={4}>
+                                    <FiStar size={14} color="#6c757d" />
+                                    <Text size="sm" c="dimmed">
+                                      {project.stars.toLocaleString()}
+                                    </Text>
+                                    <Group gap={2} ml="xs">
+                                      <FiArrowUp size={12} color="green" />
+                                      <Text size="xs" c="green">
+                                        +{project.weeklyStars} this week
+                                      </Text>
+                                    </Group>
+                                  </Group>
+                                  <Group gap={4}>
+                                    <FiGitBranch size={14} color="#6c757d" />
+                                    <Text size="sm" c="dimmed">
+                                      {project.forks}
+                                    </Text>
+                                  </Group>
+                                  <Text size="sm" c="dimmed">
+                                    Updated {project.lastUpdated}
+                                  </Text>
+                                </Group>
+                              </div>
+                            </Group>
+                          </Grid.Col>
+                          <Grid.Col span={4}>
+                            <Group justify="flex-end" align="flex-start">
+                              <Badge variant="light">{project.language}</Badge>
+                              <ActionIcon variant="subtle">
+                                <FiHeart size={16} />
+                              </ActionIcon>
+                              <ActionIcon variant="subtle">
+                                <FiBookmark size={16} />
+                              </ActionIcon>
+                            </Group>
+                          </Grid.Col>
+                        </Grid>
+                      </Card>
+                    ))}
+                  </Stack>
+                </Stack>
+              </Grid.Col>
+
+              <Grid.Col span={3}>
+                <Stack gap="lg">
+                  {/* Related Tags */}
+                  <Card p="md" withBorder radius="lg">
+                    <Title order={4} mb="md">
+                      Related Tags
+                    </Title>
+                    <Stack gap="xs">
+                      {tagData.relatedTags.map((tag: string) => (
+                        <Group key={tag} justify="space-between">
+                          <Badge
+                            variant="light"
+                            component={Link}
+                            to={`/tags/${tag}`}
+                            style={{ cursor: "pointer" }}
+                          >
+                            #{tag}
+                          </Badge>
+                          <Text size="xs" c="dimmed">
+                            {Math.floor(Math.random() * 500) + 100}
+                          </Text>
+                        </Group>
+                      ))}
+                    </Stack>
+                  </Card>
+
+                  {/* Weekly Activity */}
+                  <Card p="md" withBorder radius="lg">
+                    <Title order={4} mb="md">
+                      This Week
+                    </Title>
+                    <Stack gap="sm">
+                      <Group justify="space-between">
+                        <Text size="sm">New Projects</Text>
+                        <Badge variant="light" color="blue">
+                          +{weeklyStats.newProjects}
+                        </Badge>
+                      </Group>
+                      <Group justify="space-between">
+                        <Text size="sm">New Developers</Text>
+                        <Badge variant="light" color="green">
+                          +{weeklyStats.newDevelopers}
+                        </Badge>
+                      </Group>
+                      <Group justify="space-between">
+                        <Text size="sm">Contributions</Text>
+                        <Badge variant="light" color="purple">
+                          {weeklyStats.totalContributions}
+                        </Badge>
+                      </Group>
+                      <Group justify="space-between">
+                        <Text size="sm">Top Language</Text>
+                        <Badge variant="light" color="orange">
+                          {weeklyStats.topLanguage}
+                        </Badge>
+                      </Group>
+                    </Stack>
+                  </Card>
+                </Stack>
+              </Grid.Col>
+            </Grid>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="developers">
+            <Stack gap="lg">
+              <Title order={3}>Top Contributors</Title>
+              <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+                {topDevelopers.map((developer) => (
+                  <Card key={developer.username} p="lg" withBorder radius="lg">
+                    <Group mb="md">
+                      <Avatar src={developer.avatar} size="lg" />
+                      <div style={{ flex: 1 }}>
+                        <Anchor
+                          component={Link}
+                          to={developer.link}
+                          size="lg"
+                          fw={600}
+                          style={{ textDecoration: "none" }}
+                        >
+                          {developer.name}
+                        </Anchor>
+                        <Text size="sm" c="dimmed">
+                          @{developer.username}
+                        </Text>
+                      </div>
+                      <Button variant="outline" size="sm">
+                        Follow
+                      </Button>
+                    </Group>
+                    <Text size="sm" c="dimmed" mb="md">
+                      {developer.bio}
+                    </Text>
+                    <Group justify="space-between">
+                      <Group gap="lg">
+                        <Text size="sm" c="dimmed">
+                          {developer.followers} followers
+                        </Text>
+                        <Text size="sm" c="dimmed">
+                          {developer.projects} projects
+                        </Text>
+                      </Group>
+                    </Group>
+                  </Card>
+                ))}
+              </SimpleGrid>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="analytics">
+            <Grid>
+              <Grid.Col span={8}>
+                <Stack gap="lg">
+                  <Title order={3}>Growth Analytics</Title>
+                  <Card p="lg" withBorder radius="lg">
+                    <Stack gap="md">
+                      <Title order={4}>Project Growth Over Time</Title>
+                      <Box h={300} bg="gray.0" style={{ borderRadius: 8 }}>
+                        <Center h="100%">
+                          <Text c="dimmed">
+                            Chart placeholder - Project growth visualization
+                          </Text>
+                        </Center>
+                      </Box>
+                    </Stack>
+                  </Card>
+
+                  <Card p="lg" withBorder radius="lg">
+                    <Stack gap="md">
+                      <Title order={4}>Language Distribution</Title>
+                      <Box h={200} bg="gray.0" style={{ borderRadius: 8 }}>
+                        <Center h="100%">
+                          <Text c="dimmed">
+                            Chart placeholder - Language distribution
+                          </Text>
+                        </Center>
+                      </Box>
+                    </Stack>
+                  </Card>
+                </Stack>
+              </Grid.Col>
+
+              <Grid.Col span={4}>
+                <Card p="md" withBorder radius="lg">
+                  <Title order={4} mb="md">
+                    Key Metrics
+                  </Title>
+                  <Stack gap="md">
+                    <div>
+                      <Group justify="space-between" mb="xs">
+                        <Text size="sm">Weekly Activity</Text>
+                        <Text size="sm" fw={600}>
+                          High
+                        </Text>
+                      </Group>
+                      <Progress value={85} color="green" size="sm" />
+                    </div>
+
+                    <div>
+                      <Group justify="space-between" mb="xs">
+                        <Text size="sm">Community Health</Text>
+                        <Text size="sm" fw={600}>
+                          Excellent
+                        </Text>
+                      </Group>
+                      <Progress value={95} color="blue" size="sm" />
+                    </div>
+
+                    <div>
+                      <Group justify="space-between" mb="xs">
+                        <Text size="sm">Growth Rate</Text>
+                        <Text size="sm" fw={600}>
+                          +{tagData.weeklyGrowth}%
+                        </Text>
+                      </Group>
+                      <Progress
+                        value={tagData.weeklyGrowth * 3}
+                        color={tagData.color}
+                        size="sm"
+                      />
+                    </div>
+                  </Stack>
+                </Card>
+              </Grid.Col>
+            </Grid>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="resources">
+            <Title order={3} mb="lg">
+              Learning Resources
+            </Title>
+            <Stack gap="md">
+              {learningResources.map((resource, index) => (
+                <Card key={index} p="lg" withBorder radius="lg">
+                  <Group justify="space-between" mb="sm">
+                    <div style={{ flex: 1 }}>
+                      <Group gap="sm" mb="xs">
+                        <Title order={4}>{resource.title}</Title>
+                        <Badge variant="light" size="sm">
+                          {resource.type}
+                        </Badge>
+                        <Badge
+                          variant="outline"
+                          size="sm"
+                          color={
+                            resource.difficulty === "Beginner"
+                              ? "green"
+                              : resource.difficulty === "Intermediate"
+                                ? "orange"
+                                : "red"
+                          }
+                        >
+                          {resource.difficulty}
+                        </Badge>
+                      </Group>
+                      <Text size="sm" c="dimmed">
+                        {resource.description}
+                      </Text>
+                    </div>
+                    <Button
+                      variant="light"
+                      rightSection={<FiExternalLink size={14} />}
+                      component="a"
+                      href={resource.url}
+                      target="_blank"
+                    >
+                      View
+                    </Button>
+                  </Group>
+                </Card>
+              ))}
+            </Stack>
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+    </Container>
+  );
+};
+
+export default TagDetailsPage;


### PR DESCRIPTION
# Description
Add socials concept pages
- Landing Page
- Explore page
- Tags Page

# Screenshots
## Landing Page
<img width="1512" height="857" alt="Screenshot 2025-08-20 at 4 40 28 PM" src="https://github.com/user-attachments/assets/9c331ae8-af43-4c3c-989d-805f0d82463b" />
## Explore page
<img width="1081" height="799" alt="Screenshot 2025-08-20 at 4 41 17 PM" src="https://github.com/user-attachments/assets/134af9b5-8be2-4f85-9f82-01ea05795f61" />
## Tags Page
<img width="1230" height="795" alt="Screenshot 2025-08-20 at 4 41 46 PM" src="https://github.com/user-attachments/assets/98e114fa-7577-48f2-9050-332fb5a217bc" />



