### PR TITLE
feat(socials): add project public view for socials

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,6 +10,7 @@ import HealthCheck from "./components/HealthCheck";
 import ClustersPage from "./pages/admin/ClustersPage";
 import ClusterSettingsPage from "./pages/admin/cluster/ClusterSettingsPage";
 import ProfileViewPage from "./pages/Users/ProfileViewPage";
+import ProjectViewPage from "./pages/Projects/ProjectViewPage";
 
 // import { HomePage } from "./pages/Home.page";
 const AppsListPage = React.lazy(() => import("./pages/Apps/AppsListPage"));
@@ -82,6 +83,7 @@ export const DashboardRoutes = [
   { path: "/", element: <LandingPage /> },
   { path: "/explore", element: <ExplorePage /> },
   { path: "/tags/:tagName", element: <TagDetailsPage /> },
+  { path: "/explore/:project_id", element: <ProjectViewPage /> },
   { path: "/profile/:user_id", element: <UserProfilePage /> },
   { path: "/users/profile/settings", element: <UserProfileSettingsPage /> },
   { path: "/:username", element: <ProfileViewPage /> },

--- a/src/components/Cards/ProjectExploreCard.tsx
+++ b/src/components/Cards/ProjectExploreCard.tsx
@@ -86,7 +86,6 @@ const ProjectExploreCard = ({ project }: ProjectExploreCardProps) => {
       radius="lg"
       style={{
         flex: "1 1 350px",
-        maxWidth: "380px",
         display: "flex",
         flexDirection: "column",
       }}
@@ -97,7 +96,7 @@ const ProjectExploreCard = ({ project }: ProjectExploreCardProps) => {
             <div>
               <Anchor
                 component={Link}
-                to={project.link || "#"}
+                to={`/explore/${project?.id}`}
                 fw={600}
                 style={{ textDecoration: "none" }}
               >

--- a/src/components/Cards/ProjectSocialsCard.tsx
+++ b/src/components/Cards/ProjectSocialsCard.tsx
@@ -360,6 +360,7 @@ export default function ProjectSocialsCard({
             bottom: "15px",
             right: "8px",
           }}
+          tt="capitalize"
         >
           {isPublicProject ? "Public" : "Private"}
         </Badge>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,7 +35,7 @@ import { Logo, UserDropDown } from "./Common";
 import { Link, useNavigate } from "react-router-dom";
 import Search from "./Elements/Search";
 import { useAuth } from "@/utils/AuthContext";
-import { IoAirplaneOutline } from "react-icons/io5";
+import { DOCS_URL } from "@/config";
 
 interface HeaderProps {
   opened: boolean;
@@ -71,12 +71,18 @@ export const DashboardHeader = ({ opened, toggle }: HeaderProps) => {
           >
             <Group gap={5}>
               <Text fw={700}>Explore</Text>
-              <IoAirplaneOutline
-                size={18}
-                style={{ transform: "rotate(315deg)" }}
-              />
             </Group>
           </Link>
+          <a
+            href={`${DOCS_URL}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ textDecoration: "none", paddingLeft: "10px" }}
+          >
+            <Group gap={5}>
+              <Text fw={700}>Docs</Text>
+            </Group>
+          </a>
         </Group>
         <Group>
           <Search />

--- a/src/components/Trending/TrendingProjects.tsx
+++ b/src/components/Trending/TrendingProjects.tsx
@@ -59,7 +59,7 @@ export default function TrendingProjects({
                 <Group align="flex-start" gap={12} mt={2}>
                   <div style={{ flex: 1 }}>
                     <Anchor
-                      href={`/projects/${project.id}`}
+                      href={`/explore/${project.id}`}
                       size="sm"
                       fw={500}
                       style={{
@@ -110,7 +110,7 @@ export default function TrendingProjects({
 
                 <Group gap={2} mt={6}>
                   <FiUsers size={10} color="#6c757d" />
-                  <Text size="xs" c="dimmed" fw={500} ml={2}>
+                  <Text size="sm" c="dimmed" fw={500} ml={2}>
                     {project.followers_count || 0} followers
                   </Text>
                 </Group>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -12,7 +12,6 @@ import {
   Select,
   SimpleGrid,
   ThemeIcon,
-  Flex,
   Center,
   Box,
   Loader,
@@ -282,37 +281,29 @@ const ExplorePage = () => {
           </Tabs.Panel>
 
           <Tabs.Panel value="projects">
-            <Grid>
-              <Grid.Col span={12}>
-                <Flex wrap="wrap" gap="lg" justify="flex-start">
-                  {searching ? (
-                    <Center w="100%" h="300px">
-                      <Loader size="xl" type="oval" />
-                    </Center>
-                  ) : selectedCategory === "projects" ? (
-                    searchQuery !== "" ? (
-                      searchResponse?.data?.projects?.length > 0 ? (
-                        searchResponse.data.projects.map((project: any) => (
-                          <ProjectExploreCard
-                            key={project.id}
-                            project={project}
-                          />
-                        ))
-                      ) : (
-                        <EmptyState message="No projects found" />
-                      )
-                    ) : (
-                      projectsResponse?.data?.projects?.map((project: any) => (
-                        <ProjectExploreCard
-                          key={project.id}
-                          project={project}
-                        />
-                      ))
-                    )
-                  ) : null}
-                </Flex>
-              </Grid.Col>
-            </Grid>
+            <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
+              {searching ? (
+                <div style={{ gridColumn: "1 / -1" }}>
+                  <Center w="100%" h="300px">
+                    <Loader size="xl" type="oval" />
+                  </Center>
+                </div>
+              ) : selectedCategory === "projects" ? (
+                searchQuery !== "" ? (
+                  searchResponse?.data?.projects?.length > 0 ? (
+                    searchResponse.data.projects.map((project: any) => (
+                      <ProjectExploreCard key={project.id} project={project} />
+                    ))
+                  ) : (
+                    <EmptyState message="No projects found" />
+                  )
+                ) : (
+                  projectsResponse?.data?.projects?.map((project: any) => (
+                    <ProjectExploreCard key={project.id} project={project} />
+                  ))
+                )
+              ) : null}
+            </SimpleGrid>
           </Tabs.Panel>
 
           <Tabs.Panel value="users">
@@ -545,7 +536,7 @@ interface EmptyStateProps {
   message?: string;
 }
 
-const EmptyState = ({ message = "No data found" }: EmptyStateProps) => {
+export const EmptyState = ({ message = "No data found" }: EmptyStateProps) => {
   return (
     <Center w="100%" h="200px">
       <Box

--- a/src/pages/Projects/ProjectViewPage.tsx
+++ b/src/pages/Projects/ProjectViewPage.tsx
@@ -1,0 +1,335 @@
+import UserCard from "@/components/Cards/UserCard";
+import { Tag } from "@/types/tag";
+import { User } from "@/types/user";
+import { API_PROJECTS } from "@/utils/apis";
+import {
+  beautify,
+  getTagColor,
+  timeAgo,
+  useSetContainerSize,
+  useSetNoSidebar,
+} from "@/utils/helpers";
+import useGet from "@/utils/useGet";
+import {
+  ActionIcon,
+  Anchor,
+  Badge,
+  Box,
+  Breadcrumbs,
+  Button,
+  Card,
+  Center,
+  Container,
+  Grid,
+  Group,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Tabs,
+  Text,
+  ThemeIcon,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+import { Fragment, useEffect, useState } from "react";
+import {
+  FiCalendar,
+  FiCheck,
+  FiLayers,
+  FiShare2,
+  FiTag,
+  FiUserPlus,
+  FiUsers,
+} from "react-icons/fi";
+import { LuUsers } from "react-icons/lu";
+import { Link, useParams } from "react-router-dom";
+import { EmptyState } from "../ExplorePage";
+import usePost from "@/utils/usePost";
+
+const ProjectViewPage = () => {
+  useSetNoSidebar();
+  useSetContainerSize("full");
+
+  const { project_id } = useParams<{ project_id: string }>();
+  const [isFollowingProject, setIsFollowingProject] = useState<
+    boolean | undefined
+  >(undefined);
+
+  const {
+    uploadData: followProject,
+    submitting: following,
+    success: follow_success,
+    data: follow_response,
+  } = usePost();
+
+  const {
+    uploadData: unfollowProject,
+    submitting: unfollowing,
+    success: unfollow_success,
+    data: unfollow_response,
+  } = usePost();
+
+  const {
+    data: projectResponse,
+    getData: getProjectDetails,
+    loading: gettingProjectDetails,
+  } = useGet();
+
+  const {
+    data: followersResponse,
+    getData: getProjectFollowers,
+    loading: gettingFollowers,
+  } = useGet();
+
+  useEffect(() => {
+    getProjectDetails({
+      api: `${API_PROJECTS}/${project_id}`,
+      params: { public_view: "True" },
+    });
+  }, []);
+
+  useEffect(() => {
+    getProjectFollowers({
+      api: `${API_PROJECTS}/${project_id}/following`,
+    });
+  }, []);
+
+  const isFollowLoading = following || unfollowing;
+  const projectDetails = projectResponse?.data?.project || {};
+  const projectFollowers = followersResponse?.data.followers || [];
+
+  useEffect(() => {
+    if (projectDetails?.is_following !== undefined) {
+      setIsFollowingProject(projectDetails.is_following);
+    }
+  }, [projectDetails?.is_following]);
+
+  useEffect(() => {
+    if (follow_success && follow_response) {
+      setIsFollowingProject(true);
+    }
+  }, [follow_success, follow_response]);
+
+  useEffect(() => {
+    if (unfollow_success && unfollow_response) {
+      setIsFollowingProject(false);
+    }
+  }, [unfollow_success, unfollow_response]);
+
+  if (gettingProjectDetails || gettingFollowers) {
+    return (
+      <Container size="xl" py="lg">
+        <Center w="100%" h="300px">
+          <Loader size="xl" type="oval" />
+        </Center>
+      </Container>
+    );
+  }
+
+  const breadcrumbItems = [
+    { title: "Explore", href: "/explore" },
+    { title: "Projects", href: "/explore#projects" },
+    { title: projectDetails?.name || "Project", href: "#" },
+  ].map((item, index) => (
+    <Anchor key={index} component={Link} to={item.href} size="sm">
+      {item.title}
+    </Anchor>
+  ));
+
+  // Handle follow/unfollow click
+  const onFollowClick = () => {
+    if (isFollowingProject) {
+      unfollowProject({
+        api: `${API_PROJECTS}/${project_id}/following`,
+        method: "DELETE",
+      });
+    } else {
+      followProject({
+        api: `${API_PROJECTS}/${project_id}/following`,
+      });
+    }
+  };
+
+  return (
+    <>
+      <Container size="xl" py="lg">
+        <Stack gap="xl">
+          <Breadcrumbs>{breadcrumbItems}</Breadcrumbs>
+
+          <Stack gap="lg">
+            <Group justify="space-between" align="flex-start">
+              <Group>
+                <div>
+                  <Group gap="xs" mb="xs">
+                    <Title order={1}>{projectDetails?.name}</Title>
+                    <Badge variant="light" size="lg" tt="capitalize">
+                      {projectDetails?.project_type}
+                    </Badge>
+                  </Group>
+                  <Text size="lg" c="dimmed" maw={600}>
+                    {projectDetails?.description}
+                  </Text>
+                </div>
+              </Group>
+
+              <Group>
+                <Button
+                  variant="outline"
+                  leftSection={
+                    isFollowLoading ? (
+                      <Loader size="xs" />
+                    ) : isFollowingProject ? (
+                      <FiCheck size={14} />
+                    ) : (
+                      <FiUserPlus size={14} />
+                    )
+                  }
+                  onClick={onFollowClick}
+                  disabled={isFollowLoading}
+                >
+                  {isFollowLoading
+                    ? isFollowingProject
+                      ? "Unfollowing..."
+                      : "Following..."
+                    : isFollowingProject
+                      ? "Following"
+                      : "Follow"}
+                </Button>
+                <Tooltip label="Share tag">
+                  <ActionIcon variant="outline" size="lg">
+                    <FiShare2 size={18} />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            </Group>
+
+            <Group gap="xl">
+              <Group gap={6}>
+                <LuUsers size={16} />
+                <Text size="md" fw={500}>
+                  {projectDetails.followers_count || 0}
+                </Text>
+                <Text size="md" c="dimmed">
+                  Followers
+                </Text>
+              </Group>
+              <Group gap={6}>
+                <FiLayers size={16} />
+                <Text size="md" fw={500}>
+                  {projectDetails?.apps_count || 0}
+                </Text>
+                <Text size="md" c="dimmed">
+                  Apps
+                </Text>
+              </Group>
+              <Group gap={6}>
+                <FiTag size={16} />
+                <Text size="md" fw={500}>
+                  {projectDetails.tags_count || 0}
+                </Text>
+                <Text size="md" c="dimmed">
+                  Tags
+                </Text>
+              </Group>
+              <Group gap={6}>
+                <FiCalendar size={16} />
+                <Text size="md" c="dimmed" fw={500}>
+                  {timeAgo(projectDetails?.date_created)}
+                </Text>
+              </Group>
+            </Group>
+          </Stack>
+
+          <Tabs defaultValue="users">
+            <Tabs.List mb="xl">
+              <Tabs.Tab value="users" leftSection={<FiUsers size={16} />}>
+                Followers
+              </Tabs.Tab>
+              <Tabs.Tab value="tags" leftSection={<FiTag size={16} />}>
+                Tags
+              </Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value="users">
+              <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
+                {projectFollowers.length > 0 ? (
+                  projectFollowers?.map((user: User) => (
+                    <Fragment key={user.username}>
+                      <UserCard user={user} isCard showBorder />
+                    </Fragment>
+                  ))
+                ) : (
+                  <Box style={{ gridColumn: "1 / -1" }}>
+                    <EmptyState message="No followers found for this project" />
+                  </Box>
+                )}
+              </SimpleGrid>
+            </Tabs.Panel>
+
+            <Tabs.Panel value="tags">
+              <Grid>
+                <Grid.Col span={12}>
+                  <SimpleGrid
+                    cols={{ base: 1, sm: 2, md: 4, lg: 7 }}
+                    spacing="md"
+                  >
+                    {projectDetails?.tags?.length > 0 ? (
+                      projectDetails?.tags?.map((tag: Tag) => {
+                        return (
+                          <Card
+                            key={tag.id}
+                            p="lg"
+                            withBorder
+                            radius="lg"
+                            ta="center"
+                            component={Link}
+                            to={`/tags/${tag.name}`}
+                            style={{
+                              cursor: "pointer",
+                              textDecoration: "none",
+                              color: "inherit",
+                              transition: "all 0.2s ease",
+                              display: "flex",
+                              flexDirection: "column",
+                            }}
+                            className="hover:shadow-md"
+                            onClick={(e) => {
+                              if ((e.target as HTMLElement).closest("button")) {
+                                e.preventDefault();
+                              }
+                            }}
+                          >
+                            <ThemeIcon
+                              size="xl"
+                              variant="light"
+                              color={getTagColor(tag.name)}
+                              mx="auto"
+                              mb="md"
+                            >
+                              <FiTag size={24} />
+                            </ThemeIcon>
+                            <Stack gap="xs" align="center" style={{ flex: 1 }}>
+                              <Title order={4} size="sm">
+                                {beautify(tag.name)}
+                              </Title>
+                            </Stack>
+                          </Card>
+                        );
+                      })
+                    ) : (
+                      <Box style={{ gridColumn: "1 / -1" }}>
+                        <EmptyState message="No tags found for this project" />
+                      </Box>
+                    )}
+                  </SimpleGrid>
+                </Grid.Col>
+              </Grid>
+            </Tabs.Panel>
+          </Tabs>
+        </Stack>
+      </Container>
+    </>
+  );
+};
+
+export default ProjectViewPage;

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -696,3 +696,30 @@ export const getTagColor = (tagName: string) => {
 
   return brightColors[Math.abs(hash) % brightColors.length];
 };
+
+export function timeAgo(dateString: string): string {
+  const now = new Date();
+  const date = new Date(dateString);
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  const intervals: { label: string; seconds: number }[] = [
+    { label: "year", seconds: 31536000 },
+    { label: "month", seconds: 2592000 },
+    { label: "week", seconds: 604800 },
+    { label: "day", seconds: 86400 },
+    { label: "hour", seconds: 3600 },
+    { label: "minute", seconds: 60 },
+    { label: "second", seconds: 1 },
+  ];
+
+  for (const interval of intervals) {
+    const count = Math.floor(seconds / interval.seconds);
+    if (count >= 1) {
+      return count === 1
+        ? `${count} ${interval.label} ago`
+        : `${count} ${interval.label}s ago`;
+    }
+  }
+
+  return "just now";
+}


### PR DESCRIPTION
# Description

- This PR adds the public view for projects showing project meta data such as project info, followers, tags and the follow/unfollow functionality.
- Also includes minor fixes and page enhancements 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## ClickUp Ticket ID

## How Can This Been Tested?

- Run this and checkout the explore page, you can now click to see more information about that project i.e. followers and associated tags.
- You can also follow/unfollow that project.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="1453" height="592" alt="Screenshot 2025-09-22 at 7 14 21 PM" src="https://github.com/user-attachments/assets/e764040d-b299-40ae-9c21-c993bb548c9a" />

<img width="1452" height="609" alt="Screenshot 2025-09-22 at 7 13 59 PM" src="https://github.com/user-attachments/assets/406bb6c3-8ddf-4f58-b33f-163dc8bcfd26" />
