### PR TITLE
feat: add infinite scroll to projects/users listings on explore page

### DIFF
--- a/src/components/Trending/TrendingTags.tsx
+++ b/src/components/Trending/TrendingTags.tsx
@@ -47,7 +47,7 @@ export default function TrendingTags({
           <TagsSkeleton />
         ) : (
           response?.data?.tags?.map((tag: Tag) => (
-            <Group key={tag.name} justify="space-between">
+            <Group key={tag.id} justify="space-between">
               <Badge
                 variant="outline"
                 color={getTagColor(tag.name)}

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -45,6 +45,7 @@ import { User } from "@/types/user";
 import UserCard from "@/components/Cards/UserCard";
 import { TbFolderOff } from "react-icons/tb";
 import { useDebouncedValue } from "@mantine/hooks";
+import { useInfiniteScrollWithPagination } from "@/hooks/generic/useInfiniteScroll";
 
 const ExplorePage = () => {
   useSetNoSidebar();
@@ -61,9 +62,64 @@ const ExplorePage = () => {
     getData: searchSocials,
     loading: searching,
   } = useGet();
-  const { data: projectsResponse, getData: getProjects } = useGet();
-  const { data: developersResponse, getData: getDevelopers } = useGet();
+  const {
+    data: projectsResponse,
+    getData: getProjects,
+    loading,
+    success,
+  } = useGet();
+  const {
+    data: usersResponse,
+    getData: getUsers,
+    loading: loadingUsers,
+    success: fetchedUsers,
+  } = useGet();
   const { data: tagsResponse, getData: getTags } = useGet();
+
+  const { items: projects, lastElementRef } = useInfiniteScrollWithPagination({
+    loading,
+    success,
+    data: projectsResponse,
+    extractItems: (data) => data?.data?.projects || [],
+    extractPagination: (data) => data?.data?.pagination || {},
+    extractItemId: (project) => project.id,
+    onLoadMore: (page) => {
+      getProjects({
+        api: `${API_SOCIALS}?entity=projects`,
+        params: { page, per_page: 10 },
+      });
+    },
+  });
+
+  useEffect(() => {
+    getProjects({
+      api: `${API_SOCIALS}?entity=projects`,
+      params: { page: 1, per_page: 10 },
+    });
+  }, []);
+
+  const { items: users, lastElementRef: userLastElementRef } =
+    useInfiniteScrollWithPagination({
+      loading: loadingUsers,
+      success: fetchedUsers,
+      data: usersResponse,
+      extractItems: (data) => data?.data?.users || [],
+      extractPagination: (data) => data?.data?.pagination || {},
+      extractItemId: (user) => user.id,
+      onLoadMore: (page) => {
+        getUsers({
+          api: `${API_SOCIALS}?entity=users`,
+          params: { page, per_page: 25 },
+        });
+      },
+    });
+
+  useEffect(() => {
+    getUsers({
+      api: `${API_SOCIALS}?entity=users`,
+      params: { page: 1, per_page: 25 },
+    });
+  }, []);
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -88,8 +144,8 @@ const ExplorePage = () => {
   }, []);
 
   useEffect(() => {
-    getDevelopers({
-      api: `${API_SOCIALS}?entity=users&per_page=21&page=1`,
+    getUsers({
+      api: `${API_SOCIALS}?entity=users&per_page=25&page=1`,
     });
   }, []);
 
@@ -453,9 +509,21 @@ const ExplorePage = () => {
                     <EmptyState message="No projects found" />
                   )
                 ) : (
-                  projectsResponse?.data?.projects?.map((project: any) => (
-                    <ProjectExploreCard key={project.id} project={project} />
-                  ))
+                  projects?.map((project: any, index) => {
+                    const isLast = index === projects.length - 1;
+                    return (
+                      <div
+                        key={project.id}
+                        ref={isLast ? lastElementRef : null}
+                        style={{ height: "100%" }}
+                      >
+                        <ProjectExploreCard
+                          key={project.id}
+                          project={project}
+                        />
+                      </div>
+                    );
+                  })
                 )
               ) : null}
             </SimpleGrid>
@@ -483,11 +551,17 @@ const ExplorePage = () => {
                     </div>
                   )
                 ) : (
-                  developersResponse?.data?.users?.map((user: User) => (
-                    <Fragment key={user.username}>
-                      <UserCard user={user} isCard showBorder />
-                    </Fragment>
-                  ))
+                  users?.map((user: User, index) => {
+                    const isLast = index === projects.length - 1;
+                    return (
+                      <div
+                        key={user.id}
+                        ref={isLast ? userLastElementRef : null}
+                      >
+                        <UserCard user={user} isCard showBorder />
+                      </div>
+                    );
+                  })
                 )
               ) : null}
             </SimpleGrid>


### PR DESCRIPTION
# Description

- This PR includes infinite scroll to the projects and users tabs on the explore page to allow browsing users to see more for the current tab.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## ClickUp Ticket ID

## How Can This Been Tested?

- Run this branch locally and on the explore page visit the individual tabs of projects and users to see the infinite scroll in action

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="1446" height="840" alt="Screenshot 2025-10-02 at 1 01 02 PM" src="https://github.com/user-attachments/assets/34cb39b9-03ad-460e-bc23-41abcdf3d5c9" />