### PR TITLE
feat(admin): add inactive users listing and actions menu to table

### DIFF
--- a/src/components/Admin/AdminClustersList.tsx
+++ b/src/components/Admin/AdminClustersList.tsx
@@ -10,11 +10,13 @@ import {
   Text,
   Badge,
   Skeleton,
+  Container,
+  ThemeIcon,
 } from "@mantine/core";
 import { FaPlus } from "react-icons/fa6";
 import { HiOutlineServer } from "react-icons/hi";
-import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
+import { beautify } from "@/utils/helpers";
 
 const ClusterCard = ({ cluster }: { cluster: any }) => {
   const isDisabled = cluster.disabled;
@@ -22,37 +24,62 @@ const ClusterCard = ({ cluster }: { cluster: any }) => {
   const navigate = useNavigate();
 
   return (
-    <StyledCard
-      key={cluster.id}
+    <Card
       withBorder
+      radius="md"
+      p="md"
+      h="100%"
       onClick={() => navigate(`/admin/clusters/${cluster?.id}`)}
+      style={{
+        cursor: "pointer",
+        display: "flex",
+        flexDirection: "column",
+        transition: "transform 0.2s ease, box-shadow 0.2s ease",
+        opacity: isDisabled ? 0.7 : 1,
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = "translateY(-4px)";
+        e.currentTarget.style.boxShadow = "var(--mantine-shadow-sm)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = "translateY(0)";
+        e.currentTarget.style.boxShadow = "none";
+      }}
     >
-      <Group justify="space-between" align="flex-start">
-        <Group gap="xs" align="flex-start">
-          <HiOutlineServer size={25} />
-          <Stack gap={0} align="flex-start">
-            <Text fw={500} size="lg">
-              {cluster.name}
-            </Text>
-            <Text size="sm" c="dimmed">
-              {cluster.description}
-            </Text>
-          </Stack>
-        </Group>
-        <Group gap="xs">
+      <Group justify="space-between" align="flex-start" mb="sm" wrap="nowrap">
+        <ThemeIcon
+          size={42}
+          radius="md"
+          variant={isDisabled ? "default" : "light"}
+          color={isDisabled ? "gray" : "blue"}
+        >
+          <HiOutlineServer size={22} />
+        </ThemeIcon>
+
+        <Group gap={6} wrap="wrap" justify="flex-end">
           {isML && (
-            <Badge color="blue" variant="light">
-              supports ML
+            <Badge color="blue" variant="light" size="sm" radius="sm">
+              Supports ML
             </Badge>
           )}
           {isDisabled && (
-            <Badge color="red" variant="light">
+            <Badge color="red" variant="dot" size="sm" radius="sm">
               Disabled
             </Badge>
           )}
         </Group>
       </Group>
-    </StyledCard>
+
+      <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+        <Text fw={600} size="lg" lineClamp={2} mb="xs">
+          {cluster.name}
+        </Text>
+
+        <Text size="sm" c="dimmed" lineClamp={2} mt="auto">
+          {beautify(cluster.description) || "No description provided."}
+        </Text>
+      </Stack>
+    </Card>
   );
 };
 
@@ -65,57 +92,40 @@ const AdminClustersList = () => {
 
   if (loading) {
     return (
+      <Container size="1070" mt="sm">
+        <SimpleGrid cols={{ base: 1, xs: 2, md: 3 }} mt="md">
+          {[...Array(3)].map((_, index) => (
+            <Skeleton key={index} height={100} radius="md" />
+          ))}
+        </SimpleGrid>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="1070" mt="sm">
       <Stack gap={0}>
         <TitleText
           rightSection={
-            <Button leftSection={<FaPlus />} variant="filled">
+            <Button
+              leftSection={<FaPlus />}
+              variant="filled"
+              onClick={() => navigate("/admin/clusters/create")}
+            >
               Add Cluster
             </Button>
           }
         >
           Clusters
         </TitleText>
-
         <SimpleGrid cols={{ base: 1, xs: 2, md: 3 }} mt="md">
-          {[...Array(6)].map((_, index) => (
-            <Skeleton key={index} height={100} radius="md" />
+          {clusters?.data?.clusters?.map((cluster: any) => (
+            <ClusterCard key={cluster.id} cluster={cluster} />
           ))}
         </SimpleGrid>
       </Stack>
-    );
-  }
-
-  return (
-    <Stack gap={0}>
-      <TitleText
-        rightSection={
-          <Button
-            leftSection={<FaPlus />}
-            variant="filled"
-            onClick={() => navigate("/admin/clusters/create")}
-          >
-            Add Cluster
-          </Button>
-        }
-      >
-        Clusters
-      </TitleText>
-      <SimpleGrid cols={{ base: 1, xs: 2, md: 3 }} mt="md">
-        {clusters?.data?.clusters?.map((cluster: any) => (
-          <ClusterCard key={cluster.id} cluster={cluster} />
-        ))}
-      </SimpleGrid>
-    </Stack>
+    </Container>
   );
 };
-
-const StyledCard = styled(Card)`
-  transition: transform 0.2s ease-in-out;
-  cursor: pointer;
-
-  &:hover {
-    transform: translateY(-2px);
-  }
-` as typeof Card;
 
 export default AdminClustersList;

--- a/src/components/Cards/AppsCard.tsx
+++ b/src/components/Cards/AppsCard.tsx
@@ -1,16 +1,39 @@
+import React from "react";
 import { beautify } from "@/utils/helpers";
 import { MODAL_SERVERS } from "@/utils/constants";
-import { Anchor, Card, Flex, Group, Pill, Stack, Text } from "@mantine/core";
+import {
+  Anchor,
+  Card,
+  Flex,
+  Group,
+  Badge,
+  Stack,
+  Text,
+  Box,
+  ThemeIcon,
+  Divider,
+} from "@mantine/core";
 import { FiLayers } from "react-icons/fi";
 import { GoClock } from "react-icons/go";
 import { HiMiniCubeTransparent } from "react-icons/hi2";
 import { PiShareFatThin } from "react-icons/pi";
 import { SiJupyter } from "react-icons/si";
-import React from "react";
 
-const AppsCard = (props: any) => {
-  const { app, project_id } = props;
+const getStatusColor = (status: string) => {
+  const normalized = status.toLowerCase();
+  if (normalized === "running") {
+    return "green";
+  }
+  if (normalized === "deployed") {
+    return "blue";
+  }
+  if (normalized === "failed" || normalized === "error") {
+    return "red";
+  }
+  return "gray";
+};
 
+const AppsCard = ({ app, project_id }: any) => {
   const modalServerEntry =
     app.model_server &&
     MODAL_SERVERS.find((server) => server.value === app.model_server);
@@ -19,121 +42,137 @@ const AppsCard = (props: any) => {
   const modalServerColor = modalServerEntry?.color || "gray";
 
   return (
-    <Card p="md" radius="md" withBorder>
-      <Group wrap="nowrap" gap={10}>
-        {app.is_notebook ? (
-          <SiJupyter size={35} color="#f57c00" />
-        ) : modalServerIcon ? (
-          React.createElement(modalServerIcon, {
-            size: 35,
-            color: modalServerColor,
-          })
-        ) : (
-          <FiLayers size={20} color="gray" />
-        )}
-        <Stack gap={3} flex={1}>
+    <Card
+      p="md"
+      radius="md"
+      withBorder
+      h="100%"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        transition: "box-shadow 0.2s ease, transform 0.2s ease",
+      }}
+      className="app-card-hover"
+    >
+      <Group wrap="nowrap" gap={15} align="flex-start">
+        <ThemeIcon
+          size={48}
+          radius="md"
+          variant="light"
+          color={app.is_notebook ? "orange" : modalServerColor}
+        >
+          {app.is_notebook ? (
+            <SiJupyter size={24} />
+          ) : modalServerIcon ? (
+            React.createElement(modalServerIcon, { size: 24 })
+          ) : (
+            <FiLayers size={24} />
+          )}
+        </ThemeIcon>
+
+        <Stack gap={4} flex={1} style={{ overflow: "hidden" }}>
           <Anchor
             fw={600}
+            size="md"
             href={`/projects/${project_id}/apps/${app.id}`}
-            truncate
-            style={{ flex: 1 }}
+            truncate="end"
             c="var(--mantine-color-text)"
             className="no-scale"
           >
             {beautify(app.name)}
           </Anchor>
 
-          <Anchor
-            href={app.url}
-            target="_blank"
-            c="var(--mantine-color-text)"
-            maw="95%"
-            className="no-scale"
-          >
-            <Group gap={4} align="center" wrap="nowrap">
-              <Text size="0.8rem" truncate>
+          {app.url && (
+            <Anchor
+              href={app.url}
+              target="_blank"
+              c="dimmed"
+              className="no-scale"
+              style={{ display: "flex", alignItems: "center", gap: "4px" }}
+            >
+              <Text size="xs" truncate="end">
                 {new URL(app.url).hostname}
               </Text>
-              <PiShareFatThin size={15} />
-            </Group>
-          </Anchor>
+              <PiShareFatThin size={14} style={{ flexShrink: 0 }} />
+            </Anchor>
+          )}
         </Stack>
       </Group>
 
-      {app?.image && !app?.is_notebook && (
-        <Pill w="fit-content" mt="sm">
-          <Flex gap={5} wrap="nowrap" w="fit-content" align="center">
-            <HiMiniCubeTransparent size={14} />
-            <Text size="sm" truncate>
-              {app?.image}
-            </Text>
-          </Flex>
-        </Pill>
-      )}
+      <Box style={{ flex: 1, minWidth: 0 }} mt="md">
+        {app?.image && !app?.is_notebook && (
+          <Badge
+            variant="default"
+            size="md"
+            radius="sm"
+            maw="100%"
+            leftSection={<HiMiniCubeTransparent size={14} />}
+            style={{
+              textTransform: "none",
+              fontWeight: 500,
+            }}
+          >
+            {app?.image}
+          </Badge>
+        )}
+      </Box>
 
-      <Group justify="space-between" mt="md">
-        <Group gap={10} align="center">
-          {app?.is_notebook && (
-            <Pill w="fit-content" py={2}>
-              <Flex
-                gap={5}
-                wrap="nowrap"
-                w="fit-content"
-                align="center"
-                justify="center"
+      <Box mt="auto">
+        <Divider my="sm" />
+        <Group justify="space-between" align="center" wrap="nowrap">
+          <Group gap={8} align="center" wrap="nowrap">
+            {app?.is_notebook && (
+              <Badge
+                tt="capitalize"
+                variant="light"
+                color="orange"
+                size="md"
+                radius="sm"
+                leftSection={<SiJupyter size={10} />}
               >
-                <SiJupyter size={13} color="#f57c00" />
-                <Text size="xs" truncate>
-                  Notebook
-                </Text>
-              </Flex>
-            </Pill>
-          )}
+                Notebook
+              </Badge>
+            )}
 
-          {app.model_server && (
-            <Pill w="fit-content" py={2}>
-              <Flex gap={5} align="center" wrap="nowrap">
-                {modalServerIcon &&
-                  React.createElement(modalServerIcon, {
-                    size: 13,
-                    color: modalServerColor,
-                  })}
-                <Text size="xs" truncate>
-                  {app.model_server === "HUGGINGFACE_SERVER"
-                    ? beautify(app.task)
-                    : modalServerEntry?.label}
-                </Text>
-              </Flex>
-            </Pill>
-          )}
+            {app.model_server && (
+              <Badge
+                tt="capitalize"
+                variant="light"
+                color={modalServerColor}
+                size="sm"
+                radius="sm"
+                leftSection={
+                  modalServerIcon &&
+                  React.createElement(modalServerIcon, { size: 10 })
+                }
+              >
+                {app.model_server === "HUGGINGFACE_SERVER"
+                  ? beautify(app.task)
+                  : modalServerEntry?.label}
+              </Badge>
+            )}
 
-          <Flex gap={5} c="var(--mantine-color-dark-3)" align="center">
-            <GoClock size={13} />
-            <Text size="xs">{app.age}</Text>
-          </Flex>
+            <Flex gap={4} c="dimmed" align="center">
+              <GoClock size={12} />
+              <Text size="xs" fw={500}>
+                {app.age}
+              </Text>
+            </Flex>
+          </Group>
+
+          <Badge
+            size="md"
+            tt="capitalize"
+            variant="light"
+            color={getStatusColor(app.app_running_status)}
+            radius="xl"
+          >
+            {app.app_running_status}
+          </Badge>
         </Group>
-
-        <Pill
-          size="xs"
-          fw={500}
-          bg={getStatusColor(app.app_running_status).background}
-          c={getStatusColor(app.app_running_status).text}
-        >
-          {app.app_running_status}
-        </Pill>
-      </Group>
+      </Box>
     </Card>
   );
-};
-
-// Helper function for status colors
-const getStatusColor = (status: string) => {
-  const colors: Record<string, { background: string; text: string }> = {
-    running: { background: "#e3fbe3", text: "#1a7a1a" },
-    deployed: { background: "#e3f2fd", text: "#1a4a7a" },
-    unknown: { background: "", text: "" },
-  };
-  return colors[status.toLowerCase()] || colors.unknown;
 };
 
 export default AppsCard;

--- a/src/components/Cards/ProjectExploreCard.tsx
+++ b/src/components/Cards/ProjectExploreCard.tsx
@@ -118,7 +118,7 @@ const ProjectExploreCard = ({ project }: ProjectExploreCardProps) => {
         <Button
           variant="outline"
           size="xs"
-          radius="xl"
+          radius="md"
           onClick={onFollowClick}
           style={{ flexShrink: 0 }}
           leftSection={
@@ -155,9 +155,10 @@ const ProjectExploreCard = ({ project }: ProjectExploreCardProps) => {
             color="blue"
             variant="light"
             radius="xl"
+            tt="capitalize"
             style={{ maxWidth: "100%" }}
           >
-            <Text size="xs" truncate="end">
+            <Text size="xs" truncate="end" lineClamp={1}>
               {tag.name}
             </Text>
           </Badge>

--- a/src/components/Cards/ProjectSocialsCard.tsx
+++ b/src/components/Cards/ProjectSocialsCard.tsx
@@ -49,7 +49,6 @@ export default function ProjectSocialsCard({
     return user.id === project?.owner_id;
   }, [user?.id, project?.owner_id]);
 
-  // --- KEEPING ALL YOUR EXISTING LOGIC AND HOOKS ---
   const {
     uploadData: followProject,
     submitting: following,
@@ -155,16 +154,15 @@ export default function ProjectSocialsCard({
     <Card
       key={project.id}
       withBorder
-      radius="lg" // Upgraded to match new premium aesthetic
-      p="lg" // Increased padding for breathability
-      shadow="sm" // Subtle shadow
+      radius="md"
+      p="sm"
+      shadow="sm"
       style={{
         display: "flex",
         flexDirection: "column",
-        height: "100%", // Ensures all cards in the grid are equal height
+        height: "100%",
       }}
     >
-      {/* Top Section: Title, Description, Menu */}
       <Box style={{ flex: 1 }}>
         <Group justify="space-between" align="flex-start" wrap="nowrap" mb="sm">
           <Text fw={700} size="lg" lineClamp={1}>
@@ -182,7 +180,7 @@ export default function ProjectSocialsCard({
             <Menu.Target>
               <ActionIcon
                 variant="subtle"
-                color="blue" // Matching the blue dots in your screenshot
+                color="blue"
                 aria-label="Options"
                 onClick={() => setMenuOpened((o) => !o)}
               >
@@ -278,17 +276,11 @@ export default function ProjectSocialsCard({
           </Menu>
         </Group>
 
-        <Text
-          size="sm"
-          c="dimmed"
-          mb="xl" // Replaced strict line heights with a simple margin bottom
-          lineClamp={2}
-        >
+        <Text size="sm" c="dimmed" mb="xl" lineClamp={2}>
           {beautify(project.description) || "No description provided."}
         </Text>
       </Box>
 
-      {/* Bottom Section: Tags & Visibility Status */}
       <Group justify="space-between" align="center" mt="auto" wrap="nowrap">
         <Group gap="xs" style={{ flex: 1, overflow: "hidden" }} wrap="nowrap">
           {project?.tags &&
@@ -296,10 +288,10 @@ export default function ProjectSocialsCard({
               <Badge
                 key={tag.id}
                 size="sm"
-                radius="xl" // Pill shape
+                radius="xl"
                 color="blue"
                 variant="light"
-                tt="uppercase" // Matches your screenshot styling
+                tt="uppercase"
                 component={Link}
                 to={`/tags/${tag.name}`}
                 style={{ cursor: "pointer" }}
@@ -308,13 +300,12 @@ export default function ProjectSocialsCard({
               </Badge>
             ))}
 
-          {/* +X Badge */}
           {project?.tags && project.tags.length > 3 && (
             <Menu shadow="md" width={200} position="bottom-start">
               <Menu.Target>
                 <Badge
                   size="sm"
-                  radius="xl" // Pill shape
+                  radius="xl"
                   color="blue"
                   variant="light"
                   style={{ cursor: "pointer" }}
@@ -338,12 +329,10 @@ export default function ProjectSocialsCard({
           )}
         </Group>
 
-        {/* Project Visibility Status Badge */}
-        {/* Removed absolute positioning so it aligns perfectly with tags */}
         <Badge
           size="sm"
-          radius="xl" // Pill shape
-          color={isPublicProject ? "green" : "gray"} // Soft gray for private looks better than aggressive red
+          radius="xl"
+          color={isPublicProject ? "green" : "gray"}
           variant="light"
           tt="capitalize"
         >

--- a/src/components/Cards/UserCard.tsx
+++ b/src/components/Cards/UserCard.tsx
@@ -102,7 +102,7 @@ const UserCard = ({
               <Button
                 variant="outline"
                 size="xs"
-                radius="xl"
+                radius="md"
                 color="blue"
                 leftSection={
                   isFollowingUser ? (

--- a/src/components/Elements/Charts.tsx
+++ b/src/components/Elements/Charts.tsx
@@ -247,7 +247,7 @@ export const LineLargeMetricChart = ({
                   key={range}
                   variant={activePreset === range ? "solid" : "outline"}
                   size="xs"
-                  radius="xl"
+                  radius="md"
                   onClick={() => handlePresetClick(range)}
                 >
                   {range}
@@ -270,7 +270,7 @@ export const LineLargeMetricChart = ({
                 c="light-dark(var(--mantine-color-dark-9), white)"
                 mx="auto"
                 size="sm"
-                radius="xl"
+                radius="md"
                 leftSection={<CiCalendarDate size={18} />}
                 className="dimmed-placeholder"
               />
@@ -287,7 +287,7 @@ export const LineLargeMetricChart = ({
                   setActivePreset(null);
                 }}
                 mx="auto"
-                radius="xl"
+                radius="md"
                 size="sm"
                 leftSection={<CiCalendarDate size={18} />}
                 className="dimmed-placeholder"

--- a/src/components/Elements/CustomTable.tsx
+++ b/src/components/Elements/CustomTable.tsx
@@ -7,9 +7,12 @@ import {
   Pagination,
   Group,
   Flex,
+  Menu,
+  ActionIcon,
 } from "@mantine/core";
 import styled from "styled-components";
 import TableFilter from "./TableFilter";
+import { IoEllipsisVertical } from "react-icons/io5";
 export interface TColumn {
   id: string;
   header: string;
@@ -20,6 +23,14 @@ export interface TColumn {
     options?: { label: string; value: string }[];
     placeholder?: string;
   };
+}
+
+export interface TRowAction {
+  label: string;
+  onClick: (item: any) => void;
+  color?: string;
+  icon?: React.ReactNode;
+  hidden?: boolean;
 }
 
 interface TPaginationData {
@@ -53,6 +64,8 @@ interface TTableProps {
   showPagination?: boolean;
   pagination?: TPaginationData;
   title?: string;
+  hideActions?: boolean;
+  rowActions?: (item: any) => TRowAction[];
 }
 
 export const Table = ({
@@ -76,6 +89,8 @@ export const Table = ({
   onFilterChange,
   filters = {},
   hideFilters = false,
+  hideActions = true,
+  rowActions,
   title,
 }: TTableProps) => {
   const startItem = pagination
@@ -156,6 +171,19 @@ export const Table = ({
                         )}
                       </MantineTable.Th>
                     ))}
+                    {rowActions && !hideActions && (
+                      <MantineTable.Th
+                        style={{
+                          width: 80,
+                          textAlign: "center",
+                          verticalAlign: "top",
+                        }}
+                      >
+                        <Text size="sm" fw={700}>
+                          Actions
+                        </Text>
+                      </MantineTable.Th>
+                    )}
                   </MantineTable.Tr>
                 </MantineTable.Thead>
               )}
@@ -195,6 +223,43 @@ export const Table = ({
                             (noEmptyText && <Text c="dimmed">Empty</Text>)}
                         </MantineTable.Td>
                       ))}
+                      {rowActions && !hideActions && (
+                        <MantineTable.Td
+                          onClick={(e) => e.stopPropagation()}
+                          style={{ textAlign: "center" }}
+                        >
+                          <Menu
+                            shadow="md"
+                            width={180}
+                            position="bottom-end"
+                            withinPortal
+                          >
+                            <Menu.Target>
+                              <ActionIcon variant="subtle" color="gray">
+                                <IoEllipsisVertical />
+                              </ActionIcon>
+                            </Menu.Target>
+
+                            <Menu.Dropdown>
+                              {rowActions(item).map((action, actionIdx) => {
+                                if (action.hidden) {
+                                  return null;
+                                }
+                                return (
+                                  <Menu.Item
+                                    key={actionIdx}
+                                    color={action.color}
+                                    leftSection={action.icon}
+                                    onClick={() => action.onClick(item)}
+                                  >
+                                    {action.label}
+                                  </Menu.Item>
+                                );
+                              })}
+                            </Menu.Dropdown>
+                          </Menu>
+                        </MantineTable.Td>
+                      )}
                     </StyledTableRow>
                   ))
                 ) : (

--- a/src/components/Elements/Elements.tsx
+++ b/src/components/Elements/Elements.tsx
@@ -211,7 +211,7 @@ export const AddServiceButton = ({
     <div>
       <Menu transitionProps={{ transition: "pop-top-right" }} radius="md">
         <Menu.Target>
-          <Button rightSection={<IoIosArrowDown />} size="sm" radius="xl">
+          <Button rightSection={<IoIosArrowDown />} size="sm" radius="md">
             {title}
           </Button>
         </Menu.Target>

--- a/src/components/Elements/Modals.tsx
+++ b/src/components/Elements/Modals.tsx
@@ -45,11 +45,11 @@ export const ModalConfirm = (props: TModalConfirm) => {
 
       {showFooterActions && (
         <Group justify="flex-end">
-          <Button radius="xl" variant="default" onClick={onClose}>
+          <Button radius="md" variant="default" onClick={onClose}>
             Cancel
           </Button>
           <Button
-            radius="xl"
+            radius="md"
             color={buttonColor || "blue"}
             variant="filled"
             onClick={onConfirm}

--- a/src/components/Elements/Search.tsx
+++ b/src/components/Elements/Search.tsx
@@ -82,7 +82,7 @@ const Search = ({
   return (
     <Select
       placeholder="Search..."
-      radius="xl"
+      radius="md"
       leftSection={<FiSearch />}
       miw={{ base: "auto", sm: 300 }}
       style={wide ? { flex: 1 } : {}}

--- a/src/components/Forms/CreateProjectForm.tsx
+++ b/src/components/Forms/CreateProjectForm.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   Text,
   Alert,
+  Container,
 } from "@mantine/core";
 import {
   InvalidFeedback,
@@ -159,7 +160,7 @@ const CreateProjectForm = (props: TCreateProjectForm) => {
     feedback.numbers?.length;
 
   return (
-    <div>
+    <Container size="1070" mt="sm">
       {showTitle && <TitleText>Create new Project</TitleText>}
       <Paper p="lg" radius="md">
         <form onSubmit={handleSubmit}>
@@ -325,7 +326,7 @@ const CreateProjectForm = (props: TCreateProjectForm) => {
           </Stack>
         </form>
       </Paper>
-    </div>
+    </Container>
   );
 };
 
@@ -464,12 +465,12 @@ export const MigrateProjectForm = (props: {
 
           <Group justify="flex-end">
             {onCancel && (
-              <Button radius="xl" variant="default" onClick={onCancel}>
+              <Button radius="md" variant="default" onClick={onCancel}>
                 Cancel
               </Button>
             )}
             <Button
-              radius="xl"
+              radius="md"
               variant="filled"
               color={project ? "blue" : "gray.9"}
               type="submit"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,19 @@
-import { Box, Burger, Container, Group, Pill, Text } from "@mantine/core";
+import {
+  AppShell,
+  Box,
+  Burger,
+  Group,
+  Pill,
+  Text,
+  useMantineColorScheme,
+} from "@mantine/core";
 import classes from "./Header.module.css";
+
 import { Logo, UserDropDown } from "./Common";
 import { Link } from "react-router-dom";
 import Search from "./Elements/Search";
 import { useAuth } from "@/utils/AuthContext";
-import { DOCS_URL, STATUS_URL } from "@/config";
+import { DOCS_URL } from "@/config";
 
 interface HeaderProps {
   opened: boolean;
@@ -14,83 +23,75 @@ interface HeaderProps {
 export const DashboardHeader = ({ opened, toggle }: HeaderProps) => {
   const { user } = useAuth();
 
+  const { colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === "dark";
+
   return (
-    <Box
-      component="header"
+    <AppShell.Header
       style={{
-        position: "sticky",
-        top: 0,
-        zIndex: 100,
-        backdropFilter: "blur(13px)",
-        WebkitBackdropFilter: "blur(13px)",
-        backgroundColor: "var(--mantine-color-body)",
-        opacity: 0.9,
+        backgroundColor: isDark
+          ? "rgba(26, 27, 30, 0.75)"
+          : "rgba(255, 255, 255, 0.75)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
       }}
     >
-      <Container size="xl">
-        <Group h="100%" py={10} justify="space-between">
-          <Group>
-            <Burger
-              opened={opened}
-              onClick={toggle}
-              hiddenFrom="sm"
+      <Group h="100%" px="md" py="sm" justify="space-between">
+        <Group>
+          <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
+          <Link to="/">
+            <Logo />
+          </Link>
+          {user?.is_admin && (
+            <Pill
               size="sm"
-            />
-            <Link to="/">
-              <Logo />
-            </Link>
-            {user?.is_admin && (
-              <Pill
-                size="sm"
-                style={{
-                  backgroundColor: "var(--mantine-primary-color-2)",
-                  color: "var(--mantine-primary-color-9)",
-                }}
-              >
-                Admin
-              </Pill>
-            )}
+              style={{
+                backgroundColor: "var(--mantine-primary-color-2)",
+                color: "var(--mantine-primary-color-9)",
+              }}
+            >
+              Admin
+            </Pill>
+          )}
 
-            {!user?.is_admin && (
-              <>
-                <Link
-                  to="/explore"
-                  style={{ textDecoration: "none", paddingLeft: "10px" }}
-                >
-                  <Group gap={5}>
-                    <Text fw={700}>Explore</Text>
-                  </Group>
-                </Link>
-                <a
-                  href={`${DOCS_URL}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ textDecoration: "none", paddingLeft: "10px" }}
-                >
-                  <Group gap={5}>
-                    <Text fw={700}>Docs</Text>
-                  </Group>
-                </a>
-                <a
-                  href={`${STATUS_URL}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ textDecoration: "none", paddingLeft: "10px" }}
-                >
-                  <Group gap={5}>
-                    <Text fw={700}>Status</Text>
-                  </Group>
-                </a>
-              </>
-            )}
-          </Group>
-          <Group>
-            <Search />
-            <UserDropDown />
-          </Group>
+          {!user?.is_admin && (
+            <>
+              <Link
+                to="/explore"
+                style={{ textDecoration: "none", paddingLeft: "10px" }}
+              >
+                <Group gap={5}>
+                  <Text fw={700}>Explore</Text>
+                </Group>
+              </Link>
+              <a
+                href={`${DOCS_URL}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "none", paddingLeft: "10px" }}
+              >
+                <Group gap={5}>
+                  <Text fw={700}>Docs</Text>
+                </Group>
+              </a>
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "none", paddingLeft: "10px" }}
+              >
+                <Group gap={5}>
+                  <Text fw={700}>Status</Text>
+                </Group>
+              </a>
+            </>
+          )}
         </Group>
-      </Container>
-    </Box>
+        <Group>
+          <Search />
+          <UserDropDown />
+        </Group>
+      </Group>
+    </AppShell.Header>
   );
 };
 

--- a/src/components/Layouts/AdminDashboardLayout.tsx
+++ b/src/components/Layouts/AdminDashboardLayout.tsx
@@ -1,6 +1,6 @@
 import { DashboardHeader } from "@/components/Header";
 import LeftMenu, { TLeftMenuType } from "@/components/Navbars/LeftMenu";
-import { AppShell, Box, Container, Flex } from "@mantine/core";
+import { AppShell, Container } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useState, createContext, useMemo } from "react";
 export interface TAdminMenuContextType {
@@ -58,44 +58,28 @@ export const AdminDashboardLayout = ({
       <AppShell
         header={{ height: 60 }}
         navbar={{
-          width: menuType === "noSidebar" ? 0 : 250,
+          width: 200,
           breakpoint: "sm",
-          collapsed: { mobile: !opened },
+          collapsed: {
+            mobile: !opened,
+            desktop: menuType === "noSidebar",
+          },
         }}
-        py="md"
-        className="container"
+        padding="md"
       >
         <DashboardHeader opened={opened} toggle={toggle} />
 
-        <Container size="xl" pt="md">
-          <Flex gap="lg" align="flex-start" wrap="nowrap">
-            <Box
-              w={280}
-              style={{
-                flexShrink: 0,
-                display: menuType === "noSidebar" ? "none" : "block",
-              }}
-            >
-              <LeftMenu
-                menuType={menuType}
-                clusterId={clusterId}
-                title={title}
-                subtitle={subtitle}
-              />
-            </Box>
-
-            <Box
-              component="main"
-              style={{
-                flex: 1,
-                minWidth: 0,
-                width: "100%",
-              }}
-            >
-              {children}
-            </Box>
-          </Flex>
-        </Container>
+        <LeftMenu
+          menuType={menuType}
+          clusterId={clusterId}
+          title={title}
+          subtitle={subtitle}
+        />
+        <AppShell.Main>
+          <Container size={1400} w="100%">
+            {children}
+          </Container>
+        </AppShell.Main>
       </AppShell>
     </AdminMenuContext.Provider>
   );

--- a/src/components/Layouts/DashboardLayout.tsx
+++ b/src/components/Layouts/DashboardLayout.tsx
@@ -1,6 +1,6 @@
 import { DashboardHeader } from "@/components/Header";
 import LeftMenu, { TLeftMenuType } from "@/components/Navbars/LeftMenu";
-import { AppShell, Box, Container, Flex } from "@mantine/core";
+import { AppShell, Container } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useState, createContext, useMemo } from "react";
 
@@ -72,60 +72,33 @@ export const DashboardLayout = ({
   return (
     <MenuContext.Provider value={contextValue}>
       <AppShell
+        header={{ height: 60 }}
         navbar={{
-          width: menuType === "noSidebar" ? 0 : 250,
+          width: 200,
           breakpoint: "sm",
-          collapsed: { mobile: !opened },
+          collapsed: {
+            mobile: !opened,
+            desktop: menuType === "noSidebar",
+          },
         }}
-        py="md"
-        className="container"
-        style={{
-          minHeight: "100vh",
-          backgroundColor: "var(--mantine-color-body)",
-          backgroundImage: `
-    radial-gradient(circle, light-dark(rgba(0,0,0,0.1), rgba(255,255,255,0.1)) 1px, transparent 1px),
-    radial-gradient(circle, light-dark(rgba(0,0,0,0.1), rgba(255,255,255,0.1)) 1px, transparent 1px)
-  `,
-          backgroundSize: "40px 40px",
-          backgroundPosition: "0 0, 20px 20px",
-        }}
+        padding="md"
       >
         <DashboardHeader opened={opened} toggle={toggle} />
 
-        <Container size="xl" pt="md">
-          <Flex gap="lg" align="flex-start" wrap="nowrap">
-            <Box
-              w={280}
-              style={{
-                flexShrink: 0,
-                display: menuType === "noSidebar" ? "none" : "block",
-                position: "sticky",
-                top: 85,
-                height: "calc(100vh - 100px)",
-              }}
-            >
-              <LeftMenu
-                menuType={menuType}
-                projectId={projectId}
-                project={project}
-                appId={appId}
-                title={title}
-                subtitle={subtitle}
-              />
-            </Box>
+        <LeftMenu
+          menuType={menuType}
+          projectId={projectId}
+          project={project}
+          appId={appId}
+          title={title}
+          subtitle={subtitle}
+        />
 
-            <Box
-              component="main"
-              style={{
-                flex: 1,
-                minWidth: 0,
-                width: "100%",
-              }}
-            >
-              {children}
-            </Box>
-          </Flex>
-        </Container>
+        <AppShell.Main>
+          <Container size={1400} w="100%">
+            {children}
+          </Container>
+        </AppShell.Main>
       </AppShell>
     </MenuContext.Provider>
   );

--- a/src/components/Layouts/RegisterLayoutHandler.tsx
+++ b/src/components/Layouts/RegisterLayoutHandler.tsx
@@ -9,7 +9,7 @@ import { beautify, returnObject } from "../../utils/helpers";
 import useGet from "@/utils/useGet";
 import { IoAdd } from "react-icons/io5";
 import { Table } from "../Elements/CustomTable";
-import { Button, Stack } from "@mantine/core";
+import { Button, Container, Stack } from "@mantine/core";
 import TitleText from "../TitleText";
 import { SimpleDetailsCard } from "../Cards/DetailsCard";
 import { BarMetricChart } from "../Elements/Charts";
@@ -57,6 +57,7 @@ const RegisterLayoutHandler = (props: any) => {
     createTitle,
     metaData,
     tableTotals,
+    rowActions,
     // externalFilters,
     initialFilters,
     isExternalRoute,
@@ -163,8 +164,9 @@ const RegisterLayoutHandler = (props: any) => {
   }
 
   return (
-    <Stack gap={20}>
-      {/* {externalFilters && externalFilters.length > 0 && (
+    <Container size="1070" mt="sm">
+      <Stack gap={20}>
+        {/* {externalFilters && externalFilters.length > 0 && (
         <div style={{ display: "flex", gap: 30, marginBottom: 30 }}>
           {externalFilters.map((row: any) => (
             <TableFilter
@@ -180,63 +182,66 @@ const RegisterLayoutHandler = (props: any) => {
           ))}
         </div>
       )} */}
-      {/* {showTotals && totalsData && ( */}
-      {showTitle && (
-        <TitleText
-          rightSection={
-            formRoute && (
-              <Button
-                className="capitalize"
-                leftSection={<IoAdd fontSize="small" />}
-                onClick={() => navigate(formRoute)}
-                size="sm"
-              >
-                {createTitle || `New ${beautify(source)}`}
-              </Button>
-            )
-          }
-        >
-          {title || getTitle()}
-        </TitleText>
-      )}
+        {/* {showTotals && totalsData && ( */}
+        {showTitle && (
+          <TitleText
+            rightSection={
+              formRoute && (
+                <Button
+                  className="capitalize"
+                  leftSection={<IoAdd fontSize="small" />}
+                  onClick={() => navigate(formRoute)}
+                  size="sm"
+                >
+                  {createTitle || `New ${beautify(source)}`}
+                </Button>
+              )
+            }
+          >
+            {title || getTitle()}
+          </TitleText>
+        )}
 
-      {metaData && registerData && (
-        <SimpleDetailsCard
-          data={metaData(
-            registerData?.data?.meta_data || registerData?.data?.metadata,
-          )}
-        />
-      )}
+        {metaData && registerData && (
+          <SimpleDetailsCard
+            data={metaData(
+              registerData?.data?.meta_data || registerData?.data?.metadata,
+            )}
+          />
+        )}
 
-      {graphData && (
-        <BarMetricChart
-          title={graphTitle || getTitle()}
-          data={graphDataResults}
-          showAllXValues
+        {graphData && (
+          <BarMetricChart
+            title={graphTitle || getTitle()}
+            data={graphDataResults}
+            showAllXValues
+            filters={filters}
+            setFilters={(data) => {
+              setFilter({ ...filters, ...data });
+            }}
+            height={250}
+            valueFormatter={(value) => `${value}`}
+            isLoading={fetchingGraphData}
+          />
+        )}
+        <Table
+          title={title || getTitle()}
+          loading={loading}
+          columns={tableColumns ? tableColumns(tableDataResults) : []}
+          data={tableData ? tableData(tableDataResults) : []}
+          tableTotals={tableTotals ? tableTotals(registerData) : {}}
+          pagination={pagination}
           filters={filters}
-          setFilters={(data) => {
-            setFilter({ ...filters, ...data });
+          onFilterChange={(data) => {
+            setFilter({ filters, ...data });
           }}
-          height={250}
-          valueFormatter={(value) => `${value}`}
-          isLoading={fetchingGraphData}
+          striped
+          showPagination
+          rowActions={rowActions}
+          hideActions={false}
         />
-      )}
-      <Table
-        title={title || getTitle()}
-        loading={loading}
-        columns={tableColumns ? tableColumns(tableDataResults) : []}
-        data={tableData ? tableData(tableDataResults) : []}
-        tableTotals={tableTotals ? tableTotals(registerData) : {}}
-        pagination={pagination}
-        filters={filters}
-        onFilterChange={(data) => {
-          setFilter({ filters, ...data });
-        }}
-        striped
-        showPagination
-      />
-    </Stack>
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/components/Lists/ProjectsList.tsx
+++ b/src/components/Lists/ProjectsList.tsx
@@ -4,7 +4,6 @@ import {
   Badge,
   Box,
   Button,
-  Divider,
   Group,
   Skeleton,
   Stack,
@@ -110,9 +109,7 @@ const ProjectsList = () => {
 
   return (
     <div>
-      <Divider py="xs" mt="sm" />
-
-      <Box py="md">
+      <Box>
         <Group justify="space-between" align="center">
           {/* Left Side */}
           <Title fz="1.8rem">Projects</Title>
@@ -136,7 +133,7 @@ const ProjectsList = () => {
 
             <Button
               leftSection={<IoAdd size={18} />}
-              radius="xl"
+              radius="md"
               component={Link}
               to="/projects/create"
             >

--- a/src/components/Navbars/LeftMenu.tsx
+++ b/src/components/Navbars/LeftMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  AppShell,
   NavLink,
   Text,
   Group,
@@ -7,7 +8,6 @@ import {
   ScrollArea,
   Stack,
   useMantineColorScheme,
-  Box,
 } from "@mantine/core";
 import {
   HiOutlineSquares2X2,
@@ -24,6 +24,8 @@ import {
   HiOutlineCloud,
   HiOutlineGlobeAlt,
   HiOutlineArrowPath,
+  HiOutlineUserMinus,
+  HiOutlineFolder,
 } from "react-icons/hi2";
 import { GiNetworkBars } from "react-icons/gi";
 import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
@@ -63,7 +65,7 @@ interface INavLink {
   label: string;
   icon: React.ComponentType;
   key: string;
-  link: string;
+  link?: string;
   description?: string;
   children?: INavLink[];
 }
@@ -114,11 +116,24 @@ const LeftMenu = React.memo(
           label: "Users",
           icon: HiOutlineUsers,
           key: "users",
-          link: "/admin/users/list",
+          children: [
+            {
+              label: "User List",
+              icon: HiOutlineUsers,
+              key: "user_list",
+              link: `/admin/users/list`,
+            },
+            {
+              label: "Inactive Users",
+              icon: HiOutlineUserMinus,
+              key: "inactive_users",
+              link: `/admin/inactive_users/list`,
+            },
+          ],
         },
         {
           label: "Projects",
-          icon: HiOutlineUsers,
+          icon: HiOutlineFolder,
           key: "projects",
           link: "/admin/projects/list",
         },
@@ -447,19 +462,14 @@ const LeftMenu = React.memo(
     // }, [appId, projectId]);
     useEffect(() => {}, [navbarLinks]);
     return (
-      <Stack
-        pr="sm"
-        gap={0}
-        style={{
-          display: menuType === "noSidebar" ? "none" : "flex",
-          borderRight: "1px solid var(--mantine-color-default-border)",
-          height: "calc(100vh - 100px)",
-        }}
+      <AppShell.Navbar
+        p="5px"
+        style={{ display: menuType === "noSidebar" ? "none" : "flex" }}
+        w={280}
       >
-        {/* 1. Replaced AppShell.Section with ScrollArea */}
-        <ScrollArea style={{ flex: 1 }} type="scroll">
+        <AppShell.Section grow component={ScrollArea}>
           {showProjectHeader && (
-            <Stack pb={20} gap={10}>
+            <Stack pb={20} gap={30}>
               <SelectProject project_id={projectId} />
               {["app", "mlops"].includes(menuType) && (
                 <Stack gap={5} ml={10}>
@@ -477,7 +487,7 @@ const LeftMenu = React.memo(
                       }}
                     >
                       <IoArrowBack />
-                      <Text fz="md" fw={700}>
+                      <Text fz="sm" fw={700}>
                         {title}
                       </Text>
                     </UnstyledButton>
@@ -486,9 +496,7 @@ const LeftMenu = React.memo(
               )}
             </Stack>
           )}
-
-          {/* Navigation Links Mapping */}
-          {navbarLinks.map((link: INavLink, index) => (
+          {navbarLinks.map((link: INavLink) => (
             <React.Fragment key={link.key}>
               {link.children ? (
                 <Stack gap={5} my={2} mx={10} mt={20}>
@@ -497,64 +505,71 @@ const LeftMenu = React.memo(
                   </Text>
                 </Stack>
               ) : (
-                <NavLink
-                  component={Link}
-                  key={link.key}
-                  label={link.label}
-                  leftSection={<link.icon />}
-                  active={!!matchPath({ path: link.link }, location.pathname)}
-                  to={link.link}
-                  pb="xs"
-                  mb="sm"
-                  styles={{
-                    root: {
-                      borderBottom:
-                        index !== navbarLinks.length - 1
-                          ? "0.5px solid var(--mantine-color-gray-7)"
-                          : "none",
-                    },
-                    label: {
-                      fontSize: "0.9rem",
-                      fontWeight: 600,
-                    },
-                  }}
-                  className="navlink"
-                />
+                link.link && (
+                  <NavLink
+                    component={Link}
+                    key={link.key}
+                    label={link.label}
+                    leftSection={<link.icon />}
+                    active={
+                      link.link
+                        ? !!matchPath({ path: link.link }, location.pathname)
+                        : false
+                    }
+                    to={link.link}
+                    styles={{
+                      root: {
+                        borderRadius: "0.4rem",
+                      },
+                      label: {
+                        fontSize: "0.8rem",
+                      },
+                    }}
+                    className="navlink"
+                  />
+                )
               )}
               {link.children && (
                 <Stack gap={5}>
-                  {link.children.map((child) => (
-                    <NavLink
-                      component={Link}
-                      key={child.key}
-                      label={child.label}
-                      leftSection={<child.icon />}
-                      active={
-                        !!matchPath({ path: child.link }, location.pathname)
-                      }
-                      to={child.link}
-                      styles={{
-                        root: { borderRadius: "0.4rem", paddingLeft: "1.5rem" },
-                        label: { fontSize: "0.8rem" },
-                      }}
-                      className="navlink"
-                    />
-                  ))}
+                  {link.children.map((child) =>
+                    child.link ? (
+                      <NavLink
+                        component={Link}
+                        key={child.key}
+                        label={child.label}
+                        leftSection={<child.icon />}
+                        active={
+                          !!matchPath({ path: child.link }, location.pathname)
+                        }
+                        to={child.link}
+                        styles={{
+                          root: {
+                            borderRadius: "0.4rem",
+                            paddingLeft: "1.5rem",
+                          },
+                          label: {
+                            fontSize: "0.8rem",
+                          },
+                        }}
+                        className="navlink"
+                      />
+                    ) : null,
+                  )}
                 </Stack>
               )}
             </React.Fragment>
           ))}
-        </ScrollArea>
+        </AppShell.Section>
 
-        {/* 2. Replaced Footer AppShell.Section with Box */}
-        <Box pt="sm">
+        <AppShell.Section>
           <UnstyledButton
             style={{
-              width: "100%", // Ensures button spans full width of sidebar
               padding: rem(8),
               borderRadius: rem(4),
+              "&:hover": {
+                backgroundColor: "#f8f9fa",
+              },
             }}
-            className="hover:bg-gray-100 dark:hover:bg-zinc-800"
             onClick={() =>
               setColorScheme(colorScheme === "dark" ? "light" : "dark")
             }
@@ -570,8 +585,8 @@ const LeftMenu = React.memo(
               </Text>
             </Group>
           </UnstyledButton>
-        </Box>
-      </Stack>
+        </AppShell.Section>
+      </AppShell.Navbar>
     );
   },
 );

--- a/src/components/Trending/TrendingTags.tsx
+++ b/src/components/Trending/TrendingTags.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Card, Group, Title, Stack, Badge, Skeleton } from "@mantine/core";
 import { FiTrendingUp } from "react-icons/fi";
 import { Link } from "react-router-dom";
 import useGet from "@/utils/useGet";
 import { API_SOCIALS } from "@/utils/apis";
 import { Tag } from "@/types/tag";
-import { getTagColor } from "@/utils/helpers";
+import { IoTrendingUp } from "react-icons/io5";
 
 interface TrendingTagsProps {
   title?: string;
@@ -42,13 +42,40 @@ export default function TrendingTags({
             {response?.data?.tags?.map((tag: Tag) => (
               <Badge
                 key={tag.id}
-                variant="outline"
-                color={getTagColor(tag.name)}
+                variant="default"
                 component={Link}
                 to={`/tags/${tag.name}`}
-                style={{ cursor: "pointer", textDecoration: "none" }}
+                size="md"
+                radius="md"
+                pr={4}
+                tt="capitalize"
+                style={{
+                  cursor: "pointer",
+                  textDecoration: "none",
+                  fontWeight: 500,
+                }}
+                rightSection={
+                  <Badge
+                    variant="light"
+                    color="gray"
+                    size="sm"
+                    radius="sm"
+                    style={{
+                      padding: "0 6px",
+                      height: 13,
+                      minWidth: 20,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      color: "var(--mantine-color-dimmed)",
+                    }}
+                    leftSection={<IoTrendingUp />}
+                  >
+                    {tag.projects_count}
+                  </Badge>
+                }
               >
-                # {tag.name}
+                {tag.name}
               </Badge>
             ))}
           </Group>
@@ -65,7 +92,7 @@ const TagsSkeleton = () => {
         <Skeleton
           key={index}
           height={24}
-          width={Math.random() * 40 + 60} // Keeps the organic, varied tag widths
+          width={Math.random() * 40 + 60}
           radius="xl"
         />
       ))}

--- a/src/hooks/handlers/useRegisterHandler.ts
+++ b/src/hooks/handlers/useRegisterHandler.ts
@@ -12,10 +12,12 @@ import useNamespaces from "../cluster/useNamespaces";
 import useDeployments from "../cluster/useDeployments";
 import useJobs from "../cluster/useJobs";
 import useStorageClasses from "../cluster/useStorageClasses";
+import { useInactiveUsers } from "../useInactiveUsers";
 
 // handle register creation
 export const registerHooks: Record<string, any> = {
   users: useUsers,
+  inactive_users: useInactiveUsers,
   databases: useDatabases,
   projects: useProjects,
   apps: useApps,
@@ -32,6 +34,7 @@ export const registerHooks: Record<string, any> = {
 };
 export const sourceApis: Record<string, string> = {
   users: "/users",
+  inactive_users: "/users/inactive_users",
   databases: `${DATABASE_API_URL}/databases`,
   projects: `/projects`,
   apps: `/apps`,

--- a/src/hooks/useInactiveUsers.tsx
+++ b/src/hooks/useInactiveUsers.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+import { formatDate } from "@/utils/helpers";
+import { IoBanOutline, IoEyeOutline, IoPowerOutline } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
+
+export const useInactiveUsers = () => {
+  const navigate = useNavigate();
+
+  const tableColumns = () => [
+    {
+      id: "name",
+      header: "Name",
+      filter: { key: "keywords", type: "text", placeholder: "Search by name" },
+    },
+    { id: "email", header: "Email" },
+    { id: "last_seen", header: "Last Seen" },
+    {
+      id: "date_joined",
+      header: "Date Joined",
+      filter: { type: "date_range" },
+    },
+    { id: "age", header: "Age" },
+  ];
+  const tableData = (data: any) => {
+    if (!data) {
+      return [];
+    }
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data.map((item: any) => {
+      const row = {
+        ...item,
+        date_joined: formatDate(item.date_created),
+        last_seen: formatDate(item.last_seen, "DD MMM YYYY, HH:mm:ss"),
+      };
+      return row;
+    });
+  };
+  const rowActions = (item: any) => [
+    {
+      label: "View User",
+      icon: <IoEyeOutline size={16} />,
+      onClick: (row: any) => {
+        navigate(`/admin/users/${row.id}`);
+      },
+    },
+    {
+      label: "Enable",
+      icon: <IoPowerOutline size={16} />,
+      color: "green",
+      hidden: !item.disabled,
+      onClick: (row: any) => {
+        console.log("Enabling user:", row.email);
+      },
+    },
+    {
+      label: "Disable",
+      icon: <IoBanOutline size={16} />,
+      color: "red",
+      hidden: item.disabled,
+      onClick: (row: any) => {
+        console.log("Disabling user:", row.email);
+      },
+    },
+  ];
+
+  const dataParent = "users";
+  const apiRoute = `/users/inactive_users?range=60`;
+
+  return { tableColumns, tableData, rowActions, apiRoute, dataParent };
+};

--- a/src/pages/Apps/AppDeploymentDetailPage.tsx
+++ b/src/pages/Apps/AppDeploymentDetailPage.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Alert,
   Skeleton,
+  Container,
 } from "@mantine/core";
 import {
   TbArrowLeft,
@@ -165,16 +166,18 @@ const AppDeploymentDetailPage = () => {
 
   if (loading) {
     return (
-      <Stack gap="lg">
-        <Skeleton height={40} radius="md" />
-        <Card p="lg" radius="md" withBorder>
-          <Stack gap="md">
-            <Skeleton height={20} width="40%" />
-            <Skeleton height={60} />
-            <Skeleton height={400} />
-          </Stack>
-        </Card>
-      </Stack>
+      <Container size="1070" mt="sm">
+        <Stack gap="lg">
+          <Skeleton height={40} radius="md" />
+          <Card p="lg" radius="md" withBorder>
+            <Stack gap="md">
+              <Skeleton height={20} width="40%" />
+              <Skeleton height={60} />
+              <Skeleton height={400} />
+            </Stack>
+          </Card>
+        </Stack>
+      </Container>
     );
   }
 
@@ -193,136 +196,138 @@ const AppDeploymentDetailPage = () => {
   }
 
   return (
-    <Stack gap="lg">
-      {/* Header */}
-      <Flex justify="space-between" align="center">
-        <Group gap="sm">
-          <Button
-            component={Link}
-            to={`/projects/${project_id}/apps/${app_id}/build_logs`}
-            variant="subtle"
-            leftSection={<TbArrowLeft size={16} />}
-            color="gray"
-          >
-            Back to Deployments
-          </Button>
-        </Group>
-      </Flex>
+    <Container size="1070" mt="sm">
+      <Stack gap="lg">
+        {/* Header */}
+        <Flex justify="space-between" align="center">
+          <Group gap="sm">
+            <Button
+              component={Link}
+              to={`/projects/${project_id}/apps/${app_id}/build_logs`}
+              variant="subtle"
+              leftSection={<TbArrowLeft size={16} />}
+              color="gray"
+            >
+              Back to Deployments
+            </Button>
+          </Group>
+        </Flex>
 
-      <TitleText>Deployment Details</TitleText>
+        <TitleText>Deployment Details</TitleText>
 
-      {/* Deployment Info Card */}
-      <Card p="md" radius="md" withBorder>
-        <Stack gap="sm">
-          {/* Header with status and deployment info */}
-          <Flex justify="space-between" align="center" wrap="wrap" gap="sm">
-            <Group gap="sm">
-              {metaData && getStatusBadge(metaData.status)}
-              <Text size="sm" fw={600}>
-                Deployment #{metaData ? shortenID(metaData.build_id) : ""}
-              </Text>
-            </Group>
-            <Text size="xs" c="dimmed" ff="mono">
-              {build_id}
-            </Text>
-          </Flex>
-
-          {/* Compact details grid */}
-          <Flex wrap="wrap" gap="lg" mt="xs">
-            <Flex align="center" gap={3}>
-              <TbUser size={13} color="var(--mantine-color-gray-6)" />
-              <Text size="xs" c="gray.7" fw={700}>
-                <Text size="xs" c="dimmed" component="span" fw={500}>
-                  App Name:
-                </Text>{" "}
-                {metaData?.app_name || app?.name || "Unknown"}
+        {/* Deployment Info Card */}
+        <Card p="md" radius="md" withBorder>
+          <Stack gap="sm">
+            {/* Header with status and deployment info */}
+            <Flex justify="space-between" align="center" wrap="wrap" gap="sm">
+              <Group gap="sm">
+                {metaData && getStatusBadge(metaData.status)}
+                <Text size="sm" fw={600}>
+                  Deployment #{metaData ? shortenID(metaData.build_id) : ""}
+                </Text>
+              </Group>
+              <Text size="xs" c="dimmed" ff="mono">
+                {build_id}
               </Text>
             </Flex>
 
-            <Flex align="center" gap={3}>
-              <TbCalendar size={14} color="var(--mantine-color-gray-6)" />
-              <Text size="xs" c="gray.7" fw={700}>
-                <Text size="xs" c="dimmed" component="span" fw={500}>
-                  Started:
-                </Text>{" "}
-                {metaData?.started_at
-                  ? moment(metaData.started_at).format("MMM DD, HH:mm")
-                  : "N/A"}
-              </Text>
-            </Flex>
+            {/* Compact details grid */}
+            <Flex wrap="wrap" gap="lg" mt="xs">
+              <Flex align="center" gap={3}>
+                <TbUser size={13} color="var(--mantine-color-gray-6)" />
+                <Text size="xs" c="gray.7" fw={700}>
+                  <Text size="xs" c="dimmed" component="span" fw={500}>
+                    App Name:
+                  </Text>{" "}
+                  {metaData?.app_name || app?.name || "Unknown"}
+                </Text>
+              </Flex>
 
-            <Flex align="center" gap={3}>
-              <TbClock size={14} color="var(--mantine-color-gray-6)" />
-              <Text size="xs" c="gray.7" fw={700}>
-                <Text size="xs" c="dimmed" component="span" fw={500}>
-                  Duration:
-                </Text>{" "}
-                {metaData
-                  ? formatDuration(metaData.started_at, metaData.completed_at)
-                  : "N/A"}
-              </Text>
-            </Flex>
-
-            {metaData?.completed_at && (
               <Flex align="center" gap={3}>
                 <TbCalendar size={14} color="var(--mantine-color-gray-6)" />
                 <Text size="xs" c="gray.7" fw={700}>
                   <Text size="xs" c="dimmed" component="span" fw={500}>
-                    Completed:
+                    Started:
                   </Text>{" "}
-                  {moment(metaData.completed_at).format("MMM DD, HH:mm")}
+                  {metaData?.started_at
+                    ? moment(metaData.started_at).format("MMM DD, HH:mm")
+                    : "N/A"}
                 </Text>
               </Flex>
-            )}
-          </Flex>
 
-          {/* Error alert - only show if there's an error */}
-          {metaData?.error && (
+              <Flex align="center" gap={3}>
+                <TbClock size={14} color="var(--mantine-color-gray-6)" />
+                <Text size="xs" c="gray.7" fw={700}>
+                  <Text size="xs" c="dimmed" component="span" fw={500}>
+                    Duration:
+                  </Text>{" "}
+                  {metaData
+                    ? formatDuration(metaData.started_at, metaData.completed_at)
+                    : "N/A"}
+                </Text>
+              </Flex>
+
+              {metaData?.completed_at && (
+                <Flex align="center" gap={3}>
+                  <TbCalendar size={14} color="var(--mantine-color-gray-6)" />
+                  <Text size="xs" c="gray.7" fw={700}>
+                    <Text size="xs" c="dimmed" component="span" fw={500}>
+                      Completed:
+                    </Text>{" "}
+                    {moment(metaData.completed_at).format("MMM DD, HH:mm")}
+                  </Text>
+                </Flex>
+              )}
+            </Flex>
+
+            {/* Error alert - only show if there's an error */}
+            {metaData?.error && (
+              <Alert
+                icon={<TbAlertCircle size={16} />}
+                color="red"
+                variant="light"
+                p="sm"
+                mt="xs"
+              >
+                <Text size="xs" fw={500} mb={4}>
+                  Deployment Error
+                </Text>
+                <Text size="xs" style={{ wordBreak: "break-word" }}>
+                  {metaData.error}
+                </Text>
+              </Alert>
+            )}
+          </Stack>
+        </Card>
+
+        {/* Build Logs Section */}
+        <div>
+          {build_id ? (
+            hasStaticLogs ? (
+              <StaticLogsDisplay
+                logsData={logsData}
+                buildId={build_id}
+                onRefresh={refreshLogs}
+              />
+            ) : (
+              <BuildLogsTerminal
+                logsSocketUrl={getLogsSocketUrl()}
+                buildId={build_id}
+              />
+            )
+          ) : (
             <Alert
               icon={<TbAlertCircle size={16} />}
-              color="red"
+              title="No build ID available"
+              color="orange"
               variant="light"
-              p="sm"
-              mt="xs"
             >
-              <Text size="xs" fw={500} mb={4}>
-                Deployment Error
-              </Text>
-              <Text size="xs" style={{ wordBreak: "break-word" }}>
-                {metaData.error}
-              </Text>
+              Unable to load build logs without a valid build ID.
             </Alert>
           )}
-        </Stack>
-      </Card>
-
-      {/* Build Logs Section */}
-      <div>
-        {build_id ? (
-          hasStaticLogs ? (
-            <StaticLogsDisplay
-              logsData={logsData}
-              buildId={build_id}
-              onRefresh={refreshLogs}
-            />
-          ) : (
-            <BuildLogsTerminal
-              logsSocketUrl={getLogsSocketUrl()}
-              buildId={build_id}
-            />
-          )
-        ) : (
-          <Alert
-            icon={<TbAlertCircle size={16} />}
-            title="No build ID available"
-            color="orange"
-            variant="light"
-          >
-            Unable to load build logs without a valid build ID.
-          </Alert>
-        )}
-      </div>
-    </Stack>
+        </div>
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/Apps/AppDeploymentPage.tsx
+++ b/src/pages/Apps/AppDeploymentPage.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip,
   Code,
   Skeleton,
+  Container,
 } from "@mantine/core";
 import {
   TbAlertCircle,
@@ -229,89 +230,93 @@ const AppDeploymentPage = () => {
   // Show loading skeleton while app data is loading
   if (appLoading) {
     return (
-      <Stack gap="lg">
-        {/* Header Loading */}
-        <Flex justify="space-between" align="center">
-          <Skeleton height={32} width={150} />
-          <Group gap="sm">
-            <Skeleton height={28} width={120} />
-            <Skeleton height={28} width={28} radius="md" />
-          </Group>
-        </Flex>
+      <Container size="1070" mt="sm">
+        <Stack gap="lg">
+          {/* Header Loading */}
+          <Flex justify="space-between" align="center">
+            <Skeleton height={32} width={150} />
+            <Group gap="sm">
+              <Skeleton height={28} width={120} />
+              <Skeleton height={28} width={28} radius="md" />
+            </Group>
+          </Flex>
 
-        {/* Table Loading */}
-        <Stack gap="md">
-          <Skeleton height={50} />
-          <Skeleton height={40} />
-          <Skeleton height={40} />
-          <Skeleton height={40} />
+          {/* Table Loading */}
+          <Stack gap="md">
+            <Skeleton height={50} />
+            <Skeleton height={40} />
+            <Skeleton height={40} />
+            <Skeleton height={40} />
+          </Stack>
         </Stack>
-      </Stack>
+      </Container>
     );
   }
 
   return (
-    <Stack gap="lg">
-      {/* Header */}
-      <Flex justify="space-between" align="center">
-        <TitleText>Deployments</TitleText>
-        <Group gap="sm">
-          {loading ? (
-            <Skeleton height={28} width={120} />
-          ) : (
-            <Badge variant="light" color="gray" size="lg">
-              {builds.length} deployment{builds.length !== 1 ? "s" : ""}
-            </Badge>
-          )}
-          <ActionIcon
-            variant="filled"
-            size="md"
-            onClick={() => window.location.reload()}
+    <Container size="1070" mt="sm">
+      <Stack gap="lg">
+        {/* Header */}
+        <Flex justify="space-between" align="center">
+          <TitleText>Deployments</TitleText>
+          <Group gap="sm">
+            {loading ? (
+              <Skeleton height={28} width={120} />
+            ) : (
+              <Badge variant="light" color="gray" size="lg">
+                {builds.length} deployment{builds.length !== 1 ? "s" : ""}
+              </Badge>
+            )}
+            <ActionIcon
+              variant="filled"
+              size="md"
+              onClick={() => window.location.reload()}
+              color="blue"
+              loading={loading}
+              disabled={loading}
+            >
+              <TbRefresh size={16} />
+            </ActionIcon>
+          </Group>
+        </Flex>
+
+        {/* Enhanced Table */}
+        <Table
+          columns={columns}
+          data={tableData}
+          loading={loading || appLoading}
+          showIndex={false}
+          hideFilters
+          verticalSpacing="md"
+          striped="odd"
+          rowHover
+        />
+
+        {/* Empty State */}
+        {builds.length === 0 && !loading && !appLoading && (
+          <Alert
+            icon={<TbPlayerPlay size={20} />}
+            title="No deployments yet"
             color="blue"
-            loading={loading}
-            disabled={loading}
-          >
-            <TbRefresh size={16} />
-          </ActionIcon>
-        </Group>
-      </Flex>
-
-      {/* Enhanced Table */}
-      <Table
-        columns={columns}
-        data={tableData}
-        loading={loading || appLoading}
-        showIndex={false}
-        hideFilters
-        verticalSpacing="md"
-        striped="odd"
-        rowHover
-      />
-
-      {/* Empty State */}
-      {builds.length === 0 && !loading && !appLoading && (
-        <Alert
-          icon={<TbPlayerPlay size={20} />}
-          title="No deployments yet"
-          color="blue"
-          variant="light"
-          p="xl"
-          radius="md"
-        >
-          <Text size="sm" c="dimmed" mb="md">
-            No deployment history available for this app. Deployments will
-            appear here once you start deploying your application.
-          </Text>
-          <Button
-            leftSection={<TbPlayerPlay size={16} />}
             variant="light"
-            size="sm"
+            p="xl"
+            radius="md"
           >
-            Start your first deployment
-          </Button>
-        </Alert>
-      )}
-    </Stack>
+            <Text size="sm" c="dimmed" mb="md">
+              No deployment history available for this app. Deployments will
+              appear here once you start deploying your application.
+            </Text>
+            <Button
+              leftSection={<TbPlayerPlay size={16} />}
+              variant="light"
+              size="sm"
+            >
+              Start your first deployment
+            </Button>
+          </Alert>
+        )}
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/Apps/AppDetailPage.tsx
+++ b/src/pages/Apps/AppDetailPage.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Card,
   Code,
+  Container,
   Flex,
   Grid,
   Pill,
@@ -88,91 +89,93 @@ const AppDetailPage = () => {
     },
   ];
   return (
-    <Stack gap={20}>
-      <TitleText
-        rightSection={
-          <Button
-            color="gray.9"
-            variant="filled"
-            size="sm"
-            radius="md"
-            leftSection={<TbWorld />}
-            onClick={() => window.open(app?.url, "_blank")}
-          >
-            {app?.is_notebook ? "Open Notebook" : "Visit App"}
-          </Button>
-        }
-      >
-        {app?.name}
-      </TitleText>
-      <Card p="lg" radius="md" withBorder>
-        {loading ? (
-          <AppDetailsSkeleton />
-        ) : (
-          <Stack gap={20}>
-            <Flex gap={20} wrap="wrap">
-              {app?.image && !app?.is_notebook && (
-                <Stack gap={5}>
-                  <Text className="subtitle">Image</Text>
-                  <Code>
-                    <CustomText
-                      size="sm"
-                      leftSection={<FaDocker color="gray.7" />}
-                    >
-                      {app?.image}
-                    </CustomText>
-                  </Code>
-                </Stack>
-              )}
-              <Stack gap={5} w="fit-content" flex={app?.is_notebook && 1}>
-                <CustomText className="subtitle" leftSection={<TbWorld />}>
-                  Domain
-                </CustomText>
-                <Text
-                  component={Link}
-                  size="sm"
-                  to={app?.url}
-                  target="_blank"
-                  className="link"
-                >
-                  {app?.url}
-                  <FiExternalLink />
-                </Text>
-              </Stack>
-              {app?.is_notebook && (
-                <Pill w="fit-content">
-                  <Flex gap={5} wrap="nowrap" w="fit-content" align="center">
-                    <SiJupyter size={13} color="#f57c00" />
-                    <Text size="sm" truncate>
-                      Notebook
-                    </Text>
-                  </Flex>
-                </Pill>
-              )}
-            </Flex>
-
-            <Grid>
-              {appInfo.map((info) => (
-                <Grid.Col
-                  span={{ base: 12, md: 4, lg: 3 }}
-                  key={info.label}
-                  hidden={info?.visible === false}
-                >
-                  <Flex>
-                    <Stack gap={5}>
-                      <Text className="subtitle">{info.label}</Text>
-                      <CustomText size="sm" leftSection={info?.icon}>
-                        {info.value}
+    <Container size="1070" mt="sm">
+      <Stack gap={20}>
+        <TitleText
+          rightSection={
+            <Button
+              color="gray.9"
+              variant="filled"
+              size="sm"
+              radius="md"
+              leftSection={<TbWorld />}
+              onClick={() => window.open(app?.url, "_blank")}
+            >
+              {app?.is_notebook ? "Open Notebook" : "Visit App"}
+            </Button>
+          }
+        >
+          {app?.name}
+        </TitleText>
+        <Card p="lg" radius="md" withBorder>
+          {loading ? (
+            <AppDetailsSkeleton />
+          ) : (
+            <Stack gap={20}>
+              <Flex gap={20} wrap="wrap">
+                {app?.image && !app?.is_notebook && (
+                  <Stack gap={5}>
+                    <Text className="subtitle">Image</Text>
+                    <Code>
+                      <CustomText
+                        size="sm"
+                        leftSection={<FaDocker color="gray.7" />}
+                      >
+                        {app?.image}
                       </CustomText>
-                    </Stack>
-                  </Flex>
-                </Grid.Col>
-              ))}
-            </Grid>
-          </Stack>
-        )}
-      </Card>
-    </Stack>
+                    </Code>
+                  </Stack>
+                )}
+                <Stack gap={5} w="fit-content" flex={app?.is_notebook && 1}>
+                  <CustomText className="subtitle" leftSection={<TbWorld />}>
+                    Domain
+                  </CustomText>
+                  <Text
+                    component={Link}
+                    size="sm"
+                    to={app?.url}
+                    target="_blank"
+                    className="link"
+                  >
+                    {app?.url}
+                    <FiExternalLink />
+                  </Text>
+                </Stack>
+                {app?.is_notebook && (
+                  <Pill w="fit-content">
+                    <Flex gap={5} wrap="nowrap" w="fit-content" align="center">
+                      <SiJupyter size={13} color="#f57c00" />
+                      <Text size="sm" truncate>
+                        Notebook
+                      </Text>
+                    </Flex>
+                  </Pill>
+                )}
+              </Flex>
+
+              <Grid>
+                {appInfo.map((info) => (
+                  <Grid.Col
+                    span={{ base: 12, md: 4, lg: 3 }}
+                    key={info.label}
+                    hidden={info?.visible === false}
+                  >
+                    <Flex>
+                      <Stack gap={5}>
+                        <Text className="subtitle">{info.label}</Text>
+                        <CustomText size="sm" leftSection={info?.icon}>
+                          {info.value}
+                        </CustomText>
+                      </Stack>
+                    </Flex>
+                  </Grid.Col>
+                ))}
+              </Grid>
+            </Stack>
+          )}
+        </Card>
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/Apps/AppLogsPage.tsx
+++ b/src/pages/Apps/AppLogsPage.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { Card, Code, Flex, Loader, Stack, Text } from "@mantine/core";
+import {
+  Card,
+  Code,
+  Container,
+  Flex,
+  Loader,
+  Stack,
+  Text,
+} from "@mantine/core";
 import TitleText from "@/components/TitleText";
 import usePost from "@/utils/usePost";
 import { useGetApp } from "@/utils/helpers";
@@ -43,38 +51,40 @@ const LogsCard = ({ project_id, app_id }: TLogsCardProps) => {
   }, [appLogsSuccess]);
 
   return (
-    <Stack gap={10}>
-      <TitleText className="title">Logs</TitleText>
-      <Card radius="md" withBorder>
-        <Card.Section>
-          <Code
-            p="lg"
-            block
-            mah="80vh"
-            bg="dark.7"
-            c="white"
-            style={{
-              overflow: "auto",
-            }}
-          >
-            {appLogsLoading ? (
-              <Flex justify="center" align="center" h="100%">
-                <Loader size="sm" />
-              </Flex>
-            ) : logs.length <= 0 ? (
-              <Text size="xs" py="lg" ta="center">
-                No logs found
-              </Text>
-            ) : (
-              logs.map((log) => (
-                <Text size="xs" key={log}>
-                  {log}
+    <Container size="1070" mt="sm">
+      <Stack gap={10}>
+        <TitleText className="title">Logs</TitleText>
+        <Card radius="md" withBorder>
+          <Card.Section>
+            <Code
+              p="lg"
+              block
+              mah="80vh"
+              bg="dark.7"
+              c="white"
+              style={{
+                overflow: "auto",
+              }}
+            >
+              {appLogsLoading ? (
+                <Flex justify="center" align="center" h="100%">
+                  <Loader size="sm" />
+                </Flex>
+              ) : logs.length <= 0 ? (
+                <Text size="xs" py="lg" ta="center">
+                  No logs found
                 </Text>
-              ))
-            )}
-          </Code>
-        </Card.Section>
-      </Card>
-    </Stack>
+              ) : (
+                logs.map((log) => (
+                  <Text size="xs" key={log}>
+                    {log}
+                  </Text>
+                ))
+              )}
+            </Code>
+          </Card.Section>
+        </Card>
+      </Stack>
+    </Container>
   );
 };

--- a/src/pages/Apps/AppMetrics.tsx
+++ b/src/pages/Apps/AppMetrics.tsx
@@ -7,7 +7,7 @@ import TitleText from "@/components/TitleText";
 import { MONITORING_API_URL } from "@/config";
 import { bytesToMB } from "@/utils/helpers";
 import usePost from "@/utils/usePost";
-import { Grid } from "@mantine/core";
+import { Container, Grid } from "@mantine/core";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
@@ -141,7 +141,7 @@ const AppMetrics = () => {
   ]);
 
   return (
-    <div>
+    <Container size="1070" mt="sm">
       <TitleText>App Metrics</TitleText>
       <Grid>
         <Grid.Col span={12}>
@@ -214,7 +214,7 @@ const AppMetrics = () => {
           />
         </Grid.Col>
       </Grid>
-    </div>
+    </Container>
   );
 };
 

--- a/src/pages/Apps/AppSettingsPage.tsx
+++ b/src/pages/Apps/AppSettingsPage.tsx
@@ -39,6 +39,7 @@ import {
   List,
   Collapse,
   Box,
+  Container,
 } from "@mantine/core";
 import { useContext, useEffect, useState } from "react";
 import {
@@ -78,7 +79,7 @@ const AppSettingsPage = () => {
   }, [setContainerSize]);
   useEffect(() => {}, [app]);
   return (
-    <div>
+    <Container size="1070" mt="sm">
       <Tabs defaultValue="general">
         <Tabs.List>
           <Tabs.Tab value="general">General</Tabs.Tab>
@@ -100,7 +101,7 @@ const AppSettingsPage = () => {
           <DomainsTab app={app} setRefresh={setRefresh} />
         </Tabs.Panel>
       </Tabs>
-    </div>
+    </Container>
   );
 };
 

--- a/src/pages/Apps/AppsListPage.tsx
+++ b/src/pages/Apps/AppsListPage.tsx
@@ -1,5 +1,5 @@
 import TitleText from "@/components/TitleText";
-import { Stack } from "@mantine/core";
+import { Container, Stack } from "@mantine/core";
 import { useParams } from "react-router-dom";
 import { useGetProject } from "@/utils/helpers";
 import AppsList from "@/components/Lists/AppsList";
@@ -11,22 +11,24 @@ const AppsListPage = () => {
   const [refresh, setRefresh] = useState(false);
 
   return (
-    <Stack>
-      <TitleText
-        loading={false}
-        rightSection={
-          <AddServiceButton
-            project={project}
-            setRefresh={setRefresh}
-            title="Add App"
-            dontShowDatabase
-          />
-        }
-      >
-        Applications
-      </TitleText>
-      <AppsList project_id={project_id} refresh={refresh} />
-    </Stack>
+    <Container size="1070" mt="sm">
+      <Stack>
+        <TitleText
+          loading={false}
+          rightSection={
+            <AddServiceButton
+              project={project}
+              setRefresh={setRefresh}
+              title="Add App"
+              dontShowDatabase
+            />
+          }
+        >
+          Applications
+        </TitleText>
+        <AppsList project_id={project_id} refresh={refresh} />
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -263,7 +263,7 @@ const ExplorePage = () => {
   };
 
   return (
-    <Container size="xl" py="lg">
+    <Container size="xl">
       <Stack gap="xl">
         {/* Header Section */}
         <Stack gap="lg">
@@ -284,7 +284,7 @@ const ExplorePage = () => {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.currentTarget.value)}
                   size="md"
-                  radius="xl"
+                  radius="md"
                 />
               </Grid.Col>
               <Grid.Col span={3}>
@@ -298,7 +298,7 @@ const ExplorePage = () => {
                   onChange={(value) => setSelectedCategory(value || "all")}
                   leftSection={<FiFilter size={16} />}
                   size="md"
-                  radius="xl"
+                  radius="md"
                 />
               </Grid.Col>
               <Grid.Col span={3}>
@@ -314,7 +314,7 @@ const ExplorePage = () => {
                   onChange={(value) => setSortBy(value || "trending")}
                   leftSection={<FiTrendingUp size={16} />}
                   size="md"
-                  radius="xl"
+                  radius="md"
                 />
               </Grid.Col>
             </Grid>
@@ -511,7 +511,7 @@ const ExplorePage = () => {
 
                 <Grid.Col span={{ base: 12, lg: 4 }}>
                   <Stack gap="lg">
-                    <TrendingTags title="Popular Tags" perPage={30} />
+                    <TrendingTags title="Popular Tags" perPage={28} />
                   </Stack>
                 </Grid.Col>
               </Grid>
@@ -630,7 +630,7 @@ const ExplorePage = () => {
                           return (
                             <Card
                               key={tag.id}
-                              p="sm" // Reduced padding for a tighter feel
+                              p="sm"
                               withBorder
                               radius="lg"
                               component={Link}
@@ -643,23 +643,21 @@ const ExplorePage = () => {
                               }}
                               className="hover:shadow-md"
                             >
-                              {/* Switched to a horizontal layout to save vertical space */}
                               <Group
                                 wrap="nowrap"
                                 justify="space-between"
                                 align="center"
                               >
-                                {/* Left side: Icon + Text */}
                                 <Group
                                   wrap="nowrap"
                                   gap="sm"
                                   style={{ flex: 1, minWidth: 0 }}
                                 >
                                   <ThemeIcon
-                                    size="lg" // Reduced from xl to lg
+                                    size="lg"
                                     variant="light"
                                     color={getTagColor(tag.name)}
-                                    radius="md" // Added slightly softer edges to the icon background
+                                    radius="md"
                                   >
                                     <FiTag size={18} />
                                   </ThemeIcon>
@@ -677,15 +675,14 @@ const ExplorePage = () => {
                                   </Box>
                                 </Group>
 
-                                {/* Right side: Button */}
                                 <Button
                                   variant="outline"
                                   color="blue"
                                   size="xs"
-                                  radius="xl" // Updated to pill-shape to match your other modern buttons
+                                  radius="xl"
                                   loading={tagState.loading}
                                   disabled={tagState.loading}
-                                  style={{ flexShrink: 0 }} // Prevents the button from getting squished
+                                  style={{ flexShrink: 0 }}
                                   onClick={(e) => {
                                     e.preventDefault();
                                     handleTagFollow(tag);
@@ -698,7 +695,6 @@ const ExplorePage = () => {
                                     )
                                   }
                                 >
-                                  {/* Note: I adjusted the loading text logic slightly so it makes sense based on the action */}
                                   {tagState.loading
                                     ? tagState.is_following
                                       ? "Unfollowing..."
@@ -775,7 +771,7 @@ const ExplorePage = () => {
                                 variant="outline"
                                 color="blue"
                                 size="xs"
-                                radius="xl"
+                                radius="md"
                                 loading={tagState.loading}
                                 disabled={tagState.loading}
                                 style={{ flexShrink: 0 }}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -207,7 +207,7 @@ const LandingPage = () => {
                   loading={loading}
                 />
                 <Select
-                  radius="xl"
+                  radius="md"
                   data={["All Activity", "Following", "Your Activity"]}
                   defaultValue="Your Activity"
                   size="xs"
@@ -216,7 +216,7 @@ const LandingPage = () => {
               </Group>
             </Group>
 
-            <ScrollArea h={964}>
+            <ScrollArea h={800}>
               {loading ? (
                 <Stack gap="md">
                   {Array.from({ length: 5 }).map((_, index) => (

--- a/src/pages/Projects/ProjectMetrics.tsx
+++ b/src/pages/Projects/ProjectMetrics.tsx
@@ -6,7 +6,7 @@ import TitleText from "@/components/TitleText";
 import { MONITORING_API_URL } from "@/config";
 import { bytesToMB, useGetProject, useSetContainerSize } from "@/utils/helpers";
 import usePost from "@/utils/usePost";
-import { Grid } from "@mantine/core";
+import { Container, Grid } from "@mantine/core";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
@@ -130,7 +130,7 @@ const ProjectMetrics = () => {
     gpuMetricsData,
   ]);
   return (
-    <div>
+    <Container size="1070" mt="sm">
       <TitleText>Project Metrics</TitleText>
       <Grid>
         <Grid.Col span={12}>
@@ -205,7 +205,7 @@ const ProjectMetrics = () => {
           />
         </Grid.Col>
       </Grid>
-    </div>
+    </Container>
   );
 };
 

--- a/src/pages/Projects/ProjectSettingsPage.tsx
+++ b/src/pages/Projects/ProjectSettingsPage.tsx
@@ -4,6 +4,7 @@ import { useGetProject } from "@/utils/helpers";
 import {
   Button,
   Card,
+  Container,
   Divider,
   Flex,
   Grid,
@@ -40,7 +41,7 @@ const ProjectSettingsPage = () => {
   useEffect(() => {}, [project]);
 
   return (
-    <div>
+    <Container size="1070" mt="sm">
       <Tabs defaultValue="general">
         <Tabs.List>
           <Tabs.Tab value="general">General</Tabs.Tab>
@@ -64,7 +65,7 @@ const ProjectSettingsPage = () => {
           Settings tab content
         </Tabs.Panel> */}
       </Tabs>
-    </div>
+    </Container>
   );
 };
 
@@ -192,7 +193,7 @@ const GeneralTab = ({
                 </Text>
               </Stack>
               <Button
-                radius="xl"
+                radius="md"
                 variant="outline"
                 onClick={() => setUpdateConfirmOpened(true)}
                 leftSection={<IoPencil />}
@@ -209,7 +210,7 @@ const GeneralTab = ({
                 </Text>
               </Stack>
               <Button
-                radius="xl"
+                radius="md"
                 variant="outline"
                 onClick={() => setMigrateConfirmOpened(true)}
                 leftSection={<BiTransferAlt />}
@@ -227,7 +228,7 @@ const GeneralTab = ({
                   </Text>
                 </Stack>
                 <Button
-                  radius="xl"
+                  radius="md"
                   variant="outline"
                   color="green"
                   onClick={() => setEnableConfirmOpened(true)}
@@ -246,7 +247,7 @@ const GeneralTab = ({
                   </Text>
                 </Stack>
                 <Button
-                  radius="xl"
+                  radius="md"
                   variant="outline"
                   color="red"
                   onClick={() => setDisableConfirmOpened(true)}
@@ -267,7 +268,7 @@ const GeneralTab = ({
                 </Text>
               </Stack>
               <Button
-                radius="xl"
+                radius="md"
                 variant="outline"
                 color="red"
                 onClick={() => setDeleteConfirmOpened(true)}

--- a/src/pages/Projects/ProjectUsers.tsx
+++ b/src/pages/Projects/ProjectUsers.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   TextInput,
   Modal,
+  Container,
 } from "@mantine/core";
 import { HiDotsVertical } from "react-icons/hi";
 import { HiTrash } from "react-icons/hi2";
@@ -328,7 +329,7 @@ export const MembersSection = ({ project }: { project: any }) => {
     .find((m) => m?.user?.id === user?.id)
     ?.role.split(".")[1];
   return (
-    <div>
+    <Container size="1070" mt="sm">
       <TitleText>Members</TitleText>
       <Stack gap={20}>
         {isSelf && (myRole === "owner" || myRole === "admin") && (
@@ -361,7 +362,7 @@ export const MembersSection = ({ project }: { project: any }) => {
               </Flex>
               <Group justify="start" mt={10}>
                 <Button
-                  radius="xl"
+                  radius="md"
                   color="var(--mantine-color-text)"
                   leftSection={<IoMdSend />}
                   onClick={handleInviteMember}
@@ -504,6 +505,6 @@ export const MembersSection = ({ project }: { project: any }) => {
           </>
         )}
       </Modal>
-    </div>
+    </Container>
   );
 };

--- a/src/pages/TagDetailsPage.tsx
+++ b/src/pages/TagDetailsPage.tsx
@@ -403,7 +403,7 @@ const TagDetailsPage = () => {
               <Group gap="sm">
                 <Button
                   variant={isFollowing ? "light" : "filled"}
-                  radius="xl"
+                  radius="md"
                   size="md"
                   leftSection={
                     isFollowing ? (

--- a/src/pages/Users/ProfileViewPage.tsx
+++ b/src/pages/Users/ProfileViewPage.tsx
@@ -15,7 +15,6 @@ import {
   Divider,
   Skeleton,
   Center,
-  Badge,
   ThemeIcon,
   Anchor,
   LoadingOverlay,
@@ -42,7 +41,7 @@ import {
 } from "react-icons/fi";
 import { ProfileAvatar } from "@/components/Common";
 import { useParams, useNavigate } from "react-router-dom";
-import { FaUsersViewfinder, FaXTwitter } from "react-icons/fa6";
+import { FaCircleDot, FaUsersViewfinder, FaXTwitter } from "react-icons/fa6";
 import { ACTIVITY_LOGS_API_URL } from "@/config";
 import { Project } from "@/types/project";
 import ActivityTimeline from "@/components/Elements/Timeline";
@@ -51,6 +50,7 @@ import { TbFolderOff } from "react-icons/tb";
 import usePost from "@/utils/usePost";
 import { API_USERS } from "@/utils/apis";
 import PaginationInfo from "@/components/PaginationInfo";
+import { LuUserCheck, LuUsers } from "react-icons/lu";
 
 const ProfileViewPage = () => {
   useSetNoSidebar();
@@ -232,58 +232,134 @@ const ProfileViewPage = () => {
     <Grid gutter={40}>
       {/* LEFT COLUMN - MAIN PROFILE & PROJECTS */}
       <Grid.Col span={{ base: 12, md: 8 }}>
-        {/* PROFILE HEADER CARD */}
+        <Group justify="space-between">
+          <Title order={3}>User Details</Title>
+        </Group>
+        <Divider my="xs" />
         {fetchingUserDetails && !userData?.data?.user ? (
           <ProfileHeaderSkeleton />
         ) : (
-          <Card p={0} radius="lg" withBorder shadow="sm" mb={40}>
-            {/* Modern Banner */}
-            <Box
-              h={140}
-              style={{
-                background:
-                  "linear-gradient(45deg, var(--mantine-color-blue-6), var(--mantine-color-cyan-6))",
-              }}
-            />
-
-            <Box p="xl" pt={0}>
-              <Flex justify="space-between" align="flex-end" mt={-60} mb="md">
-                {/* Overlapping Avatar */}
-                <Box
-                  style={{
-                    borderRadius: "50%",
-                    border: "6px solid var(--mantine-color-body)",
-                    backgroundColor: "var(--mantine-color-body)",
-                  }}
+          <Card
+            p="xl"
+            radius="md"
+            withBorder
+            style={{
+              position: "relative",
+              overflow: "hidden",
+              [`@media (min-width: 992px)`]: {
+                height: "280px",
+              },
+            }}
+            mb={20}
+          >
+            <Grid gutter="xl">
+              <Grid.Col span={{ base: 12, lg: 10 }}>
+                <Flex
+                  gap="xl"
+                  align="flex-start"
+                  direction={{ base: "column", sm: "row" }}
                 >
-                  <ProfileAvatar user={userData?.data?.user} size={120} />
-                </Box>
+                  <ProfileAvatar user={userData?.data?.user} size={140} />
+                  <Stack gap="xs" flex={1}>
+                    <Group gap="sm" wrap="nowrap">
+                      <Title order={2}>
+                        {userData?.data?.user?.name || "N/A"}
+                      </Title>
+                    </Group>
 
-                {/* Action Buttons floated right */}
-                <Box mb="sm">
+                    <Text c="dimmed" size="md">
+                      @{userData?.data?.user?.username || "johndoe"}
+                    </Text>
+
+                    <Text size="md" maw={600} lineClamp={3}>
+                      {beautify(userData?.data?.user?.biography)}
+                    </Text>
+
+                    <Group gap="xl" mt={20}>
+                      <Group gap={6}>
+                        <LuUserCheck size={18} />
+                        <Text size="sm" fw={500}>
+                          {userData?.data?.user?.following_count || 0}
+                        </Text>
+                        <Text size="sm" c="dimmed">
+                          Following
+                        </Text>
+                      </Group>
+
+                      <Group gap={6}>
+                        <LuUsers size={18} />
+                        <Text size="sm" fw={500}>
+                          {userData?.data?.user?.followers_count || 0}
+                        </Text>
+                        <Text size="sm" c="dimmed">
+                          Followers
+                        </Text>
+                      </Group>
+                    </Group>
+
+                    <Group gap="md" mt="xs">
+                      <Group gap={4}>
+                        <Text size="sm" c="dimmed">
+                          Member Since{" "}
+                          {new Date(
+                            userData?.data?.user?.date_created,
+                          ).getFullYear()}
+                        </Text>
+                      </Group>
+
+                      <Group gap="xs">
+                        {socialLinks?.map(
+                          (social, index) =>
+                            social.url !== null && (
+                              <>
+                                <FaCircleDot size="4" color="gray" />
+                                <ActionIcon
+                                  key={index}
+                                  variant="subtle"
+                                  size="lg"
+                                  component="a"
+                                  href={social.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  <social.icon size={18} />
+                                </ActionIcon>
+                              </>
+                            ),
+                        )}
+                      </Group>
+                    </Group>
+                  </Stack>
+                </Flex>
+              </Grid.Col>
+
+              <Grid.Col span={{ base: 12, md: 2 }}>
+                <Stack align="flex-end" gap="md" h="100%">
                   {isCurrentUser ? (
                     <Button
-                      variant="default"
-                      radius="xl"
+                      variant="outline"
+                      size="sm"
+                      color="blue"
                       onClick={() => navigate("/users/profile/settings")}
-                      leftSection={<FiEdit size={16} />}
+                      leftSection={<FiEdit size={20} />}
                     >
                       Edit Profile
                     </Button>
                   ) : (
                     <Button
-                      variant={isFollowingUser ? "default" : "filled"}
-                      color={isFollowingUser ? "gray" : "blue"}
-                      radius="xl"
+                      variant="outline"
+                      size="sm"
+                      color="blue"
                       onClick={onFollowClick}
                       leftSection={
                         isFollowingUser ? (
-                          <FiCheck size={16} />
+                          <FiCheck size={20} />
                         ) : (
-                          <FiUserPlus size={16} />
+                          <FiUserPlus size={20} />
                         )
                       }
                       loading={isLoading}
+                      disabled={isLoading}
                     >
                       {isLoading
                         ? isFollowingUser
@@ -294,77 +370,9 @@ const ProfileViewPage = () => {
                           : "Follow"}
                     </Button>
                   )}
-                </Box>
-              </Flex>
-
-              <Stack gap="xs">
-                <Group align="center" gap="sm">
-                  <Title order={2} style={{ letterSpacing: "-0.5px" }}>
-                    {userData?.data?.user?.name || "N/A"}
-                  </Title>
-                  <Badge
-                    tt="capitalize"
-                    variant="light"
-                    color="blue"
-                    radius="xl"
-                  >
-                    Member Since{" "}
-                    {new Date(
-                      userData?.data?.user?.date_created || Date.now(),
-                    ).getFullYear()}
-                  </Badge>
-                </Group>
-
-                <Text c="dimmed" size="lg" fw={500} mt={-5}>
-                  @{userData?.data?.user?.username || "johndoe"}
-                </Text>
-
-                <Text size="md" maw={650} mt="sm" lh={1.6}>
-                  {beautify(userData?.data?.user?.biography)}
-                </Text>
-
-                <Group gap="xl" mt="md">
-                  <Group gap={6}>
-                    <Text size="md" fw={700}>
-                      {userData?.data?.user?.following_count || 0}
-                    </Text>
-                    <Text size="sm" c="dimmed">
-                      Following
-                    </Text>
-                  </Group>
-                  <Group gap={6}>
-                    <Text size="md" fw={700}>
-                      {userData?.data?.user?.followers_count || 0}
-                    </Text>
-                    <Text size="sm" c="dimmed">
-                      Followers
-                    </Text>
-                  </Group>
-
-                  <Divider orientation="vertical" />
-
-                  <Group gap="xs">
-                    {socialLinks?.map(
-                      (social, index) =>
-                        social.url !== null && (
-                          <ActionIcon
-                            key={index}
-                            variant="subtle"
-                            color="gray"
-                            size="lg"
-                            radius="xl"
-                            component="a"
-                            href={social.url}
-                            target="_blank"
-                          >
-                            <social.icon size={20} />
-                          </ActionIcon>
-                        ),
-                    )}
-                  </Group>
-                </Group>
-              </Stack>
-            </Box>
+                </Stack>
+              </Grid.Col>
+            </Grid>
           </Card>
         )}
 
@@ -373,7 +381,7 @@ const ProfileViewPage = () => {
           <ProjectsSkeleton />
         ) : (
           userProjectData?.data?.pinned?.length > 0 && (
-            <Stack gap="lg" mb={40}>
+            <Stack gap="md" mb={40}>
               <Title order={3} size="h4" fw={700}>
                 Pinned Projects
               </Title>
@@ -394,7 +402,7 @@ const ProfileViewPage = () => {
         {fetchingUserProjects && !userProjectData?.data?.projects ? (
           <ProjectsSkeleton />
         ) : (
-          <Stack gap="lg">
+          <Stack gap="md">
             <Title order={3} size="h4" fw={700}>
               {isCurrentUser ? "My Projects" : "Projects"}
             </Title>
@@ -463,30 +471,25 @@ const ProfileViewPage = () => {
           <Stack gap="xl">
             {/* UNIFIED OVERVIEW CARD */}
             <Box>
-              <Title order={3} size="h4" fw={700} mb="md">
-                Overview
+              <Title order={3} size="h4" fw={700} mb="md" lts={0.1}>
+                Platform Summary
               </Title>
               {fetchingUserDetails ? (
                 <UserStatsSkeleton />
               ) : (
-                <Card withBorder radius="lg" shadow="sm">
+                <Card withBorder radius="md" shadow="sm" p="sm">
                   <SimpleGrid cols={2} spacing="md">
                     {userStats.map((stat, index) => (
                       <Box
                         key={index}
-                        // p="sm"
+                        p={3}
                         style={{
                           borderRadius: "var(--mantine-radius-md)",
                         }}
                       >
                         <Box key={index} p="xs">
-                          <Group gap="sm" wrap="nowrap">
-                            <ThemeIcon
-                              variant="light"
-                              // color={stat.color}
-                              size="lg"
-                              radius="md"
-                            >
+                          <Group gap="md" wrap="nowrap">
+                            <ThemeIcon variant="light" size="lg" radius="md">
                               <stat.icon size={18} />
                             </ThemeIcon>
                             <Box>
@@ -517,7 +520,7 @@ const ProfileViewPage = () => {
               <Title order={3} size="h4" fw={700} mb="md">
                 Recent Activity
               </Title>
-              <Card withBorder radius="lg" shadow="sm" p="lg">
+              <Card withBorder radius="md" shadow="sm" p="lg">
                 {fetchingUserActivities ? (
                   <UserActivitiesSkeleton />
                 ) : error || activitiesData?.data?.activity?.length === 0 ? (
@@ -599,60 +602,57 @@ const ProfileViewPage = () => {
 
 export const ProfileHeaderSkeleton = () => {
   return (
-    <Card p={0} radius="lg" withBorder shadow="sm" mb={40}>
-      {/* Skeleton for the Banner */}
-      <Skeleton height={140} radius={0} />
-
-      <Box p="xl" pt={0}>
-        <Flex justify="space-between" align="flex-end" mt={-60} mb="md">
-          {/* Skeleton for the Overlapping Avatar */}
-          <Box
-            style={{
-              borderRadius: "50%",
-              border: "6px solid var(--mantine-color-body)",
-              backgroundColor: "var(--mantine-color-body)",
-            }}
+    <Card
+      p="xl"
+      radius="md"
+      withBorder
+      style={{
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <Grid gutter="xl">
+        <Grid.Col span={{ base: 12, md: 8 }}>
+          <Flex
+            gap="xl"
+            align="flex-start"
+            direction={{ base: "column", sm: "row" }}
           >
-            <Skeleton circle height={120} width={120} />
-          </Box>
+            {/* Avatar */}
+            <Skeleton circle height={140} width={140} />
 
-          {/* Skeleton for the Edit/Follow Button */}
-          <Box mb="sm">
-            <Skeleton height={36} width={100} radius="md" />
-          </Box>
-        </Flex>
+            <Stack gap="xs" flex={1}>
+              {/* Name */}
+              <Group gap="sm" wrap="nowrap">
+                <Skeleton height={28} width={200} />
+              </Group>
 
-        <Stack gap="xs">
-          {/* Skeleton for Name & Badge */}
-          <Group align="center" gap="sm">
-            <Skeleton height={32} width={220} radius="sm" />
-            <Skeleton height={24} width={130} radius="sm" />
-          </Group>
+              {/* Username */}
+              <Skeleton height={18} width={120} />
 
-          {/* Skeleton for Username */}
-          <Skeleton height={18} width={100} mt={-5} />
+              {/* Biography */}
+              <Skeleton height={50} width="80%" />
 
-          {/* Skeleton for Biography (3 lines) */}
-          <Box mt="sm">
-            <Skeleton height={16} width="80%" mb={8} radius="sm" />
-            <Skeleton height={16} width="90%" mb={8} radius="sm" />
-            <Skeleton height={16} width="60%" radius="sm" />
-          </Box>
+              {/* Following + Followers */}
+              <Group gap="xl">
+                <Skeleton height={16} width={80} />
+                <Skeleton height={16} width={80} />
+              </Group>
 
-          {/* Skeleton for Followers/Following/Socials */}
-          <Group gap="xl" mt="md">
-            <Group gap={6}>
-              <Skeleton height={20} width={30} radius="sm" />
-              <Skeleton height={14} width={60} radius="sm" />
-            </Group>
-            <Group gap={6}>
-              <Skeleton height={20} width={30} radius="sm" />
-              <Skeleton height={14} width={60} radius="sm" />
-            </Group>
-            <Skeleton height={28} width={120} radius="xl" />
-          </Group>
-        </Stack>
-      </Box>
+              {/* Member Since + Socials */}
+              <Group gap="md" mt="sm">
+                <Skeleton height={14} width={150} />
+              </Group>
+            </Stack>
+          </Flex>
+        </Grid.Col>
+
+        <Grid.Col span={{ base: 12, md: 4 }}>
+          <Stack align="flex-end" gap="md" h="100%">
+            <Skeleton height={36} width={100} />
+          </Stack>
+        </Grid.Col>
+      </Grid>
     </Card>
   );
 };
@@ -710,7 +710,6 @@ export const UserStatsSkeleton: React.FC = () => {
             key={index}
             p="sm"
             style={{
-              backgroundColor: "var(--mantine-color-gray-0)",
               borderRadius: "var(--mantine-radius-md)",
             }}
           >

--- a/src/pages/Users/UserProfileSettingsPage.tsx
+++ b/src/pages/Users/UserProfileSettingsPage.tsx
@@ -1,4 +1,13 @@
-import { Button, Card, Divider, Flex, Group, Stack, Text } from "@mantine/core";
+import {
+  Button,
+  Card,
+  Container,
+  Divider,
+  Flex,
+  Group,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { useEffect, useState } from "react";
 import { HiPlus } from "react-icons/hi2";
 import { FaArrowLeft, FaLockOpen } from "react-icons/fa";
@@ -118,144 +127,148 @@ const SocialLinksTab = ({
     })) || [];
 
   return (
-    <Stack gap={30} mt="md">
-      {/* Social Links */}
-      <Stack gap={0}>
-        <TitleText>Social Media Links</TitleText>
-        {links.length > 0 ? (
-          <SocialMediaLinksTable links={links} />
-        ) : (
-          <Text className="subtext">Add your social media profiles here.</Text>
-        )}
-        <Flex justify="flex-end" mt="md">
-          <Button
-            variant="outline"
-            onClick={() => setSocialModal(true)}
-            leftSection={links.length > 0 ? <FaPencil /> : <HiPlus />}
-          >
-            {links.length > 0 ? "Update Links" : "Add Links"}
-          </Button>
-        </Flex>
+    <Container size="1070" mt="sm">
+      <Stack gap={30} mt="md">
+        {/* Social Links */}
+        <Stack gap={0}>
+          <TitleText>Social Media Links</TitleText>
+          {links.length > 0 ? (
+            <SocialMediaLinksTable links={links} />
+          ) : (
+            <Text className="subtext">
+              Add your social media profiles here.
+            </Text>
+          )}
+          <Flex justify="flex-end" mt="md">
+            <Button
+              variant="outline"
+              onClick={() => setSocialModal(true)}
+              leftSection={links.length > 0 ? <FaPencil /> : <HiPlus />}
+            >
+              {links.length > 0 ? "Update Links" : "Add Links"}
+            </Button>
+          </Flex>
+        </Stack>
+
+        {/* User Profile */}
+        <Stack gap={0}>
+          <TitleText>Manage Profile</TitleText>
+          <Card p="lg" radius="md" withBorder>
+            <Stack gap={10} mt="md">
+              <Group justify="space-between" align="center">
+                <Stack gap={0}>
+                  <Text className="title">Toggle Profile Visibility</Text>
+                  <Text className="subtext">
+                    Make your profile {user?.is_public ? "private" : "public"}.
+                  </Text>
+                </Stack>
+                {/* Visibility Toggle */}
+                <Stack gap={10} mt="md">
+                  <Group justify="space-between" align="center">
+                    <Stack gap={0} />
+                    {visibility ? (
+                      <Button
+                        variant="outline"
+                        color="black"
+                        onClick={() => setMakePrivateConfirmOpened(true)}
+                        leftSection={<FaLock />}
+                      >
+                        Private
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        color="green"
+                        onClick={() => setMakePublicConfirmOpened(true)}
+                        leftSection={<FaLockOpen />}
+                      >
+                        Public
+                      </Button>
+                    )}
+                  </Group>
+                </Stack>
+              </Group>
+            </Stack>
+            <Divider my="md" />
+            <Stack gap={10}>
+              <Group justify="space-between">
+                <Stack gap={0}>
+                  <Text className="title">Update profile</Text>
+                  <Text className="subtext">
+                    Modify the profile name and description
+                  </Text>
+                </Stack>
+                <Button
+                  variant="outline"
+                  onClick={() => setUpdateModal(true)}
+                  leftSection={<FaPencil />}
+                >
+                  Update
+                </Button>
+              </Group>
+            </Stack>
+
+            {/* Modals */}
+            <ModalConfirm
+              opened={updateModal}
+              onClose={() => setUpdateModal(false)}
+              title="Update Profile Information"
+              buttonText="Update"
+              size="xl"
+              showFooterActions={false}
+              onConfirm={() => {}}
+            >
+              <UpdateProfileForm
+                user={user}
+                onCancel={() => setUpdateModal(false)}
+                refresh={() => setRefresh((prev) => prev + 1)}
+              />
+            </ModalConfirm>
+
+            <ModalConfirm
+              opened={makePrivateConfirmOpened}
+              onClose={() => setMakePrivateConfirmOpened(false)}
+              title="Make Profile Private"
+              buttonText="Confirm"
+              buttonColor="black"
+              onConfirm={handleMakePrivate}
+              leftSection={<FaLock />}
+            >
+              Are you sure you want to make your profile <b>private</b>? It will
+              no longer be publicly visible.
+            </ModalConfirm>
+
+            <ModalConfirm
+              opened={makePublicConfirmOpened}
+              onClose={() => setMakePublicConfirmOpened(false)}
+              title="Make Profile Public"
+              buttonText="Confirm"
+              buttonColor="green"
+              onConfirm={handleMakePublic}
+              leftSection={<FaLockOpen />}
+            >
+              Are you sure you want to make your profile <b>public</b>? It will
+              be visible to everyone.
+            </ModalConfirm>
+
+            <ModalConfirm
+              opened={socialModal}
+              onClose={() => setSocialModal(false)}
+              title="Social Media Links"
+              size="xl"
+              showFooterActions={false}
+              onConfirm={() => {}}
+            >
+              <SocialMediaLinksForm
+                user={user}
+                onCancel={() => setSocialModal(false)}
+                refresh={() => setRefresh((prev) => prev + 1)}
+              />
+            </ModalConfirm>
+          </Card>
+        </Stack>
       </Stack>
-
-      {/* User Profile */}
-      <Stack gap={0}>
-        <TitleText>Manage Profile</TitleText>
-        <Card p="lg" radius="md" withBorder>
-          <Stack gap={10} mt="md">
-            <Group justify="space-between" align="center">
-              <Stack gap={0}>
-                <Text className="title">Toggle Profile Visibility</Text>
-                <Text className="subtext">
-                  Make your profile {user?.is_public ? "private" : "public"}.
-                </Text>
-              </Stack>
-              {/* Visibility Toggle */}
-              <Stack gap={10} mt="md">
-                <Group justify="space-between" align="center">
-                  <Stack gap={0} />
-                  {visibility ? (
-                    <Button
-                      variant="outline"
-                      color="black"
-                      onClick={() => setMakePrivateConfirmOpened(true)}
-                      leftSection={<FaLock />}
-                    >
-                      Private
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="outline"
-                      color="green"
-                      onClick={() => setMakePublicConfirmOpened(true)}
-                      leftSection={<FaLockOpen />}
-                    >
-                      Public
-                    </Button>
-                  )}
-                </Group>
-              </Stack>
-            </Group>
-          </Stack>
-          <Divider my="md" />
-          <Stack gap={10}>
-            <Group justify="space-between">
-              <Stack gap={0}>
-                <Text className="title">Update profile</Text>
-                <Text className="subtext">
-                  Modify the profile name and description
-                </Text>
-              </Stack>
-              <Button
-                variant="outline"
-                onClick={() => setUpdateModal(true)}
-                leftSection={<FaPencil />}
-              >
-                Update
-              </Button>
-            </Group>
-          </Stack>
-
-          {/* Modals */}
-          <ModalConfirm
-            opened={updateModal}
-            onClose={() => setUpdateModal(false)}
-            title="Update Profile Information"
-            buttonText="Update"
-            size="xl"
-            showFooterActions={false}
-            onConfirm={() => {}}
-          >
-            <UpdateProfileForm
-              user={user}
-              onCancel={() => setUpdateModal(false)}
-              refresh={() => setRefresh((prev) => prev + 1)}
-            />
-          </ModalConfirm>
-
-          <ModalConfirm
-            opened={makePrivateConfirmOpened}
-            onClose={() => setMakePrivateConfirmOpened(false)}
-            title="Make Profile Private"
-            buttonText="Confirm"
-            buttonColor="black"
-            onConfirm={handleMakePrivate}
-            leftSection={<FaLock />}
-          >
-            Are you sure you want to make your profile <b>private</b>? It will
-            no longer be publicly visible.
-          </ModalConfirm>
-
-          <ModalConfirm
-            opened={makePublicConfirmOpened}
-            onClose={() => setMakePublicConfirmOpened(false)}
-            title="Make Profile Public"
-            buttonText="Confirm"
-            buttonColor="green"
-            onConfirm={handleMakePublic}
-            leftSection={<FaLockOpen />}
-          >
-            Are you sure you want to make your profile <b>public</b>? It will be
-            visible to everyone.
-          </ModalConfirm>
-
-          <ModalConfirm
-            opened={socialModal}
-            onClose={() => setSocialModal(false)}
-            title="Social Media Links"
-            size="xl"
-            showFooterActions={false}
-            onConfirm={() => {}}
-          >
-            <SocialMediaLinksForm
-              user={user}
-              onCancel={() => setSocialModal(false)}
-              refresh={() => setRefresh((prev) => prev + 1)}
-            />
-          </ModalConfirm>
-        </Card>
-      </Stack>
-    </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/admin/CreateClusters.tsx
+++ b/src/pages/admin/CreateClusters.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import TitleText from "@/components/TitleText";
 import {
   Button,
+  Container,
   Divider,
   Group,
   Paper,
@@ -68,87 +69,89 @@ const CreateClusters = ({
   }, []);
 
   return (
-    <Stack>
-      {showTitle && <TitleText>Create Cluster</TitleText>}
-      <Paper px="lg" radius="md">
-        <form onSubmit={handleSubmit}>
-          <Stack>
-            <TextInput
-              label="Cluster Name"
-              name="name"
-              placeholder="Enter cluster name"
-              description="Enter the name of the cluster"
-              required
-              value={form?.name as string}
-              onChange={onChange}
-              error={error?.name}
-              // leftSection={<MdDriveFileRenameOutline />}
-            />
+    <Container size="1070" mt="sm">
+      <Stack>
+        {showTitle && <TitleText>Create Cluster</TitleText>}
+        <Paper px="lg" radius="md">
+          <form onSubmit={handleSubmit}>
+            <Stack>
+              <TextInput
+                label="Cluster Name"
+                name="name"
+                placeholder="Enter cluster name"
+                description="Enter the name of the cluster"
+                required
+                value={form?.name as string}
+                onChange={onChange}
+                error={error?.name}
+                // leftSection={<MdDriveFileRenameOutline />}
+              />
 
-            <TextInput
-              label="Host"
-              name="host"
-              placeholder="Enter host"
-              description="Host URL"
-              flex={1}
-              required
-              value={form?.host as string}
-              onChange={onChange}
-              error={error?.host}
-              // leftSection={<FaDocker />}
-            />
-            <TextInput
-              label="Sub Domain"
-              name="sub_domain"
-              placeholder="Enter Sub Domain"
-              description="Clusters Subdomain"
-              flex={1}
-              required
-              value={form?.sub_domain as string}
-              onChange={onChange}
-              error={error?.sub_domain}
-              // leftSection={<FaDocker />}
-            />
-            <Textarea
-              label="Description"
-              name="description"
-              placeholder="Enter description"
-              description="Description"
-              flex={1}
-              required
-              value={form?.description as string}
-              onChange={onChange}
-              error={error?.description}
-              // leftSection={<FaDocker />}
-            />
-            <Textarea
-              label="Token"
-              name="token"
-              placeholder="Enter token"
-              description="Token"
-              flex={1}
-              required={!cluster}
-              value={form?.token as string}
-              onChange={onChange}
-              error={error?.token}
-              // leftSection={<FaDocker />}
-            />
-            <Divider mt="md" />
-            <Group justify="flex-end">
-              <Button
-                type="submit"
-                variant="filled"
-                loading={submitting}
-                // leftSection={<IoRocketSharp />}
-                color="gray.9"
-              >
-                {cluster ? "Update Cluster" : "Create Cluster"}
-              </Button>
-            </Group>
-          </Stack>
-        </form>
-      </Paper>
-    </Stack>
+              <TextInput
+                label="Host"
+                name="host"
+                placeholder="Enter host"
+                description="Host URL"
+                flex={1}
+                required
+                value={form?.host as string}
+                onChange={onChange}
+                error={error?.host}
+                // leftSection={<FaDocker />}
+              />
+              <TextInput
+                label="Sub Domain"
+                name="sub_domain"
+                placeholder="Enter Sub Domain"
+                description="Clusters Subdomain"
+                flex={1}
+                required
+                value={form?.sub_domain as string}
+                onChange={onChange}
+                error={error?.sub_domain}
+                // leftSection={<FaDocker />}
+              />
+              <Textarea
+                label="Description"
+                name="description"
+                placeholder="Enter description"
+                description="Description"
+                flex={1}
+                required
+                value={form?.description as string}
+                onChange={onChange}
+                error={error?.description}
+                // leftSection={<FaDocker />}
+              />
+              <Textarea
+                label="Token"
+                name="token"
+                placeholder="Enter token"
+                description="Token"
+                flex={1}
+                required={!cluster}
+                value={form?.token as string}
+                onChange={onChange}
+                error={error?.token}
+                // leftSection={<FaDocker />}
+              />
+              <Divider mt="md" />
+              <Group justify="flex-end">
+                <Button
+                  type="submit"
+                  variant="filled"
+                  loading={submitting}
+                  // leftSection={<IoRocketSharp />}
+                  color="gray.9"
+                >
+                  {cluster ? "Update Cluster" : "Create Cluster"}
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Paper>
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import SummaryComponent from "@/components/Admin/SummaryComponent";
 import AdminClustersList from "@/components/Admin/AdminClustersList";
-import { Stack } from "@mantine/core";
+import { Container, Stack } from "@mantine/core";
 
 const DashboardPage = () => {
   return (
-    <Stack gap="xl">
-      <SummaryComponent />
-      <AdminClustersList />
-    </Stack>
+    <Container size="1070" mt="sm">
+      <Stack gap="xl">
+        <SummaryComponent />
+        <AdminClustersList />
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/admin/cluster/ClusterSettingsPage.tsx
+++ b/src/pages/admin/cluster/ClusterSettingsPage.tsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useState } from "react";
 import TitleText from "@/components/TitleText";
 import { useGetAdminCluster } from "@/utils/helpers";
-import { Button, Card, Divider, Group, Stack, Text } from "@mantine/core";
+import {
+  Button,
+  Card,
+  Container,
+  Divider,
+  Group,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { useNavigate, useParams } from "react-router-dom";
 import { ClusterDetailsCard } from "./ClustersDashboard";
 import { ModalConfirm } from "@/components/Elements/Modals";
@@ -39,79 +47,83 @@ const ClusterSettingsPage = () => {
   };
 
   return (
-    <Stack>
-      <TitleText>Cluster Settings</TitleText>
-      <ClusterDetailsCard clusterData={clusterData} loading={loading} />
-      <Stack gap={0}>
-        <TitleText>Danger Zone</TitleText>
-        <Card p="lg" radius="md" withBorder>
-          <Stack gap={10}>
-            <Group justify="space-between" align="center">
-              <Stack gap={0}>
-                <Text className="title">Update Cluster</Text>
-                <Text className="subtext">Modify the cluster information</Text>
-              </Stack>
-              <Button
-                variant="outline"
-                onClick={() => setUpdateConfirmOpened(true)}
-                leftSection={<MdEdit />}
-              >
-                Update
-              </Button>
-            </Group>
-            <Divider />
+    <Container size="1070" mt="sm">
+      <Stack>
+        <TitleText>Cluster Settings</TitleText>
+        <ClusterDetailsCard clusterData={clusterData} loading={loading} />
+        <Stack gap={0}>
+          <TitleText>Danger Zone</TitleText>
+          <Card p="lg" radius="md" withBorder>
+            <Stack gap={10}>
+              <Group justify="space-between" align="center">
+                <Stack gap={0}>
+                  <Text className="title">Update Cluster</Text>
+                  <Text className="subtext">
+                    Modify the cluster information
+                  </Text>
+                </Stack>
+                <Button
+                  variant="outline"
+                  onClick={() => setUpdateConfirmOpened(true)}
+                  leftSection={<MdEdit />}
+                >
+                  Update
+                </Button>
+              </Group>
+              <Divider />
 
-            <Group justify="space-between" align="center">
-              <Stack gap={0}>
-                <Text className="title">Delete Cluster</Text>
-                <Text className="subtext">
-                  This action is irreversible and will delete the cluster
-                  permanently.
-                </Text>
-              </Stack>
-              <Button
-                variant="outline"
-                color="red"
-                onClick={() => setDeleteConfirmOpened(true)}
-                leftSection={<HiTrash />}
-              >
-                Delete
-              </Button>
-            </Group>
-          </Stack>
-          <ModalConfirm
-            opened={deleteConfirmOpened}
-            onClose={() => setDeleteConfirmOpened(false)}
-            title="Delete Cluster"
-            buttonColor="red"
-            buttonText="Delete"
-            onConfirm={handleDelete}
-            loading={deletingCluster}
-            leftSection={<HiTrash />}
-          >
-            Are you sure you want to delete <b>{cluster?.name}</b> cluster
-            permanently? This action cannot be undone.
-          </ModalConfirm>
+              <Group justify="space-between" align="center">
+                <Stack gap={0}>
+                  <Text className="title">Delete Cluster</Text>
+                  <Text className="subtext">
+                    This action is irreversible and will delete the cluster
+                    permanently.
+                  </Text>
+                </Stack>
+                <Button
+                  variant="outline"
+                  color="red"
+                  onClick={() => setDeleteConfirmOpened(true)}
+                  leftSection={<HiTrash />}
+                >
+                  Delete
+                </Button>
+              </Group>
+            </Stack>
+            <ModalConfirm
+              opened={deleteConfirmOpened}
+              onClose={() => setDeleteConfirmOpened(false)}
+              title="Delete Cluster"
+              buttonColor="red"
+              buttonText="Delete"
+              onConfirm={handleDelete}
+              loading={deletingCluster}
+              leftSection={<HiTrash />}
+            >
+              Are you sure you want to delete <b>{cluster?.name}</b> cluster
+              permanently? This action cannot be undone.
+            </ModalConfirm>
 
-          <ModalConfirm
-            opened={updateConfirmOpened}
-            onClose={() => setUpdateConfirmOpened(false)}
-            title="Update Cluster"
-            buttonText="Update"
-            onConfirm={() => {}}
-            size="xl"
-            showFooterActions={false}
-          >
-            <CreateClusters
-              cluster={cluster}
-              showTitle={false}
-              onCancel={() => setUpdateConfirmOpened(false)}
-              refresh={() => setRefresh(true)}
-            />
-          </ModalConfirm>
-        </Card>
+            <ModalConfirm
+              opened={updateConfirmOpened}
+              onClose={() => setUpdateConfirmOpened(false)}
+              title="Update Cluster"
+              buttonText="Update"
+              onConfirm={() => {}}
+              size="xl"
+              showFooterActions={false}
+            >
+              <CreateClusters
+                cluster={cluster}
+                showTitle={false}
+                onCancel={() => setUpdateConfirmOpened(false)}
+                refresh={() => setRefresh(true)}
+              />
+            </ModalConfirm>
+          </Card>
+        </Stack>
       </Stack>
-    </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/admin/cluster/ClustersDashboard.tsx
+++ b/src/pages/admin/cluster/ClustersDashboard.tsx
@@ -1,15 +1,17 @@
 import { formatDate, useGetAdminCluster } from "@/utils/helpers";
 import React from "react";
-import { Stack, Skeleton } from "@mantine/core";
+import { Stack, Skeleton, Container } from "@mantine/core";
 import TitleText from "@/components/TitleText";
 import { useParams } from "react-router-dom";
 import DetailsCard, { SimpleDetailsCard } from "@/components/Cards/DetailsCard";
 
 const LoadingSkeleton = () => (
-  <Stack>
-    <Skeleton height={40} width={300} mb={20} />
-    <Skeleton height={100} radius="md" mb={20} />
-  </Stack>
+  <Container size="1070" mt="sm">
+    <Stack>
+      <Skeleton height={40} width={300} mb={20} />
+      <Skeleton height={100} radius="md" mb={20} />
+    </Stack>
+  </Container>
 );
 
 const ClustersDashboard = () => {
@@ -33,13 +35,15 @@ const ClustersDashboard = () => {
   }
 
   return (
-    <Stack>
-      <TitleText>
-        {clusterData?.data?.cluster?.name} Cluster Dashboard
-      </TitleText>
-      <SimpleDetailsCard data={success ? getMetaData() : {}} />
-      <ClusterDetailsCard clusterData={clusterData} />
-    </Stack>
+    <Container size="1070" mt="sm">
+      <Stack>
+        <TitleText>
+          {clusterData?.data?.cluster?.name} Cluster Dashboard
+        </TitleText>
+        <SimpleDetailsCard data={success ? getMetaData() : {}} />
+        <ClusterDetailsCard clusterData={clusterData} />
+      </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/databases/DatabaseDetails.tsx
+++ b/src/pages/databases/DatabaseDetails.tsx
@@ -14,6 +14,7 @@ import {
   ActionIcon,
   Skeleton,
   PasswordInput,
+  Container,
 } from "@mantine/core";
 import { HiLockOpen, HiLockClosed, HiTrash } from "react-icons/hi";
 import TitleText from "@/components/TitleText";
@@ -261,290 +262,293 @@ const DatabaseDetails = () => {
   ];
 
   return (
-    <Stack gap={30}>
-      <Stack gap={0}>
-        <TitleText>Database Details</TitleText>
-        {isLoadingDatabase ? (
-          <DatabaseDetailsSkeleton />
-        ) : (
-          <Card p="lg" radius="md" withBorder>
-            <Grid>
-              {projectInfo.map((info) => (
-                <Grid.Col span={{ base: 6, md: 4, lg: 4 }}>
-                  <Flex>
-                    <Stack gap={1}>
-                      <Text className="subtitle">{info.label}</Text>
-                      <Text size="sm">{info.value}</Text>
-                    </Stack>
-                  </Flex>
-                </Grid.Col>
-              ))}
-            </Grid>
-          </Card>
-        )}
-      </Stack>
-      <Stack gap={0}>
-        <TitleText>Database Connection</TitleText>
-        {isLoadingDatabase ? (
-          <DatabaseConnectionSkeleton />
-        ) : (
-          <Card p="lg" radius="md" withBorder>
-            <Stack gap="sm">
-              {connectionInfo.map((info) => (
-                <Flex
-                  key={info.label}
-                  justify="space-between"
-                  align="center"
-                  w="100%"
-                  gap={5}
-                >
-                  <Text className="subtitle" w="20%">
-                    {info.label}
-                  </Text>
-                  <Group gap="xs" w="80%">
-                    {info.hidden && (
-                      <Tooltip
-                        label={showFields[info.label] ? "Hide" : "Show"}
-                        withArrow
-                        position="right"
-                      >
-                        <ActionIcon
-                          variant="default"
-                          style={{ cursor: "pointer" }}
-                          onClick={() =>
-                            setShowFields((prev) => ({
-                              ...prev,
-                              [info.label]: !prev[info.label],
-                            }))
-                          }
+    <Container size="1070" mt="sm">
+      <Stack gap={30}>
+        <Stack gap={0}>
+          <TitleText>Database Details</TitleText>
+          {isLoadingDatabase ? (
+            <DatabaseDetailsSkeleton />
+          ) : (
+            <Card p="lg" radius="md" withBorder>
+              <Grid>
+                {projectInfo.map((info) => (
+                  <Grid.Col span={{ base: 6, md: 4, lg: 4 }}>
+                    <Flex>
+                      <Stack gap={1}>
+                        <Text className="subtitle">{info.label}</Text>
+                        <Text size="sm">{info.value}</Text>
+                      </Stack>
+                    </Flex>
+                  </Grid.Col>
+                ))}
+              </Grid>
+            </Card>
+          )}
+        </Stack>
+        <Stack gap={0}>
+          <TitleText>Database Connection</TitleText>
+          {isLoadingDatabase ? (
+            <DatabaseConnectionSkeleton />
+          ) : (
+            <Card p="lg" radius="md" withBorder>
+              <Stack gap="sm">
+                {connectionInfo.map((info) => (
+                  <Flex
+                    key={info.label}
+                    justify="space-between"
+                    align="center"
+                    w="100%"
+                    gap={5}
+                  >
+                    <Text className="subtitle" w="20%">
+                      {info.label}
+                    </Text>
+                    <Group gap="xs" w="80%">
+                      {info.hidden && (
+                        <Tooltip
+                          label={showFields[info.label] ? "Hide" : "Show"}
+                          withArrow
+                          position="right"
                         >
-                          {showFields[info.label] ? (
-                            <AiOutlineEyeInvisible size={16} />
-                          ) : (
-                            <AiOutlineEye size={16} />
-                          )}
-                        </ActionIcon>
-                      </Tooltip>
-                    )}
-                    <Tooltip
-                      label={clipboard.copied ? "Copied" : "Copy"}
-                      position="right"
-                      withArrow
-                    >
-                      <Input
-                        value={info.value}
-                        readOnly
-                        variant="filled"
-                        style={{ flex: 1 }}
-                        styles={{
-                          input: {
-                            cursor: "pointer",
-                            outline: "none",
-                            border: "none",
-                          },
-                        }}
-                        type={
-                          info.hidden
-                            ? showFields[info.label]
-                              ? "text"
-                              : "password"
-                            : "text"
-                        }
-                        rightSection={<TbCopy />}
-                        rightSectionProps={{
-                          onClick: () => {
+                          <ActionIcon
+                            variant="default"
+                            style={{ cursor: "pointer" }}
+                            onClick={() =>
+                              setShowFields((prev) => ({
+                                ...prev,
+                                [info.label]: !prev[info.label],
+                              }))
+                            }
+                          >
+                            {showFields[info.label] ? (
+                              <AiOutlineEyeInvisible size={16} />
+                            ) : (
+                              <AiOutlineEye size={16} />
+                            )}
+                          </ActionIcon>
+                        </Tooltip>
+                      )}
+                      <Tooltip
+                        label={clipboard.copied ? "Copied" : "Copy"}
+                        position="right"
+                        withArrow
+                      >
+                        <Input
+                          value={info.value}
+                          readOnly
+                          variant="filled"
+                          style={{ flex: 1 }}
+                          styles={{
+                            input: {
+                              cursor: "pointer",
+                              outline: "none",
+                              border: "none",
+                            },
+                          }}
+                          type={
+                            info.hidden
+                              ? showFields[info.label]
+                                ? "text"
+                                : "password"
+                              : "text"
+                          }
+                          rightSection={<TbCopy />}
+                          rightSectionProps={{
+                            onClick: () => {
+                              clipboard.copy(info.value);
+                            },
+                          }}
+                          onClick={() => {
                             clipboard.copy(info.value);
-                          },
-                        }}
-                        onClick={() => {
-                          clipboard.copy(info.value);
-                        }}
-                      />
-                    </Tooltip>
-                  </Group>
-                </Flex>
-              ))}
-            </Stack>
-          </Card>
-        )}
-      </Stack>
-      <Stack gap={0}>
-        <TitleText>Danger Zone</TitleText>
-        <Card p="lg" radius="md" withBorder>
-          <Stack gap={10}>
-            <Group justify="space-between" align="center">
-              <Stack gap={0}>
-                <Text className="title">Change Password</Text>
-                <Text className="subtext">
-                  Update the password for the database
-                </Text>
+                          }}
+                        />
+                      </Tooltip>
+                    </Group>
+                  </Flex>
+                ))}
               </Stack>
-              <Button
-                variant="outline"
-                onClick={() => setChangePasswordConfirmOpened(true)}
-                leftSection={<LiaExchangeAltSolid />}
-              >
-                Change Password
-              </Button>
-            </Group>
-            <Divider />
-            <Group justify="space-between" align="center">
-              <Stack gap={0}>
-                <Text className="title">Reset Database</Text>
-                <Text className="subtext">
-                  Delete all data inside this database and restore it to its
-                  initial state.
-                </Text>
-              </Stack>
-              <Button
-                variant="outline"
-                color="red"
-                onClick={() => setResetConfirmOpened(true)}
-                leftSection={<RiResetLeftLine />}
-              >
-                Reset
-              </Button>
-            </Group>
-            <Divider />
-            {database?.status === "disabled" ? (
+            </Card>
+          )}
+        </Stack>
+        <Stack gap={0}>
+          <TitleText>Danger Zone</TitleText>
+          <Card p="lg" radius="md" withBorder>
+            <Stack gap={10}>
               <Group justify="space-between" align="center">
                 <Stack gap={0}>
-                  <Text className="title">Enable Database</Text>
+                  <Text className="title">Change Password</Text>
                   <Text className="subtext">
-                    Enable the database to allow access to resources.
+                    Update the password for the database
                   </Text>
                 </Stack>
                 <Button
                   variant="outline"
-                  color="green"
-                  onClick={() => setEnableConfirmOpened(true)}
-                  leftSection={<HiLockOpen />}
+                  onClick={() => setChangePasswordConfirmOpened(true)}
+                  leftSection={<LiaExchangeAltSolid />}
                 >
-                  Enable
+                  Change Password
                 </Button>
               </Group>
-            ) : (
+              <Divider />
               <Group justify="space-between" align="center">
                 <Stack gap={0}>
-                  <Text className="title">Disable Database</Text>
+                  <Text className="title">Reset Database</Text>
                   <Text className="subtext">
-                    This will temporary disable the database. .
+                    Delete all data inside this database and restore it to its
+                    initial state.
                   </Text>
                 </Stack>
                 <Button
                   variant="outline"
                   color="red"
-                  onClick={() => setDisableConfirmOpened(true)}
-                  leftSection={<HiLockClosed />}
+                  onClick={() => setResetConfirmOpened(true)}
+                  leftSection={<RiResetLeftLine />}
                 >
-                  Disable
+                  Reset
                 </Button>
               </Group>
-            )}
-            <Divider />
-            <Group justify="space-between" align="center">
-              <Stack gap={0}>
-                <Text className="title">Delete Database</Text>
-                <Text className="subtext">
-                  This action is irreversible and will delete the database
-                  permanently.
-                </Text>
-              </Stack>
-              <Button
-                variant="outline"
-                color="red"
-                onClick={() => setDeleteConfirmOpened(true)}
-                leftSection={<HiTrash />}
-              >
-                Delete
-              </Button>
-            </Group>
-          </Stack>
-          <ModalConfirm
-            opened={deleteConfirmOpened}
-            onClose={() => setDeleteConfirmOpened(false)}
-            title="Delete Database"
-            buttonColor="red"
-            buttonText="Delete"
-            onConfirm={handleDelete}
-            loading={deletingDatabase}
-            leftSection={<HiTrash />}
-          >
-            Are you sure you want to delete <b>{database?.name}</b> database
-            permanently? Destroy the entire database, delete all tables and data
-            inside them.
-          </ModalConfirm>
-          <ModalConfirm
-            opened={disableConfirmOpened}
-            onClose={() => setDisableConfirmOpened(false)}
-            title="Disable Database"
-            buttonText="Disable"
-            onConfirm={handleDisable}
-            loading={disablingDatabase}
-            buttonColor="red"
-            leftSection={<HiLockClosed />}
-          >
-            Are you sure you want to disable <b>{database?.name}</b> database?
-            This action will prevent the database contents from being accessed.
-          </ModalConfirm>
-          <ModalConfirm
-            opened={enableConfirmOpened}
-            onClose={() => setEnableConfirmOpened(false)}
-            title="Enable Database"
-            buttonText="Enable"
-            buttonColor="green"
-            onConfirm={handleEnable}
-            loading={enablingDatabase}
-            leftSection={<HiLockOpen />}
-          >
-            Are you sure you want to enable <b>{database?.name}</b> database?
-            This action will allow the database contents to be accessed.
-          </ModalConfirm>
-          <ModalConfirm
-            opened={resetConfirmOpened}
-            onClose={() => setResetConfirmOpened(false)}
-            title="Reset Database"
-            buttonText="Reset"
-            buttonColor="red"
-            leftSection={<RiResetLeftLine />}
-            onConfirm={handleReset}
-            loading={resettingDatabase}
-          >
-            Are you sure you want to reset <b>{database?.name}</b> database?
-          </ModalConfirm>
-          <ModalConfirm
-            opened={changePasswordConfirmOpened}
-            onClose={() => setChangePasswordConfirmOpened(false)}
-            title="Change Password"
-            buttonText="Change"
-            buttonColor="red"
-            onConfirm={handleChangePassword}
-            loading={changingPasswordDatabase}
-          >
-            <form onSubmit={handleChangePassword}>
-              <Stack gap={20}>
-                <PasswordInput
-                  placeholder="New Password"
-                  label="New Password"
-                  name="password"
-                  required
-                  onChange={changePasswordOnChange}
-                  leftSection={<MdOutlineLock />}
-                />
-                <PasswordInput
-                  placeholder="Confirm New Password"
-                  label="Confirm New Password"
-                  name="confirm_password"
-                  required
-                  onChange={changePasswordOnChange}
-                  leftSection={<MdOutlineLock />}
-                />
-              </Stack>
-            </form>
-          </ModalConfirm>
-        </Card>
+              <Divider />
+              {database?.status === "disabled" ? (
+                <Group justify="space-between" align="center">
+                  <Stack gap={0}>
+                    <Text className="title">Enable Database</Text>
+                    <Text className="subtext">
+                      Enable the database to allow access to resources.
+                    </Text>
+                  </Stack>
+                  <Button
+                    variant="outline"
+                    color="green"
+                    onClick={() => setEnableConfirmOpened(true)}
+                    leftSection={<HiLockOpen />}
+                  >
+                    Enable
+                  </Button>
+                </Group>
+              ) : (
+                <Group justify="space-between" align="center">
+                  <Stack gap={0}>
+                    <Text className="title">Disable Database</Text>
+                    <Text className="subtext">
+                      This will temporary disable the database. .
+                    </Text>
+                  </Stack>
+                  <Button
+                    variant="outline"
+                    color="red"
+                    onClick={() => setDisableConfirmOpened(true)}
+                    leftSection={<HiLockClosed />}
+                  >
+                    Disable
+                  </Button>
+                </Group>
+              )}
+              <Divider />
+              <Group justify="space-between" align="center">
+                <Stack gap={0}>
+                  <Text className="title">Delete Database</Text>
+                  <Text className="subtext">
+                    This action is irreversible and will delete the database
+                    permanently.
+                  </Text>
+                </Stack>
+                <Button
+                  variant="outline"
+                  color="red"
+                  onClick={() => setDeleteConfirmOpened(true)}
+                  leftSection={<HiTrash />}
+                >
+                  Delete
+                </Button>
+              </Group>
+            </Stack>
+            <ModalConfirm
+              opened={deleteConfirmOpened}
+              onClose={() => setDeleteConfirmOpened(false)}
+              title="Delete Database"
+              buttonColor="red"
+              buttonText="Delete"
+              onConfirm={handleDelete}
+              loading={deletingDatabase}
+              leftSection={<HiTrash />}
+            >
+              Are you sure you want to delete <b>{database?.name}</b> database
+              permanently? Destroy the entire database, delete all tables and
+              data inside them.
+            </ModalConfirm>
+            <ModalConfirm
+              opened={disableConfirmOpened}
+              onClose={() => setDisableConfirmOpened(false)}
+              title="Disable Database"
+              buttonText="Disable"
+              onConfirm={handleDisable}
+              loading={disablingDatabase}
+              buttonColor="red"
+              leftSection={<HiLockClosed />}
+            >
+              Are you sure you want to disable <b>{database?.name}</b> database?
+              This action will prevent the database contents from being
+              accessed.
+            </ModalConfirm>
+            <ModalConfirm
+              opened={enableConfirmOpened}
+              onClose={() => setEnableConfirmOpened(false)}
+              title="Enable Database"
+              buttonText="Enable"
+              buttonColor="green"
+              onConfirm={handleEnable}
+              loading={enablingDatabase}
+              leftSection={<HiLockOpen />}
+            >
+              Are you sure you want to enable <b>{database?.name}</b> database?
+              This action will allow the database contents to be accessed.
+            </ModalConfirm>
+            <ModalConfirm
+              opened={resetConfirmOpened}
+              onClose={() => setResetConfirmOpened(false)}
+              title="Reset Database"
+              buttonText="Reset"
+              buttonColor="red"
+              leftSection={<RiResetLeftLine />}
+              onConfirm={handleReset}
+              loading={resettingDatabase}
+            >
+              Are you sure you want to reset <b>{database?.name}</b> database?
+            </ModalConfirm>
+            <ModalConfirm
+              opened={changePasswordConfirmOpened}
+              onClose={() => setChangePasswordConfirmOpened(false)}
+              title="Change Password"
+              buttonText="Change"
+              buttonColor="red"
+              onConfirm={handleChangePassword}
+              loading={changingPasswordDatabase}
+            >
+              <form onSubmit={handleChangePassword}>
+                <Stack gap={20}>
+                  <PasswordInput
+                    placeholder="New Password"
+                    label="New Password"
+                    name="password"
+                    required
+                    onChange={changePasswordOnChange}
+                    leftSection={<MdOutlineLock />}
+                  />
+                  <PasswordInput
+                    placeholder="Confirm New Password"
+                    label="Confirm New Password"
+                    name="confirm_password"
+                    required
+                    onChange={changePasswordOnChange}
+                    leftSection={<MdOutlineLock />}
+                  />
+                </Stack>
+              </form>
+            </ModalConfirm>
+          </Card>
+        </Stack>
       </Stack>
-    </Stack>
+    </Container>
   );
 };
 

--- a/src/pages/databases/DatabasePage.tsx
+++ b/src/pages/databases/DatabasePage.tsx
@@ -3,7 +3,7 @@ import CreateDatabaseForm from "@/components/Forms/CreateDatabaseForm";
 import DatabaseList from "@/components/Lists/databaseList";
 import TitleText from "@/components/TitleText";
 import { useGetProject } from "@/utils/helpers";
-import { Button, Stack } from "@mantine/core";
+import { Button, Container, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useState } from "react";
 import { GoPlus } from "react-icons/go";
@@ -16,34 +16,36 @@ const DatabasePage = () => {
   useGetProject(project_id || "");
 
   return (
-    <Stack>
-      <TitleText
-        loading={false}
-        rightSection={
-          <Button radius="xl" leftSection={<GoPlus />} onClick={open}>
-            Add Database
-          </Button>
-        }
-      >
-        Databases
-      </TitleText>
-      <DatabaseList project_id={project_id} refresh={refresh} />
-      <ModalConfirm
-        opened={opened}
-        onClose={close}
-        title="Create Database"
-        buttonText="Create"
-        onConfirm={() => {}}
-        showFooterActions={false}
-      >
-        <CreateDatabaseForm
-          showTitle={false}
-          onCancel={close}
-          project_id={project_id}
-          refresh={() => setRefresh(true)}
-        />
-      </ModalConfirm>
-    </Stack>
+    <Container size="1070" mt="sm">
+      <Stack>
+        <TitleText
+          loading={false}
+          rightSection={
+            <Button radius="md" leftSection={<GoPlus />} onClick={open}>
+              Add Database
+            </Button>
+          }
+        >
+          Databases
+        </TitleText>
+        <DatabaseList project_id={project_id} refresh={refresh} />
+        <ModalConfirm
+          opened={opened}
+          onClose={close}
+          title="Create Database"
+          buttonText="Create"
+          onConfirm={() => {}}
+          showFooterActions={false}
+        >
+          <CreateDatabaseForm
+            showTitle={false}
+            onCancel={close}
+            project_id={project_id}
+            refresh={() => setRefresh(true)}
+          />
+        </ModalConfirm>
+      </Stack>
+    </Container>
   );
 };
 


### PR DESCRIPTION
# Description

- This PR adds provision to handle the enable and disable of users on the admin side, and also a path to navigate to a user's admin detail view.
- This PR also fixes the previous layout inconsistencies 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## ClickUp Ticket ID

https://app.clickup.com/t/869cfbfdk

## How Can This Been Tested?

- Run this branch locally and checkout the admin side, and under the users submenu you can access the inactive user's list

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="1412" height="803" alt="Screenshot 2026-03-17 at 5 58 35 PM" src="https://github.com/user-attachments/assets/38c9c7de-f0f7-4bf5-91aa-30ada4a7374d" />
