### PR TITLE
fix(admin): left menu stale state from cluster details view

### DIFF
--- a/src/components/Navbars/LeftMenu.tsx
+++ b/src/components/Navbars/LeftMenu.tsx
@@ -204,7 +204,7 @@ const LeftMenu = React.memo(
         {
           label: "Network",
           icon: HiOutlineGlobeAlt,
-          key: "infrastructure",
+          key: "network",
           children: [
             {
               label: "Services",
@@ -369,6 +369,10 @@ const LeftMenu = React.memo(
         appId: app_id,
         clusterId: cluster_id,
       } = getPathIds();
+
+      // Clear links first to prevent stale state
+      setNavbarLinks([]);
+
       switch (menuType) {
         case "home":
           setNavbarLinks(homeNavbarLinks);
@@ -404,7 +408,7 @@ const LeftMenu = React.memo(
           setShowProjectHeader(false);
           break;
       }
-    }, [menuType, projectId, appId, location.pathname]);
+    }, [menuType, projectId, appId, clusterId, location.pathname]);
 
     // const HeaderIcon = () => {
     //   switch (menuType) {


### PR DESCRIPTION
# Description

- This PR fixes the stale state menu on the admin side menu that shows when we come back from the cluster details view page by ensuring previews nav-links are cleared and also menu items have unique key values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Clickup Ticket ID

## How Can This Been Tested?

- Checkout the admin side and try switching views from the admin dashboard into the cluster details page, and then back to the dashboard.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="1467" height="367" alt="Screenshot 2026-01-23 at 4 36 48 PM" src="https://github.com/user-attachments/assets/16d41e02-3cb9-4a72-98d0-71a7c54cc7ac" />