### PR TITLE
feat: follow and unfollow of tag and fetching of projects

### DIFF
--- a/src/pages/TagDetailsPage.tsx
+++ b/src/pages/TagDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Container,
   Title,
@@ -21,27 +21,99 @@ import {
   ActionIcon,
   Tooltip,
   Center,
+  Skeleton,
+  Notification,
 } from "@mantine/core";
 import {
-  FiTrendingUp,
-  FiStar,
   FiUsers,
   FiCode,
   FiTag,
-  FiGitBranch,
   FiHeart,
   FiBook,
   FiGlobe,
-  FiArrowUp,
   FiActivity,
   FiFilter,
   FiExternalLink,
   FiGithub,
   FiShare2,
   FiBookmark,
+  FiXCircle,
 } from "react-icons/fi";
 import { Link, useParams } from "react-router-dom";
-import { useSetContainerSize, useSetNoSidebar } from "@/utils/helpers";
+import {
+  getTagColor,
+  useSetContainerSize,
+  useSetNoSidebar,
+} from "@/utils/helpers";
+import useGet from "@/utils/useGet";
+import usePost from "@/utils/usePost";
+import { API_TAGS } from "@/utils/apis";
+import { Tag } from "@/types/tag";
+
+interface Project {
+  id: string;
+  name: string;
+  description: string;
+  owner_id: string;
+  date_created: string;
+  followers_count: number;
+  apps_count: number;
+  cluster_id: string;
+  prometheus_url: string;
+  is_public: boolean;
+  project_type: string;
+  alias: string;
+  is_following: boolean;
+  admin_disabled: boolean;
+  members_count: number;
+  disabled: boolean;
+  organisation: string;
+  tags: Array<{
+    id: string;
+    name: string;
+    is_following: boolean;
+    is_super_tag: boolean;
+    followers_count: number;
+  }>;
+  tags_count: number;
+  supports_ml: boolean | null;
+}
+
+interface Follower {
+  id: string;
+  name: string;
+  username: string;
+  email: string;
+  profile_picture: string | null;
+  biography: string | null;
+  organisation: string | null;
+  date_created: string;
+  last_seen: string;
+  following_count: number;
+  followers_count: number;
+  followed_projects_count: number;
+  owned_projects_count: number;
+  collaborative_projects_count: number;
+  followed_tags_count: number;
+  is_beta_user: boolean;
+  verified: boolean;
+  is_public: boolean | null;
+  admin_disabled: boolean | null;
+  disabled: boolean | null;
+  social_links: {
+    github: string | null;
+    linkedin: string | null;
+  } | null;
+  roles: Array<{ id: string; name: string }>;
+  credits: Array<{
+    id: string;
+    user_id: string;
+    purchased_credits: number | null;
+    promotion_credits: number | null;
+    amount: number;
+  }>;
+  age: string;
+}
 
 const TagDetailsPage = () => {
   useSetNoSidebar();
@@ -49,199 +121,315 @@ const TagDetailsPage = () => {
 
   const { tagName } = useParams<{ tagName: string }>();
   const [sortBy, setSortBy] = useState("trending");
-  const [_timeRange] = useState("week");
+  const [isFollowing, setIsFollowing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasInteracted, setHasInteracted] = useState(false);
+  const [tagId, setTagId] = useState<string | null>(null);
 
-  // Mock tag data based on the tag name
-  const getTagData = (tag: string) => {
-    const tagData: Record<string, any> = {
-      react: {
-        name: "React",
-        description: "A JavaScript library for building user interfaces",
-        category: "Frontend Framework",
-        projectCount: 1240,
-        developerCount: 892,
-        weeklyGrowth: 18,
-        totalStars: 45600,
-        color: "blue",
-        relatedTags: ["javascript", "typescript", "nextjs", "redux", "hooks"],
-        officialWebsite: "https://reactjs.org",
-        documentation: "https://reactjs.org/docs",
-        github: "https://github.com/facebook/react",
-      },
-      kubernetes: {
-        name: "Kubernetes",
-        description: "Production-Grade Container Orchestration",
-        category: "DevOps & Infrastructure",
-        projectCount: 890,
-        developerCount: 567,
-        weeklyGrowth: 25,
-        totalStars: 32400,
-        color: "cyan",
-        relatedTags: ["docker", "devops", "cloud", "microservices", "helm"],
-        officialWebsite: "https://kubernetes.io",
-        documentation: "https://kubernetes.io/docs",
-        github: "https://github.com/kubernetes/kubernetes",
-      },
-      python: {
-        name: "Python",
-        description:
-          "Python is a programming language that lets you work quickly",
-        category: "Programming Language",
-        projectCount: 1580,
-        developerCount: 1240,
-        weeklyGrowth: 12,
-        totalStars: 78900,
-        color: "green",
-        relatedTags: [
-          "django",
-          "flask",
-          "machine-learning",
-          "data-science",
-          "ai",
-        ],
-        officialWebsite: "https://python.org",
-        documentation: "https://docs.python.org",
-        github: "https://github.com/python/cpython",
-      },
-    };
+  // Hook for getting tag data
+  const {
+    data: tagResponse,
+    getData: getTagData,
+    loading: tagLoading,
+  } = useGet();
 
-    return tagData[tag?.toLowerCase() || "react"] || tagData.react;
+  // Hook for getting tag details
+  const {
+    data: tagDetailsResponse,
+    getData: getTagDetails,
+    loading: tagDetailsLoading,
+  } = useGet();
+
+  // Hook for getting tag projects
+  const {
+    data: tagProjectsResponse,
+    getData: getTagProjects,
+    loading: tagProjectsLoading,
+  } = useGet();
+
+  // Hook for getting tag followers
+  const {
+    data: tagFollowersResponse,
+    getData: getTagFollowers,
+    loading: tagFollowersLoading,
+  } = useGet();
+
+  const [tagData, setTagData] = useState<any>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [followers, setFollowers] = useState<Follower[]>([]);
+
+  // Use usePost for both follow and unfollow operations
+  const {
+    uploadData: followUnfollowTag,
+    submitting: followSubmitting,
+    success: followSuccess,
+    error: followError,
+  } = usePost();
+
+  // Fetch tag details
+  useEffect(() => {
+    if (tagName) {
+      getTagData({
+        api: `${API_TAGS}?keywords=${tagName}`,
+        params: { page: 1, per_page: 5 },
+      });
+    }
+  }, [tagName]);
+
+  // Process tag data when response is received
+  useEffect(() => {
+    if (tagResponse && tagResponse.data) {
+      // Find the exact tag match
+      const exactTag = tagResponse.data.find(
+        (tag: Tag) => tag.name.toLowerCase() === tagName?.toLowerCase(),
+      );
+
+      if (exactTag) {
+        setTagId(exactTag.id);
+
+        // Fetch detailed tag information
+        getTagDetails({
+          api: `${API_TAGS}/${exactTag.id}`,
+        });
+
+        // Fetch tag projects
+        getTagProjects({
+          api: `${API_TAGS}/${exactTag.id}/projects`,
+          params: { page: 1, per_page: 10 },
+        });
+
+        // Fetch tag followers
+        getTagFollowers({
+          api: `${API_TAGS}/${exactTag.id}/following`,
+          params: { page: 1, per_page: 10 },
+        });
+      } else if (tagResponse.data.length > 0) {
+        // Use the first result if no exact match
+        const firstTag = tagResponse.data[0];
+        setTagId(firstTag.id);
+
+        // Fetch detailed tag information
+        getTagDetails({
+          api: `${API_TAGS}/${firstTag.id}`,
+        });
+
+        // Fetch tag projects
+        getTagProjects({
+          api: `${API_TAGS}/${firstTag.id}/projects`,
+          params: { page: 1, per_page: 10 },
+        });
+
+        // Fetch tag followers
+        getTagFollowers({
+          api: `${API_TAGS}/${firstTag.id}/following`,
+          params: { page: 1, per_page: 10 },
+        });
+      }
+    }
+  }, [tagResponse, tagName]);
+
+  // Process detailed tag response
+  useEffect(() => {
+    if (tagDetailsResponse && tagDetailsResponse.data) {
+      const tagDetails = tagDetailsResponse.data;
+      setTagData({
+        ...tagDetails,
+        // category: tagDetails.category || "Technology",
+        color: getTagColor(tagDetails.name),
+        relatedTags: ["javascript", "typescript", "web"], // Default related tags
+        officialWebsite: `https://${tagDetails.name}.org`,
+        documentation: `https://docs.${tagDetails.name}.org`,
+        github: `https://github.com/${tagDetails.name}`,
+      });
+
+      // Set the following status based on the API response
+      setIsFollowing(tagDetails.is_following || false);
+    }
+  }, [tagDetailsResponse]);
+
+  // Process tag projects response
+  useEffect(() => {
+    if (tagProjectsResponse && tagProjectsResponse.data) {
+      // Check if the response has the expected structure
+      if (
+        tagProjectsResponse.data.projects &&
+        Array.isArray(tagProjectsResponse.data.projects)
+      ) {
+        setProjects(tagProjectsResponse.data.projects);
+      } else if (Array.isArray(tagProjectsResponse.data)) {
+        setProjects(tagProjectsResponse.data);
+      }
+    }
+  }, [tagProjectsResponse]);
+
+  // Process tag followers response
+  useEffect(() => {
+    if (tagFollowersResponse && tagFollowersResponse.data) {
+      // Check if the response has the expected structure
+      if (
+        tagFollowersResponse.data.followers &&
+        Array.isArray(tagFollowersResponse.data.followers)
+      ) {
+        setFollowers(tagFollowersResponse.data.followers);
+      } else if (Array.isArray(tagFollowersResponse.data)) {
+        setFollowers(tagFollowersResponse.data);
+      }
+    }
+  }, [tagFollowersResponse]);
+
+  // Handle follow success/error
+  useEffect(() => {
+    if (followSuccess) {
+      setError(null);
+      // Refresh tag data to update follower count and follow status
+      if (tagId) {
+        getTagDetails({
+          api: `${API_TAGS}/${tagId}`,
+        });
+      }
+    }
+
+    if (followError && hasInteracted) {
+      // setError(followError.message || "Failed to update follow status");
+      // Revert the follow state on error
+      setIsFollowing((prev) => !prev);
+    }
+  }, [followSuccess, followError, hasInteracted, tagId]);
+
+  // Handle sort change
+  const handleSortChange = (value: string | null) => {
+    if (value && tagId) {
+      setSortBy(value || "trending");
+      getTagProjects({
+        api: `${API_TAGS}/${tagId}/projects`,
+        params: { page: 1, per_page: 10 },
+      });
+    }
   };
 
-  const tagData = getTagData(tagName || "react");
+  // Handle follow/unfollow
+  const handleFollowToggle = () => {
+    if (!tagId) {
+      return;
+    }
 
-  const trendingProjects = [
-    {
-      name: "modern-react-template",
-      author: "frontend-masters",
-      description:
-        "Modern React template with TypeScript, Vite, and best practices",
-      stars: 2340,
-      forks: 450,
-      language: "TypeScript",
-      avatar: "https://github.com/identicons/frontend-masters.png",
-      link: "/projects/modern-react-template",
-      lastUpdated: "2 days ago",
-      weeklyStars: 125,
-    },
-    {
-      name: "react-dashboard-pro",
-      author: "ui-builders",
-      description: "Professional dashboard template with React and Material-UI",
-      stars: 1890,
-      forks: 320,
-      language: "JavaScript",
-      avatar: "https://github.com/identicons/ui-builders.png",
-      link: "/projects/react-dashboard-pro",
-      lastUpdated: "1 day ago",
-      weeklyStars: 89,
-    },
-    {
-      name: "react-native-starter",
-      author: "mobile-dev-team",
-      description:
-        "Complete React Native starter with navigation and state management",
-      stars: 1456,
-      forks: 280,
-      language: "JavaScript",
-      avatar: "https://github.com/identicons/mobile-dev-team.png",
-      link: "/projects/react-native-starter",
-      lastUpdated: "3 days ago",
-      weeklyStars: 67,
-    },
-    {
-      name: "react-hooks-library",
-      author: "hooks-experts",
-      description: "Collection of custom React hooks for common use cases",
-      stars: 3240,
-      forks: 680,
-      language: "TypeScript",
-      avatar: "https://github.com/identicons/hooks-experts.png",
-      link: "/projects/react-hooks-library",
-      lastUpdated: "1 day ago",
-      weeklyStars: 156,
-    },
-  ];
+    setHasInteracted(true);
+    setError(null);
+    // Optimistically update the UI
+    setIsFollowing((prev) => !prev);
 
-  const topDevelopers = [
-    {
-      name: "Sarah Johnson",
-      username: "sarah-react-dev",
-      bio: "Senior React developer with 8+ years of experience building scalable web applications",
-      followers: 3240,
-      projects: 45,
-      avatar: "https://github.com/identicons/sarah-react-dev.png",
-      contributions: 156,
-      link: "/users/sarah-react-dev",
-    },
-    {
-      name: "Michael Chen",
-      username: "mike-frontend",
-      bio: "Full-stack developer specializing in React and Node.js ecosystems",
-      followers: 2890,
-      projects: 38,
-      avatar: "https://github.com/identicons/mike-frontend.png",
-      contributions: 142,
-      link: "/users/mike-frontend",
-    },
-    {
-      name: "Emily Rodriguez",
-      username: "emily-ui-expert",
-      bio: "UI/UX engineer creating beautiful React components and design systems",
-      followers: 4120,
-      projects: 52,
-      avatar: "https://github.com/identicons/emily-ui-expert.png",
-      contributions: 203,
-      link: "/users/emily-ui-expert",
-    },
-  ];
-
-  const weeklyStats = {
-    newProjects: 24,
-    newDevelopers: 156,
-    totalContributions: 892,
-    topLanguage: "TypeScript",
+    followUnfollowTag({
+      api: `${API_TAGS}/${tagId}/following`,
+      method: isFollowing ? "DELETE" : "POST",
+    });
   };
 
-  const learningResources = [
-    {
-      title: "Official React Documentation",
-      description: "Comprehensive guide to React concepts and API",
-      type: "Documentation",
-      url: "https://reactjs.org/docs",
-      difficulty: "Beginner",
-    },
-    {
-      title: "React Patterns and Best Practices",
-      description:
-        "Advanced patterns for building maintainable React applications",
-      type: "Tutorial",
-      url: "#",
-      difficulty: "Advanced",
-    },
-    {
-      title: "Testing React Applications",
-      description:
-        "Complete guide to testing React components and applications",
-      type: "Course",
-      url: "#",
-      difficulty: "Intermediate",
-    },
-  ];
+  // Format date to relative time
+  const formatRelativeTime = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+    if (diffInSeconds < 60) {
+      return "just now";
+    }
+    if (diffInSeconds < 3600) {
+      return `${Math.floor(diffInSeconds / 60)} minutes ago`;
+    }
+    if (diffInSeconds < 86400) {
+      return `${Math.floor(diffInSeconds / 3600)} hours ago`;
+    }
+    if (diffInSeconds < 2592000) {
+      return `${Math.floor(diffInSeconds / 86400)} days ago`;
+    }
+    return `${Math.floor(diffInSeconds / 2592000)} months ago`;
+  };
 
   const breadcrumbItems = [
     { title: "Explore", href: "/explore" },
     { title: "Tags", href: "/explore#tags" },
-    { title: tagData.name, href: "#" },
+    { title: tagData?.name || tagName || "Tag", href: "#" },
   ].map((item, index) => (
     <Anchor key={index} component={Link} to={item.href} size="sm">
       {item.title}
     </Anchor>
   ));
 
+  const loading = tagLoading || tagDetailsLoading;
+
+  if (loading) {
+    return (
+      <Container size="xl" py="lg">
+        <Stack gap="xl">
+          <Skeleton height={20} width={200} />
+          <Stack gap="lg">
+            <Group justify="space-between">
+              <Group>
+                <Skeleton height={50} width={50} circle />
+                <div>
+                  <Skeleton height={30} width={150} mb="xs" />
+                  <Skeleton height={20} width={300} />
+                </div>
+              </Group>
+              <Group>
+                <Skeleton height={36} width={100} />
+                <Skeleton height={36} width={36} circle />
+              </Group>
+            </Group>
+            <Group>
+              {[1, 2, 3, 4].map((i) => (
+                <Skeleton key={i} height={36} width={120} />
+              ))}
+            </Group>
+          </Stack>
+          <Skeleton height={400} />
+        </Stack>
+      </Container>
+    );
+  }
+
+  if (!tagData) {
+    return (
+      <Container size="xl" py="lg">
+        <Stack gap="xl">
+          <Breadcrumbs>
+            <Anchor component={Link} to="/explore" size="sm">
+              Explore
+            </Anchor>
+            <Anchor component={Link} to="/explore#tags" size="sm">
+              Tags
+            </Anchor>
+            <Text size="sm">#{tagName}</Text>
+          </Breadcrumbs>
+          <Center style={{ height: "50vh" }}>
+            <Stack align="center">
+              <Title order={2}>Tag not found</Title>
+              <Text c="dimmed">The tag "{tagName}" could not be found.</Text>
+              <Button component={Link} to="/explore#tags" variant="light">
+                Browse all tags
+              </Button>
+            </Stack>
+          </Center>
+        </Stack>
+      </Container>
+    );
+  }
+
   return (
     <Container size="xl" py="lg">
       <Stack gap="xl">
+        {/* Error notification */}
+        {error && (
+          <Notification
+            icon={<FiXCircle size={18} />}
+            color="red"
+            title="Error"
+            onClose={() => setError(null)}
+          >
+            {error}
+          </Notification>
+        )}
+
         {/* Breadcrumbs */}
         <Breadcrumbs>{breadcrumbItems}</Breadcrumbs>
 
@@ -260,15 +448,23 @@ const TagDetailsPage = () => {
                   </Badge>
                 </Group>
                 <Text size="lg" c="dimmed" maw={600}>
-                  {tagData.description}
+                  Explore projects and developers working with {tagData.name}
                 </Text>
               </div>
             </Group>
 
             <Group>
-              <Tooltip label="Follow this tag">
-                <Button variant="outline" leftSection={<FiHeart size={16} />}>
-                  Follow
+              <Tooltip
+                label={isFollowing ? "Unfollow this tag" : "Follow this tag"}
+              >
+                <Button
+                  variant={isFollowing ? "filled" : "outline"}
+                  leftSection={<FiHeart size={16} />}
+                  onClick={handleFollowToggle}
+                  loading={followSubmitting}
+                  disabled={followSubmitting}
+                >
+                  {isFollowing ? "Following" : "Follow"}
                 </Button>
               </Tooltip>
               <Tooltip label="Share tag">
@@ -287,7 +483,7 @@ const TagDetailsPage = () => {
               size="md"
               style={{ minWidth: "auto" }}
             >
-              {tagData.projectCount.toLocaleString()} Projects
+              {(tagData.projects_count || 0).toLocaleString()} Projects
             </Button>
             <Button
               variant="light"
@@ -295,80 +491,51 @@ const TagDetailsPage = () => {
               size="md"
               style={{ minWidth: "auto" }}
             >
-              {tagData.developerCount.toLocaleString()} Developers
+              {(tagData.followers_count || 0).toLocaleString()} Followers
             </Button>
             <Button
               variant="light"
-              leftSection={<FiStar size={16} />}
-              size="md"
-              style={{ minWidth: "auto" }}
+              leftSection={<FiGlobe size={16} />}
+              rightSection={<FiExternalLink size={14} />}
+              component="a"
+              href={tagData.officialWebsite}
+              target="_blank"
             >
-              {tagData.totalStars.toLocaleString()} Stars
+              Official Website
             </Button>
             <Button
               variant="light"
-              leftSection={<FiTrendingUp size={16} />}
-              size="md"
-              style={{ minWidth: "auto" }}
+              leftSection={<FiBook size={16} />}
+              rightSection={<FiExternalLink size={14} />}
+              component="a"
+              href={tagData.documentation}
+              target="_blank"
             >
-              +{tagData.weeklyGrowth}% Growth
+              Documentation
             </Button>
-            {/* </Group>
-
-          {/* Quick Links 
-          <Group gap="sm"> */}
-            {tagData.officialWebsite && (
-              <Button
-                variant="light"
-                leftSection={<FiGlobe size={16} />}
-                rightSection={<FiExternalLink size={14} />}
-                component="a"
-                href={tagData.officialWebsite}
-                target="_blank"
-              >
-                Official Website
-              </Button>
-            )}
-            {tagData.documentation && (
-              <Button
-                variant="light"
-                leftSection={<FiBook size={16} />}
-                rightSection={<FiExternalLink size={14} />}
-                component="a"
-                href={tagData.documentation}
-                target="_blank"
-              >
-                Documentation
-              </Button>
-            )}
-            {tagData.github && (
-              <Button
-                variant="light"
-                leftSection={<FiGithub size={16} />}
-                rightSection={<FiExternalLink size={14} />}
-                component="a"
-                href={tagData.github}
-                target="_blank"
-              >
-                GitHub
-              </Button>
-            )}
+            <Button
+              variant="light"
+              leftSection={<FiGithub size={16} />}
+              rightSection={<FiExternalLink size={14} />}
+              component="a"
+              href={tagData.github}
+              target="_blank"
+            >
+              GitHub
+            </Button>
           </Group>
         </Stack>
 
         <Tabs defaultValue="projects">
           <Tabs.List mb="xl">
             <Tabs.Tab value="projects" leftSection={<FiCode size={16} />}>
-              Projects ({tagData.projectCount})
+              Projects ({(tagData.projects_count || 0).toLocaleString()})
             </Tabs.Tab>
             <Tabs.Tab value="developers" leftSection={<FiUsers size={16} />}>
-              Developers ({tagData.developerCount})
+              Developers ({(tagData.followers_count || 0).toLocaleString()})
             </Tabs.Tab>
             <Tabs.Tab value="analytics" leftSection={<FiActivity size={16} />}>
               Analytics
-            </Tabs.Tab>
-            <Tabs.Tab value="resources" leftSection={<FiBook size={16} />}>
-              Learning Resources
             </Tabs.Tab>
           </Tabs.List>
 
@@ -377,7 +544,7 @@ const TagDetailsPage = () => {
               <Grid.Col span={9}>
                 <Stack gap="lg">
                   <Group justify="space-between">
-                    <Title order={3}>Trending Projects</Title>
+                    <Title order={3}>Projects</Title>
                     <Group>
                       <Select
                         data={[
@@ -387,89 +554,161 @@ const TagDetailsPage = () => {
                           { value: "forks", label: "Most Forks" },
                         ]}
                         value={sortBy}
-                        onChange={(value) => setSortBy(value || "trending")}
+                        onChange={handleSortChange}
                         leftSection={<FiFilter size={16} />}
                       />
                     </Group>
                   </Group>
 
-                  <Stack gap="md">
-                    {trendingProjects.map((project, index) => (
-                      <Card key={project.name} p="lg" withBorder radius="lg">
-                        <Grid>
-                          <Grid.Col span={8}>
-                            <Group mb="sm">
-                              <Avatar src={project.avatar} size="md" />
-                              <div style={{ flex: 1 }}>
-                                <Group gap="xs" mb={4}>
-                                  <Anchor
-                                    component={Link}
-                                    to={project.link}
-                                    size="lg"
-                                    fw={600}
-                                    style={{ textDecoration: "none" }}
-                                    onMouseEnter={(e) => {
-                                      e.currentTarget.style.textDecoration =
-                                        "underline";
-                                    }}
-                                    onMouseLeave={(e) => {
-                                      e.currentTarget.style.textDecoration =
-                                        "none";
-                                    }}
-                                  >
-                                    {project.name}
-                                  </Anchor>
-                                  <Badge size="sm" variant="light">
-                                    #{index + 1}
-                                  </Badge>
-                                </Group>
-                                <Text size="sm" c="dimmed" mb="xs">
-                                  by {project.author}
-                                </Text>
-                                <Text size="sm" c="dimmed" mb="sm">
-                                  {project.description}
-                                </Text>
-                                <Group gap="lg">
-                                  <Group gap={4}>
-                                    <FiStar size={14} color="#6c757d" />
-                                    <Text size="sm" c="dimmed">
-                                      {project.stars.toLocaleString()}
-                                    </Text>
-                                    <Group gap={2} ml="xs">
-                                      <FiArrowUp size={12} color="green" />
-                                      <Text size="xs" c="green">
-                                        +{project.weeklyStars} this week
+                  {tagProjectsLoading ? (
+                    <Stack gap="md">
+                      {Array.from({ length: 4 }).map((_, index) => (
+                        <Card key={index} p="lg" withBorder radius="lg">
+                          <Grid>
+                            <Grid.Col span={8}>
+                              <Group mb="sm">
+                                <Skeleton height={40} width={40} circle />
+                                <div style={{ flex: 1 }}>
+                                  <Skeleton height={20} width={200} mb={4} />
+                                  <Skeleton height={16} width={150} mb="xs" />
+                                  <Skeleton height={16} width={300} mb="sm" />
+                                  <Group gap="lg">
+                                    <Skeleton height={16} width={100} />
+                                    <Skeleton height={16} width={80} />
+                                    <Skeleton height={16} width={120} />
+                                  </Group>
+                                </div>
+                              </Group>
+                            </Grid.Col>
+                            <Grid.Col span={4}>
+                              <Group justify="flex-end" align="flex-start">
+                                <Skeleton height={24} width={80} />
+                                <Skeleton height={24} width={24} circle />
+                                <Skeleton height={24} width={24} circle />
+                              </Group>
+                            </Grid.Col>
+                          </Grid>
+                        </Card>
+                      ))}
+                    </Stack>
+                  ) : projects.length > 0 ? (
+                    <Stack gap="md">
+                      {projects.map((project, index) => (
+                        <Card key={project.id} p="lg" withBorder radius="lg">
+                          <Grid>
+                            <Grid.Col span={8}>
+                              <Group mb="sm">
+                                <Avatar
+                                  size="md"
+                                  radius="sm"
+                                  color="blue"
+                                  variant="gradient"
+                                  gradient={{ from: "blue", to: "cyan" }}
+                                >
+                                  <FiCode size={14} />
+                                </Avatar>
+                                <div style={{ flex: 1 }}>
+                                  <Group gap="xs" mb={4}>
+                                    <Anchor
+                                      component={Link}
+                                      to={`/projects/${project.id}`}
+                                      size="lg"
+                                      fw={600}
+                                      style={{ textDecoration: "none" }}
+                                      onMouseEnter={(e) => {
+                                        e.currentTarget.style.textDecoration =
+                                          "underline";
+                                      }}
+                                      onMouseLeave={(e) => {
+                                        e.currentTarget.style.textDecoration =
+                                          "none";
+                                      }}
+                                    >
+                                      {project.name || "Unnamed Project"}
+                                    </Anchor>
+                                    <Badge size="sm" variant="light">
+                                      #{index + 1}
+                                    </Badge>
+                                  </Group>
+                                  <Text size="sm" c="dimmed" mb="xs">
+                                    {project.organisation || "Personal Project"}
+                                  </Text>
+                                  <Text size="sm" c="dimmed" mb="sm">
+                                    {project.description ||
+                                      "No description available"}
+                                  </Text>
+                                  <Group gap="lg">
+                                    <Group gap={4}>
+                                      <FiCode size={14} color="#6c757d" />
+                                      <Text size="sm" c="dimmed">
+                                        {project.apps_count || 0} Apps
                                       </Text>
                                     </Group>
-                                  </Group>
-                                  <Group gap={4}>
-                                    <FiGitBranch size={14} color="#6c757d" />
+                                    <Group gap={4}>
+                                      <FiUsers size={14} color="#6c757d" />
+                                      <Text size="sm" c="dimmed">
+                                        {project.members_count || 0} Members
+                                      </Text>
+                                    </Group>
+                                    <Group gap={4}>
+                                      <FiHeart size={14} color="#6c757d" />
+                                      <Text size="sm" c="dimmed">
+                                        {project.followers_count || 0} Followers
+                                      </Text>
+                                    </Group>
                                     <Text size="sm" c="dimmed">
-                                      {project.forks}
+                                      Created{" "}
+                                      {formatRelativeTime(project.date_created)}
                                     </Text>
                                   </Group>
-                                  <Text size="sm" c="dimmed">
-                                    Updated {project.lastUpdated}
-                                  </Text>
-                                </Group>
-                              </div>
+                                </div>
+                              </Group>
+                            </Grid.Col>
+                            <Grid.Col span={4}>
+                              <Group justify="flex-end" align="flex-start">
+                                <Badge variant="light">
+                                  {project.project_type || "Unknown"}
+                                </Badge>
+                                <ActionIcon variant="subtle">
+                                  <FiHeart size={16} />
+                                </ActionIcon>
+                                <ActionIcon variant="subtle">
+                                  <FiBookmark size={16} />
+                                </ActionIcon>
+                              </Group>
+                            </Grid.Col>
+                          </Grid>
+
+                          {/* Project Tags */}
+                          {project.tags && project.tags.length > 0 && (
+                            <Group gap="xs" mt="md">
+                              {project.tags.slice(0, 5).map((tag) => (
+                                <Badge
+                                  key={tag.id}
+                                  variant="light"
+                                  color={getTagColor(tag.name)}
+                                  component={Link}
+                                  to={`/tags/${tag.name}`}
+                                  style={{ cursor: "pointer" }}
+                                >
+                                  #{tag.name}
+                                </Badge>
+                              ))}
+                              {project.tags.length > 5 && (
+                                <Badge variant="outline">
+                                  +{project.tags.length - 5} more
+                                </Badge>
+                              )}
                             </Group>
-                          </Grid.Col>
-                          <Grid.Col span={4}>
-                            <Group justify="flex-end" align="flex-start">
-                              <Badge variant="light">{project.language}</Badge>
-                              <ActionIcon variant="subtle">
-                                <FiHeart size={16} />
-                              </ActionIcon>
-                              <ActionIcon variant="subtle">
-                                <FiBookmark size={16} />
-                              </ActionIcon>
-                            </Group>
-                          </Grid.Col>
-                        </Grid>
-                      </Card>
-                    ))}
-                  </Stack>
+                          )}
+                        </Card>
+                      ))}
+                    </Stack>
+                  ) : (
+                    <Center style={{ height: 200 }}>
+                      <Text c="dimmed">No projects found for this tag.</Text>
+                    </Center>
+                  )}
                 </Stack>
               </Grid.Col>
 
@@ -502,31 +741,28 @@ const TagDetailsPage = () => {
                   {/* Weekly Activity */}
                   <Card p="md" withBorder radius="lg">
                     <Title order={4} mb="md">
-                      This Week
+                      Statistics
                     </Title>
                     <Stack gap="sm">
                       <Group justify="space-between">
-                        <Text size="sm">New Projects</Text>
+                        <Text size="sm">Total Projects</Text>
                         <Badge variant="light" color="blue">
-                          +{weeklyStats.newProjects}
+                          {tagData.projects_count || 0}
                         </Badge>
                       </Group>
                       <Group justify="space-between">
-                        <Text size="sm">New Developers</Text>
+                        <Text size="sm">Total Followers</Text>
                         <Badge variant="light" color="green">
-                          +{weeklyStats.newDevelopers}
+                          {tagData.followers_count || 0}
                         </Badge>
                       </Group>
                       <Group justify="space-between">
-                        <Text size="sm">Contributions</Text>
-                        <Badge variant="light" color="purple">
-                          {weeklyStats.totalContributions}
-                        </Badge>
-                      </Group>
-                      <Group justify="space-between">
-                        <Text size="sm">Top Language</Text>
-                        <Badge variant="light" color="orange">
-                          {weeklyStats.topLanguage}
+                        <Text size="sm">Super Tag</Text>
+                        <Badge
+                          variant="light"
+                          color={tagData.is_super_tag ? "green" : "gray"}
+                        >
+                          {tagData.is_super_tag ? "Yes" : "No"}
                         </Badge>
                       </Group>
                     </Stack>
@@ -538,46 +774,80 @@ const TagDetailsPage = () => {
 
           <Tabs.Panel value="developers">
             <Stack gap="lg">
-              <Title order={3}>Top Contributors</Title>
-              <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
-                {topDevelopers.map((developer) => (
-                  <Card key={developer.username} p="lg" withBorder radius="lg">
-                    <Group mb="md">
-                      <Avatar src={developer.avatar} size="lg" />
-                      <div style={{ flex: 1 }}>
-                        <Anchor
-                          component={Link}
-                          to={developer.link}
-                          size="lg"
-                          fw={600}
-                          style={{ textDecoration: "none" }}
-                        >
-                          {developer.name}
-                        </Anchor>
-                        <Text size="sm" c="dimmed">
-                          @{developer.username}
-                        </Text>
-                      </div>
-                      <Button variant="outline" size="sm">
-                        Follow
-                      </Button>
-                    </Group>
-                    <Text size="sm" c="dimmed" mb="md">
-                      {developer.bio}
-                    </Text>
-                    <Group justify="space-between">
-                      <Group gap="lg">
-                        <Text size="sm" c="dimmed">
-                          {developer.followers} followers
-                        </Text>
-                        <Text size="sm" c="dimmed">
-                          {developer.projects} projects
-                        </Text>
+              <Title order={3}>Developers Following This Tag</Title>
+              {tagFollowersLoading ? (
+                <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <Card key={index} p="lg" withBorder radius="lg">
+                      <Group mb="md">
+                        <Skeleton height={50} width={50} circle />
+                        <div style={{ flex: 1 }}>
+                          <Skeleton height={20} width={150} mb={4} />
+                          <Skeleton height={16} width={100} />
+                        </div>
+                        <Skeleton height={30} width={80} />
                       </Group>
-                    </Group>
-                  </Card>
-                ))}
-              </SimpleGrid>
+                      <Skeleton height={16} width="100%" mb="md" />
+                      <Group justify="space-between">
+                        <Skeleton height={16} width={100} />
+                        <Skeleton height={16} width={80} />
+                      </Group>
+                    </Card>
+                  ))}
+                </SimpleGrid>
+              ) : followers.length > 0 ? (
+                <SimpleGrid cols={{ base: 1, md: 2, lg: 3 }} spacing="lg">
+                  {followers.map((developer) => (
+                    <Card key={developer.id} p="lg" withBorder radius="lg">
+                      <Group mb="md">
+                        <Avatar
+                          src={developer.profile_picture || undefined}
+                          size="lg"
+                          radius="xl"
+                        />
+                        <div style={{ flex: 1 }}>
+                          <Anchor
+                            component={Link}
+                            to={`/users/${developer.username}`}
+                            size="lg"
+                            fw={600}
+                            style={{ textDecoration: "none" }}
+                          >
+                            {developer.name}
+                          </Anchor>
+                          <Text size="sm" c="dimmed">
+                            @{developer.username}
+                          </Text>
+                        </div>
+                        <Button variant="outline" size="sm">
+                          Follow
+                        </Button>
+                      </Group>
+                      {developer.biography && (
+                        <Text size="sm" c="dimmed" mb="md" lineClamp={2}>
+                          {developer.biography}
+                        </Text>
+                      )}
+                      <Group justify="space-between">
+                        <Group gap="lg">
+                          <Text size="sm" c="dimmed">
+                            {developer.followers_count} followers
+                          </Text>
+                          <Text size="sm" c="dimmed">
+                            {developer.owned_projects_count} projects
+                          </Text>
+                        </Group>
+                      </Group>
+                    </Card>
+                  ))}
+                </SimpleGrid>
+              ) : (
+                <Center style={{ height: 200 }}>
+                  <Text c="dimmed">
+                    No developers are following this tag yet.
+                  </Text>
+                </Center>
+              )}
             </Stack>
           </Tabs.Panel>
 
@@ -644,66 +914,15 @@ const TagDetailsPage = () => {
                       <Group justify="space-between" mb="xs">
                         <Text size="sm">Growth Rate</Text>
                         <Text size="sm" fw={600}>
-                          +{tagData.weeklyGrowth}%
+                          +15%
                         </Text>
                       </Group>
-                      <Progress
-                        value={tagData.weeklyGrowth * 3}
-                        color={tagData.color}
-                        size="sm"
-                      />
+                      <Progress value={45} color={tagData.color} size="sm" />
                     </div>
                   </Stack>
                 </Card>
               </Grid.Col>
             </Grid>
-          </Tabs.Panel>
-
-          <Tabs.Panel value="resources">
-            <Title order={3} mb="lg">
-              Learning Resources
-            </Title>
-            <Stack gap="md">
-              {learningResources.map((resource, index) => (
-                <Card key={index} p="lg" withBorder radius="lg">
-                  <Group justify="space-between" mb="sm">
-                    <div style={{ flex: 1 }}>
-                      <Group gap="sm" mb="xs">
-                        <Title order={4}>{resource.title}</Title>
-                        <Badge variant="light" size="sm">
-                          {resource.type}
-                        </Badge>
-                        <Badge
-                          variant="outline"
-                          size="sm"
-                          color={
-                            resource.difficulty === "Beginner"
-                              ? "green"
-                              : resource.difficulty === "Intermediate"
-                                ? "orange"
-                                : "red"
-                          }
-                        >
-                          {resource.difficulty}
-                        </Badge>
-                      </Group>
-                      <Text size="sm" c="dimmed">
-                        {resource.description}
-                      </Text>
-                    </div>
-                    <Button
-                      variant="light"
-                      rightSection={<FiExternalLink size={14} />}
-                      component="a"
-                      href={resource.url}
-                      target="_blank"
-                    >
-                      View
-                    </Button>
-                  </Group>
-                </Card>
-              ))}
-            </Stack>
           </Tabs.Panel>
         </Tabs>
       </Stack>


### PR DESCRIPTION
# Description

This PR implements the tag details page with real data from the CraneCloud API, replacing all dummy data with actual API responses. The page now displays:

Tag information (name, project count, followers count)

Projects associated with the tag with complete project details

Developers following the tag with profile information and images

Follow and unfollow of the tag

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Been Tested?

Navigate to any tag page 

Verify that tag information is displayed correctly

Check that projects associated with the tag are shown with:

Project name and description

Organization/type

App count, member count, and follower count

Creation date

All associated tags

Verify that developers following the tag are displayed with:

Profile pictures

Names and usernames

Follower and project counts

Test the follow/unfollow functionality



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots
<img width="1346" height="610" alt="tag" src="https://github.com/user-attachments/assets/97678db9-7c50-487a-96d8-49f941badcba" />
