### PR TITLE
Fixed project card height for projects with long description

### DIFF
--- a/src/components/Cards/ProjectExploreCard.tsx
+++ b/src/components/Cards/ProjectExploreCard.tsx
@@ -88,6 +88,7 @@ const ProjectExploreCard = ({ project }: ProjectExploreCardProps) => {
         flex: "1 1 350px",
         display: "flex",
         flexDirection: "column",
+        height: "100%",
       }}
     >
       <div style={{ flex: 1 }}>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -360,10 +360,12 @@ const ExplorePage = () => {
                           spacing="md"
                         >
                           {searchResponse.data.projects.map((project: any) => (
-                            <ProjectExploreCard
+                            <div
                               key={project.id}
-                              project={project}
-                            />
+                              style={{ display: "flex", height: "100%" }}
+                            >
+                              <ProjectExploreCard project={project} />
+                            </div>
                           ))}
                         </SimpleGrid>
                       </Box>
@@ -536,7 +538,15 @@ const ExplorePage = () => {
                 searchQuery !== "" ? (
                   searchResponse?.data?.projects?.length > 0 ? (
                     searchResponse.data.projects.map((project: any) => (
-                      <ProjectExploreCard key={project.id} project={project} />
+                      <div
+                        key={project.id}
+                        style={{ display: "flex", height: "100%" }}
+                      >
+                        <ProjectExploreCard
+                          key={project.id}
+                          project={project}
+                        />
+                      </div>
                     ))
                   ) : (
                     <EmptyState message="No projects found" />
@@ -548,12 +558,9 @@ const ExplorePage = () => {
                       <div
                         key={project.id}
                         ref={isLast ? lastElementRef : null}
-                        style={{ height: "100%" }}
+                        style={{ display: "flex", height: "100%" }}
                       >
-                        <ProjectExploreCard
-                          key={project.id}
-                          project={project}
-                        />
+                        <ProjectExploreCard project={project} />
                       </div>
                     );
                   })


### PR DESCRIPTION
# Description
This PR aims to maintain consistent height for project cards in the same row. Maintaining the height of the project card with the longest description in the row.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Click up Ticket ID
https://app.clickup.com/t/869ay485e

## How Can This Been Tested?
Add a project with a very long description.
Go to the projects tab on the explore page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots
<img width="1536" height="960" alt="Screenshot 2025-10-23 at 21 25 00" src="https://github.com/user-attachments/assets/d90bffb6-50ae-4895-991e-608eb0052e01" />
